### PR TITLE
[135] Add Exportable Grant Receipts (Events with Metadata)

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/README.md
+++ b/stellargrant-contracts/contracts/stellar-grants/README.md
@@ -1,0 +1,35 @@
+# Stellar Grants Contract Events
+
+## Exportable Grant Receipts
+
+Issue #135 adds two receipt-oriented contract events that can be indexed by off-chain tools:
+
+- `PayerReceipt`
+- `PayeeReceipt`
+
+Both events include metadata fields designed for accounting exports:
+
+- `grant_id`
+- `recipient`
+- `token`
+- `amount`
+- `milestone_index` (`None` for grant-level receipts)
+
+`PayerReceipt` also includes:
+
+- `memo` (optional memo passed by funder during `grant_fund`)
+
+## When Receipts Are Emitted
+
+- `PayerReceipt`: emitted on `grant_fund`.
+- `PayeeReceipt`: emitted on `milestone_payout`, and on grant completion as a final summary snapshot.
+
+## Querying Receipts
+
+You can query contract events from Soroban RPC and filter by event type:
+
+1. Fetch contract events for the deployed contract address.
+2. Filter for `payer_receipt` and `payee_receipt` event names.
+3. Parse payload fields (`grant_id`, `recipient`, `token`, `amount`, `milestone_index`, `memo`) for export.
+
+Because these are structured contract events, indexers can store them directly in tabular format for CSV or accounting pipeline exports.

--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -715,12 +715,21 @@ impl Events {
         event.publish(env);
     }
 
-    pub fn emit_payee_receipt(env: &Env, grant_id: u64, payee: Address, amount: i128) {
+    pub fn emit_payee_receipt(
+        env: &Env,
+        grant_id: u64,
+        recipient: Address,
+        token: Address,
+        amount: i128,
+        milestone_index: Option<u32>,
+    ) {
         let event = PayeeReceipt {
             event_version: EVENT_VERSION,
             grant_id,
-            payee,
+            recipient,
+            token,
             amount,
+            milestone_index,
             timestamp: env.ledger().timestamp(),
         };
         event.publish(env);
@@ -729,15 +738,19 @@ impl Events {
     pub fn emit_payer_receipt(
         env: &Env,
         grant_id: u64,
-        payer: Address,
+        recipient: Address,
         amount: i128,
+        token: Address,
+        milestone_index: Option<u32>,
         memo: Option<String>,
     ) {
         let event = PayerReceipt {
             event_version: EVENT_VERSION,
             grant_id,
-            payer,
+            recipient,
+            token,
             amount,
+            milestone_index,
             memo,
             timestamp: env.ledger().timestamp(),
         };
@@ -945,8 +958,10 @@ pub struct GrantResumed {
 pub struct PayeeReceipt {
     pub event_version: u32,
     pub grant_id: u64,
-    pub payee: Address,
+    pub recipient: Address,
+    pub token: Address,
     pub amount: i128,
+    pub milestone_index: Option<u32>,
     pub timestamp: u64,
 }
 
@@ -955,8 +970,10 @@ pub struct PayeeReceipt {
 pub struct PayerReceipt {
     pub event_version: u32,
     pub grant_id: u64,
-    pub payer: Address,
+    pub recipient: Address,
+    pub token: Address,
     pub amount: i128,
+    pub milestone_index: Option<u32>,
     pub memo: Option<String>,
     pub timestamp: u64,
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -1369,8 +1369,15 @@ impl StellarGrantsContract {
         escrow_state.set_quorum_ready(true);
         Storage::set_escrow_state(env, grant_id, &escrow_state);
 
-        // Enhanced event emission: include all relevant data, standardize topics
-        Events::emit_payee_receipt(env, grant_id, grant.owner.clone(), total_paid);
+        // Emit a completion receipt snapshot for indexers.
+        Events::emit_payee_receipt(
+            env,
+            grant_id,
+            grant.owner.clone(),
+            grant.primary_token.clone(),
+            total_paid,
+            None,
+        );
 
         Events::emit_grant_completed(env, grant_id, total_paid, remaining_balance);
         Ok(())
@@ -1835,8 +1842,15 @@ impl StellarGrantsContract {
             Storage::set_grant(&env, grant_id, &grant);
 
             // Enhanced event emission: include all relevant data, standardize topics
-            Events::emit_grant_funded(&env, grant_id, funder.clone(), amount, token, new_balance);
-            Events::emit_payer_receipt(&env, grant_id, funder, amount, memo);
+            Events::emit_grant_funded(
+                &env,
+                grant_id,
+                funder.clone(),
+                amount,
+                token.clone(),
+                new_balance,
+            );
+            Events::emit_payer_receipt(&env, grant_id, funder, amount, token, None, memo);
 
             Ok(())
         })
@@ -2374,10 +2388,18 @@ impl StellarGrantsContract {
                     grant_id,
                     funder.clone(),
                     amount,
-                    token,
+                    token.clone(),
                     new_balance,
                 );
-                Events::emit_payer_receipt(&env, grant_id, funder.clone(), amount, None);
+                Events::emit_payer_receipt(
+                    &env,
+                    grant_id,
+                    funder.clone(),
+                    amount,
+                    token,
+                    None,
+                    None,
+                );
             }
 
             Ok(())
@@ -2530,6 +2552,14 @@ impl StellarGrantsContract {
                 grant.owner.clone(),
                 payout_amount,
                 payout_token.clone(),
+            );
+            Events::emit_payee_receipt(
+                &env,
+                grant_id,
+                grant.owner.clone(),
+                payout_token.clone(),
+                payout_amount,
+                Some(milestone_idx),
             );
 
             // Update contributor reputation when paid

--- a/stellargrant-contracts/contracts/stellar-grants/src/test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/test.rs
@@ -1998,6 +1998,70 @@ mod tests {
     }
 
     #[test]
+    fn test_grant_fund_emits_payer_receipt_with_metadata() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let (client, admin, _) = setup_test(&env);
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+
+        let owner = Address::generate(&env);
+        let funder = Address::generate(&env);
+        let grant_id = 1u64;
+        let fund_amount = 500i128;
+        let memo = Some(String::from_str(&env, "seed funding"));
+
+        token_admin.mint(&funder, &1000i128);
+
+        let mut grant = Grant::new(
+            grant_id,
+            owner.clone(),
+            String::from_str(&env, "Test"),
+            String::from_str(&env, "Desc"),
+            token_id.clone(),
+            1000,
+            500,
+            Vec::new(&env),
+            0,
+            env.ledger().timestamp(),
+            GrantStatus::Active,
+            1,
+            1,
+            &env,
+        );
+        let mut escrow_balances = Map::new(&env);
+        escrow_balances.set(token_id.clone(), 0);
+        grant.escrow_balances = escrow_balances;
+        Storage::set_grant(&env, grant_id, &grant);
+
+        client.grant_fund(&grant_id, &funder, &fund_amount, &token_id, &memo);
+
+        use soroban_sdk::testutils::Events;
+        let events = env.events().all();
+        let mut found_receipt = false;
+
+        extern crate std;
+        let token_marker = std::format!("{:?}", token_id);
+        let amount_marker = std::format!("amount: {}", fund_amount);
+
+        for e in events.events() {
+            let s = std::format!("{:?}", e);
+            if s.contains("payer_receipt") {
+                found_receipt = true;
+                assert!(s.contains("grant_id: 1"));
+                assert!(s.contains(&amount_marker));
+                assert!(s.contains(&token_marker));
+                assert!(s.contains("milestone_index: None"));
+                assert!(s.contains("seed funding"));
+            }
+        }
+
+        assert!(found_receipt, "PayerReceipt event was not emitted");
+    }
+
+    #[test]
     fn test_grant_fund_non_existent() {
         let env = Env::default();
         env.mock_all_auths();
@@ -5130,8 +5194,10 @@ mod tests {
         use soroban_sdk::testutils::Events;
         let events = env.events().all();
         let mut found_paid_event = false;
+        let mut found_payee_receipt = false;
 
         extern crate std;
+        let token_marker = std::format!("{:?}", token_id);
         for e in events.events() {
             let s = std::format!("{:?}", e);
             if s.contains("milestone_paid") {
@@ -5141,9 +5207,17 @@ mod tests {
                 assert!(s.contains("0")); // milestone_idx
                 assert!(s.contains("100")); // amount (create_milestone seeds amount=100)
             }
+            if s.contains("payee_receipt") {
+                found_payee_receipt = true;
+                assert!(s.contains("grant_id: 1"));
+                assert!(s.contains("amount: 100"));
+                assert!(s.contains(&token_marker));
+                assert!(s.contains("milestone_index: Some(0)"));
+            }
         }
 
         assert!(found_paid_event, "MilestonePaid event was not emitted");
+        assert!(found_payee_receipt, "PayeeReceipt event was not emitted");
     }
 
     #[test]


### PR DESCRIPTION
Closes #135

## Summary
- add enriched PayerReceipt and PayeeReceipt events with grant_id, recipient, token, amount, and milestone_index metadata
- include optional memo in PayerReceipt from grant_fund
- emit PayeeReceipt on milestone_payout and grant completion snapshot
- add receipt-focused unit tests and contract docs for querying receipt events

## Validation
- cargo fmt -- --check
- cargo test (blocked in this environment: missing MSVC linker link.exe)
