### PR TITLE
feat: implement milestone proof hash verification (closes #78)

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -780,6 +780,22 @@ impl Events {
         };
         event.publish(env);
     }
+
+    pub fn emit_milestone_proof_hash_submitted(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        proof_hash: BytesN<32>,
+    ) {
+        let event = MilestoneProofHashSubmitted {
+            event_version: EVENT_VERSION,
+            grant_id,
+            milestone_idx,
+            proof_hash,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
 }
 
 #[contractevent]
@@ -913,5 +929,15 @@ pub struct GrantAccepted {
     pub event_version: u32,
     pub grant_id: u64,
     pub recipient: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MilestoneProofHashSubmitted {
+    pub event_version: u32,
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub proof_hash: BytesN<32>,
     pub timestamp: u64,
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -603,6 +603,7 @@ impl StellarGrantsContract {
                 reasons: soroban_sdk::Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                proof_hash: None,
                 submission_timestamp: 0,
                 deadline,
                 community_upvotes: 0,
@@ -1550,6 +1551,7 @@ impl StellarGrantsContract {
         recipient: Address,
         description: String,
         proof_url: String,
+        proof_hash: Option<BytesN<32>>,
         payout_token: Option<Address>, // New parameter
     ) -> Result<(), ContractError> {
         recipient.require_auth();
@@ -1579,6 +1581,7 @@ impl StellarGrantsContract {
             milestone_idx,
             description,
             proof_url,
+            proof_hash,
             payout_token,
         )
     }
@@ -1628,6 +1631,7 @@ impl StellarGrantsContract {
                 sub.idx,
                 sub.description.clone(),
                 sub.proof.clone(),
+                sub.proof_hash.clone(),
                 sub.payout_token.clone(),
             )?;
         }
@@ -2531,6 +2535,7 @@ fn apply_milestone_submission(
     milestone_idx: u32,
     description: String,
     proof_url: String,
+    proof_hash: Option<BytesN<32>>,
     payout_token: Option<Address>,
 ) -> Result<(), ContractError> {
     if milestone_idx >= grant.total_milestones {
@@ -2553,10 +2558,20 @@ fn apply_milestone_submission(
         return Err(ContractError::DeadlinePassed);
     }
 
+    // Validate proof_hash: if provided, it must be exactly 32 non-zero bytes.
+    // An all-zero hash is rejected as it indicates an unset/malformed value.
+    if let Some(ref hash) = proof_hash {
+        let zero: BytesN<32> = BytesN::from_array(env, &[0u8; 32]);
+        if *hash == zero {
+            return Err(ContractError::InvalidProofHash);
+        }
+    }
+
     milestone.description = description.clone();
     // Milestone enters the community review window before official voting opens.
     milestone.state = MilestoneState::CommunityReview;
     milestone.proof_url = Some(proof_url);
+    milestone.proof_hash = proof_hash.clone();
     if let Some(token) = payout_token {
         milestone.payout_token = token;
     }
@@ -2564,6 +2579,11 @@ fn apply_milestone_submission(
 
     Storage::set_milestone(env, grant_id, milestone_idx, &milestone);
     Events::emit_milestone_submitted(env, grant_id, milestone_idx, description);
+
+    // Emit dedicated proof hash event when a hash is provided.
+    if let Some(hash) = proof_hash {
+        Events::emit_milestone_proof_hash_submitted(env, grant_id, milestone_idx, hash);
+    }
 
     Ok(())
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/test.rs
@@ -1,4 +1,4 @@
-#![allow(
+﻿#![allow(
     unused_variables,
     clippy::needless_borrow,
     clippy::bool_assert_comparison,
@@ -221,6 +221,7 @@ mod tests {
                 reasons: Map::new(env),
                 status_updated_at: 0,
                 proof_url: Some(String::from_str(env, "https://proof.url")),
+                    proof_hash: None,
                 submission_timestamp: env.ledger().timestamp(),
                 deadline: 0,
                 community_upvotes: 0,
@@ -953,6 +954,7 @@ mod tests {
                     reasons: Map::new(&env),
                     status_updated_at: 0,
                     proof_url: None,
+                    proof_hash: None,
                     submission_timestamp: 0,
                     deadline: 0,
                     community_upvotes: 0,
@@ -1040,6 +1042,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -1059,6 +1062,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -1130,6 +1134,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -1198,6 +1203,7 @@ mod tests {
                     reasons: Map::new(&env),
                     status_updated_at: 0,
                     proof_url: None,
+                    proof_hash: None,
                     submission_timestamp: 0,
                     deadline: 0,
                     community_upvotes: 0,
@@ -1268,6 +1274,7 @@ mod tests {
                     reasons: Map::new(&env),
                     status_updated_at: 0,
                     proof_url: None,
+                    proof_hash: None,
                     submission_timestamp: 0,
                     deadline: 0,
                     community_upvotes: 0,
@@ -1463,6 +1470,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -1520,6 +1528,7 @@ mod tests {
             &String::from_str(&env, "Work done"),
             &String::from_str(&env, "https://proof.url"),
             &None,
+            &None,
         );
         assert_eq!(
             result,
@@ -1538,6 +1547,7 @@ mod tests {
             &owner,
             &String::from_str(&env, "Work done"),
             &String::from_str(&env, "https://proof.url"),
+            &None,
             &None,
         );
     }
@@ -1649,6 +1659,7 @@ mod tests {
             &description,
             &proof_url,
             &None,
+            &None,
         );
 
         // Verify the milestone was stored correctly; submit now enters CommunityReview first.
@@ -1722,6 +1733,7 @@ mod tests {
                     reasons: Map::new(&env),
                     status_updated_at: 0,
                     proof_url: None,
+                    proof_hash: None,
                     submission_timestamp: 0,
                     deadline: 0,
                     community_upvotes: 0,
@@ -1736,18 +1748,21 @@ mod tests {
             idx: 0,
             description: String::from_str(&env, "First milestone desc"),
             proof: String::from_str(&env, "https://proof.example/a"),
+            proof_hash: None,
             payout_token: None,
         });
         submissions.push_back(MilestoneSubmission {
             idx: 1,
             description: String::from_str(&env, "Second milestone desc"),
             proof: String::from_str(&env, "https://proof.example/b"),
+            proof_hash: None,
             payout_token: None,
         });
         submissions.push_back(MilestoneSubmission {
             idx: 2,
             description: String::from_str(&env, "Third milestone desc"),
             proof: String::from_str(&env, "https://proof.example/c"),
+            proof_hash: None,
             payout_token: None,
         });
 
@@ -1795,6 +1810,7 @@ mod tests {
             &description,
             &proof_url,
             &None,
+            &None,
         );
         assert_eq!(result, Err(Ok(ContractError::GrantNotFound.into())));
     }
@@ -1823,7 +1839,7 @@ mod tests {
 
         // The grant has total_milestones = 1, so index 1 is out of bounds
         let result =
-            client.try_milestone_submit(&grant_id, &1u32, &owner, &description, &proof_url, &None);
+            client.try_milestone_submit(&grant_id, &1u32, &owner, &description, &proof_url, &None, &None);
         assert_eq!(result, Err(Ok(ContractError::InvalidInput.into())));
     }
 
@@ -1865,6 +1881,7 @@ mod tests {
             &description,
             &proof_url,
             &None,
+            &None,
         );
         assert_eq!(
             result,
@@ -1904,6 +1921,7 @@ mod tests {
             &attacker,
             &description,
             &proof_url,
+            &None,
             &None,
         );
         assert_eq!(result, Err(Ok(ContractError::Unauthorized.into())));
@@ -1952,8 +1970,112 @@ mod tests {
         let proof_url = String::from_str(&env, "https://proof.url");
 
         let result =
-            client.try_milestone_submit(&grant_id, &0u32, &owner, &description, &proof_url, &None);
+            client.try_milestone_submit(&grant_id, &0u32, &owner, &description, &proof_url, &None, &None);
         assert_eq!(result, Err(Ok(ContractError::InvalidState.into())));
+    }
+
+    // -------------------------------------------------------------------------
+    // proof_hash tests (issue #78)
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_milestone_submit_with_valid_proof_hash() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, contract_id) = setup_test(&env);
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let grant_id = 1u64;
+
+        create_grant(&env, &contract_id, grant_id, owner.clone(), token, Vec::new(&env));
+        create_milestone(&env, &contract_id, grant_id, 0, MilestoneState::Pending);
+
+        let description = String::from_str(&env, "Work done");
+        let proof_url = String::from_str(&env, "https://proof.url");
+        // A valid non-zero 32-byte hash (simulates an IPFS CID or commit hash)
+        let hash_bytes = [1u8; 32];
+        let proof_hash: BytesN<32> = BytesN::from_array(&env, &hash_bytes);
+
+        client.milestone_submit(
+            &grant_id,
+            &0u32,
+            &owner,
+            &description,
+            &proof_url,
+            &Some(proof_hash.clone()),
+            &None,
+        );
+
+        env.as_contract(&contract_id, || {
+            let ms = Storage::get_milestone(&env, grant_id, 0).unwrap();
+            assert_eq!(ms.state, MilestoneState::CommunityReview);
+            assert_eq!(ms.proof_hash, Some(proof_hash));
+        });
+    }
+
+    #[test]
+    fn test_milestone_submit_all_zero_proof_hash_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, contract_id) = setup_test(&env);
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let grant_id = 2u64;
+
+        create_grant(&env, &contract_id, grant_id, owner.clone(), token, Vec::new(&env));
+        create_milestone(&env, &contract_id, grant_id, 0, MilestoneState::Pending);
+
+        let description = String::from_str(&env, "Work done");
+        let proof_url = String::from_str(&env, "https://proof.url");
+        // All-zero hash is invalid (unset/malformed)
+        let zero_hash: BytesN<32> = BytesN::from_array(&env, &[0u8; 32]);
+
+        let result = client.try_milestone_submit(
+            &grant_id,
+            &0u32,
+            &owner,
+            &description,
+            &proof_url,
+            &Some(zero_hash),
+            &None,
+        );
+        assert_eq!(result, Err(Ok(ContractError::InvalidProofHash.into())));
+    }
+
+    #[test]
+    fn test_milestone_submit_without_proof_hash_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, _, contract_id) = setup_test(&env);
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let grant_id = 3u64;
+
+        create_grant(&env, &contract_id, grant_id, owner.clone(), token, Vec::new(&env));
+        create_milestone(&env, &contract_id, grant_id, 0, MilestoneState::Pending);
+
+        let description = String::from_str(&env, "Work done");
+        let proof_url = String::from_str(&env, "https://proof.url");
+
+        // proof_hash is optional — None should succeed and store None
+        client.milestone_submit(
+            &grant_id,
+            &0u32,
+            &owner,
+            &description,
+            &proof_url,
+            &None,
+            &None,
+        );
+
+        env.as_contract(&contract_id, || {
+            let ms = Storage::get_milestone(&env, grant_id, 0).unwrap();
+            assert_eq!(ms.state, MilestoneState::CommunityReview);
+            assert_eq!(ms.proof_hash, None);
+        });
     }
 
     // -------------------------------------------------------------------------
@@ -3113,6 +3235,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 1_000, // deadline at timestamp 1000
                 community_upvotes: 0,
@@ -3134,6 +3257,7 @@ mod tests {
             &owner,
             &description,
             &proof_url,
+            &None,
             &None,
         );
         assert_eq!(result, Err(Ok(ContractError::DeadlinePassed.into())));
@@ -3615,6 +3739,7 @@ mod tests {
             &String::from_str(&env, "Work done"),
             &String::from_str(&env, "https://proof.url"),
             &None,
+            &None,
         );
 
         env.as_contract(&contract_id, || {
@@ -3658,6 +3783,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -3710,6 +3836,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -3759,6 +3886,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -3806,6 +3934,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -3850,6 +3979,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -3934,6 +4064,7 @@ mod tests {
                 reasons: Map::new(&env),
                 status_updated_at: 0,
                 proof_url: None,
+                    proof_hash: None,
                 submission_timestamp: 0,
                 deadline: 0,
                 community_upvotes: 0,
@@ -4430,6 +4561,7 @@ mod tests {
             &String::from_str(&env, "Work done"),
             &String::from_str(&env, "https://proof.url"),
             &None,
+            &None,
         );
         assert_eq!(result, Err(Ok(ContractError::InvalidState.into())));
     }
@@ -4678,6 +4810,7 @@ mod tests {
             &owner,
             &String::from_str(&env, "Work done"),
             &String::from_str(&env, "https://proof.url"),
+            &None,
             &None,
         );
         assert_eq!(result, Err(Ok(ContractError::InvalidState.into())));
@@ -5088,6 +5221,7 @@ mod tests {
             &owner,
             &String::from_str(&env, "work"),
             &String::from_str(&env, "https://proof.url"),
+            &None,
             &None,
         );
         assert_eq!(result, Err(Ok(ContractError::ContractPaused.into())));

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracterror, contracttype, Address, Map, String, Vec};
+use soroban_sdk::{contracterror, contracttype, Address, BytesN, Map, String, Vec};
 
 /// Contract error types
 #[contracterror]
@@ -49,6 +49,8 @@ pub enum ContractError {
     TooManyTags = 35,
     /// A tag exceeds 20 characters.
     TagTooLong = 36,
+    /// The submitted proof hash is malformed (must be exactly 32 bytes).
+    InvalidProofHash = 37,
 }
 
 #[contracttype]
@@ -110,6 +112,7 @@ pub struct Milestone {
     pub reasons: Map<Address, String>,
     pub status_updated_at: u64,
     pub proof_url: Option<String>,
+    pub proof_hash: Option<BytesN<32>>,
     pub submission_timestamp: u64,
     pub deadline: u64,
     /// Number of community upvotes received during the CommunityReview period.
@@ -124,6 +127,7 @@ pub struct MilestoneSubmission {
     pub idx: u32,
     pub description: String,
     pub proof: String,
+    pub proof_hash: Option<BytesN<32>>,
     pub payout_token: Option<Address>, // New: Optional override for the payout token
 }
 

--- a/stellargrant-contracts/contracts/stellar-grants/tests/test_event_emission.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/tests/test_event_emission.rs
@@ -98,6 +98,7 @@ fn test_event_emission_on_milestone_vote() {
         &String::from_str(&env, "desc"),
         &String::from_str(&env, "proof"),
         &None,
+        &None,
     );
     // Advance ledger timestamp by COMMUNITY_REVIEW_PERIOD to allow voting
     const COMMUNITY_REVIEW_PERIOD: u64 = 3 * 24 * 60 * 60;

--- a/stellargrant-contracts/contracts/stellar-grants/tests/test_milestone_dispute.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/tests/test_milestone_dispute.rs
@@ -48,6 +48,7 @@ fn test_dispute_and_resolve_flow() {
         &String::from_str(&env, "Milestone 1"),
         &String::from_str(&env, "proof"),
         &None,
+        &None,
     );
     let now = env.ledger().timestamp();
     env.ledger()
@@ -104,6 +105,7 @@ fn test_vote_blocked_during_dispute() {
         &String::from_str(&env, "Milestone 1"),
         &String::from_str(&env, "proof"),
         &None,
+        &None,
     );
     let now = env.ledger().timestamp();
     env.ledger()
@@ -158,6 +160,7 @@ fn test_only_council_can_resolve_dispute() {
         &owner,
         &String::from_str(&env, "Milestone 1"),
         &String::from_str(&env, "proof"),
+        &None,
         &None,
     );
     let now = env.ledger().timestamp();

--- a/stellargrant-contracts/contracts/stellar-grants/tests/test_milestone_quorum.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/tests/test_milestone_quorum.rs
@@ -50,6 +50,7 @@ fn test_milestone_voting_quorum_and_events() {
         &String::from_str(&env, "desc"),
         &String::from_str(&env, "proof"),
         &None,
+        &None,
     );
 
     // Advance past the community review period so reviewer voting is allowed
@@ -121,6 +122,7 @@ fn test_milestone_vote_after_quorum_panics() {
         &String::from_str(&env, "desc"),
         &String::from_str(&env, "proof"),
         &None,
+        &None,
     );
     let ts = env.ledger().timestamp();
     env.ledger()
@@ -172,6 +174,7 @@ fn test_milestone_double_voting_panics() {
         &owner,
         &String::from_str(&env, "desc"),
         &String::from_str(&env, "proof"),
+        &None,
         &None,
     );
 

--- a/stellargrant-contracts/fuzz/fuzz_targets/milestone_submit.rs
+++ b/stellargrant-contracts/fuzz/fuzz_targets/milestone_submit.rs
@@ -35,7 +35,7 @@ fuzz_target!(|data: &[u8]| {
         let recipient = owner;
         let desc = String::from_str(&env, "desc");
         let proof = String::from_str(&env, "proof");
-        let _ = StellarGrantsContract::milestone_submit(env, 0, 0, recipient, desc, proof);
+        let _ = StellarGrantsContract::milestone_submit(env, 0, 0, recipient, desc, proof, None, None);
     });
     // If a panic occurred, treat as a fuzz failure only if input was not obviously invalid
     if result.is_err() && !data.is_empty() {

--- a/stellargrant-contracts/fuzz/fuzz_targets/milestone_vote.rs
+++ b/stellargrant-contracts/fuzz/fuzz_targets/milestone_vote.rs
@@ -46,6 +46,8 @@ fuzz_target!(|data: &[u8]| {
         owner.clone(),
         SorobanString::from_str(&env, "desc"),
         SorobanString::from_str(&env, "proof"),
+        None,
+        None,
     );
 
     // Step 3: vote — this must never panic, only return Err


### PR DESCRIPTION
## Summary

Resolves #78

Implements on-chain structured proof hash storage and format validation for milestone submissions, as described in the issue.

## Changes

### \	ypes.rs\
- Added \proof_hash: Option<BytesN<32>>\ field to \Milestone\ struct for mandatory CID/commit hash storage
- Added \proof_hash: Option<BytesN<32>>\ field to \MilestoneSubmission\ for batch submissions
- Added \InvalidProofHash = 37\ to \ContractError\ enum

### \lib.rs\
- Updated \milestone_submit\ signature to accept \proof_hash: Option<BytesN<32>>\
- Updated \pply_milestone_submission\ to validate and store the hash  rejects all-zero hashes (\[0u8; 32]\) as malformed/unset
- Updated \milestone_submit_batch\ to forward \proof_hash\ from each \MilestoneSubmission\

### \events.rs\
- Added \MilestoneProofHashSubmitted\ event struct
- Added \emit_milestone_proof_hash_submitted\  emitted alongside \MilestoneSubmitted\ when a valid hash is provided

### \	est.rs\ + integration tests + fuzz targets
- Updated all \Milestone\ struct constructions with \proof_hash: None\
- Updated all \milestone_submit\ / \	ry_milestone_submit\ call sites with the new parameter
- Added 3 new unit tests:
  - \	est_milestone_submit_with_valid_proof_hash\  valid 32-byte hash is stored correctly
  - \	est_milestone_submit_all_zero_proof_hash_rejected\  all-zero hash returns \InvalidProofHash\
  - \	est_milestone_submit_without_proof_hash_succeeds\  \None\ is accepted (hash is optional)

## Notes
- The \proof_hash\ field is **optional**  existing flows that don't provide a hash continue to work unchanged
- Oracle integration (future issue) can build on top of the stored \proof_hash\ field