### PR TITLE
Enforce Reviewer Stake and Implement Grant Clawback

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -871,6 +871,24 @@ impl Events {
         };
         event.publish(env);
     }
+
+    // ── Issue #163: grant clawback event ─────────────────────────────────────
+
+    pub fn emit_grant_clawbacked(
+        env: &Env,
+        grant_id: u64,
+        council: Address,
+        total_clawed_back: i128,
+    ) {
+        let event = GrantClawbacked {
+            event_version: EVENT_VERSION,
+            grant_id,
+            council,
+            total_clawed_back,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
 }
 
 #[contractevent]
@@ -1057,5 +1075,18 @@ pub struct ReputationUpdated {
     pub contributor: Address,
     pub new_reputation_score: u64,
     pub total_earned: i128,
+    pub timestamp: u64,
+}
+
+/// Emitted when the DAO Council claws back escrowed funds from a fraudulent grant (issue #163).
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GrantClawbacked {
+    pub event_version: u32,
+    pub grant_id: u64,
+    /// The council address that initiated the clawback.
+    pub council: Address,
+    /// Total amount returned across all tokens.
+    pub total_clawed_back: i128,
     pub timestamp: u64,
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -360,11 +360,7 @@ impl StellarGrantsContract {
     /// * [`ContractError::Unauthorized`] – caller is not the registered council.
     /// * [`ContractError::GrantNotFound`] – grant does not exist.
     /// * [`ContractError::InvalidState`] – grant is already Cancelled or Completed.
-    pub fn grant_clawback(
-        env: Env,
-        council: Address,
-        grant_id: u64,
-    ) -> Result<(), ContractError> {
+    pub fn grant_clawback(env: Env, council: Address, grant_id: u64) -> Result<(), ContractError> {
         council.require_auth();
 
         let council_addr = Storage::get_council(&env).ok_or(ContractError::InvalidInput)?;
@@ -443,11 +439,7 @@ impl StellarGrantsContract {
             } else {
                 // No funders recorded for this token; send the entire balance to the council
                 // as a fallback to avoid permanently locking funds.
-                token_client.transfer(
-                    &env.current_contract_address(),
-                    &council,
-                    &balance,
-                );
+                token_client.transfer(&env.current_contract_address(), &council, &balance);
             }
 
             total_clawed_back += balance;

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -344,6 +344,124 @@ impl StellarGrantsContract {
         Ok(())
     }
 
+    /// Claws back all remaining escrowed funds from a grant in cases of proven fraud.
+    ///
+    /// Only callable by the registered council address. Iterates through all tokens
+    /// in the grant's `escrow_balances` and refunds each non-zero balance to the
+    /// original funders pro-rata (matching the logic used in `resolve_dispute`).
+    /// Sets the grant status to [`GrantStatus::Cancelled`] and emits a
+    /// [`Events::emit_grant_clawbacked`] event.
+    ///
+    /// # Arguments
+    /// * `council` - The DAO Council address (must match the registered council).
+    /// * `grant_id` - The grant whose escrowed funds are to be clawed back.
+    ///
+    /// # Errors
+    /// * [`ContractError::Unauthorized`] – caller is not the registered council.
+    /// * [`ContractError::GrantNotFound`] – grant does not exist.
+    /// * [`ContractError::InvalidState`] – grant is already Cancelled or Completed.
+    pub fn grant_clawback(
+        env: Env,
+        council: Address,
+        grant_id: u64,
+    ) -> Result<(), ContractError> {
+        council.require_auth();
+
+        let council_addr = Storage::get_council(&env).ok_or(ContractError::InvalidInput)?;
+        if council_addr != council {
+            return Err(ContractError::Unauthorized);
+        }
+
+        let mut grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+
+        // Only clawback grants that are still active (not already cancelled/completed).
+        if grant.status() == GrantStatus::Cancelled || grant.status() == GrantStatus::Completed {
+            return Err(ContractError::InvalidState);
+        }
+
+        let mut total_clawed_back: i128 = 0;
+
+        // Collect all token addresses from escrow_balances to avoid borrow issues.
+        let mut token_list: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+        for (token, _) in grant.escrow_balances.iter() {
+            token_list.push_back(token);
+        }
+
+        for token in token_list.iter() {
+            let balance = grant.escrow_balances.get(token.clone()).unwrap_or(0);
+            if balance <= 0 {
+                continue;
+            }
+
+            let token_client = token::Client::new(&env, &token);
+
+            // Pro-rata refund to funders who contributed in this token.
+            let mut total_token_contributions: i128 = 0;
+            let mut token_funders: soroban_sdk::Vec<GrantFund> = soroban_sdk::Vec::new(&env);
+            for fund_entry in grant.funders.iter() {
+                if fund_entry.token == token {
+                    total_token_contributions += fund_entry.amount;
+                    token_funders.push_back(fund_entry);
+                }
+            }
+
+            if total_token_contributions > 0 {
+                let token_funders_len = token_funders.len();
+                let mut distributed: i128 = 0;
+
+                for i in 0..token_funders_len {
+                    let fund_entry = token_funders.get(i).unwrap();
+                    let is_last = i + 1 == token_funders_len;
+                    let refund_amount = if is_last {
+                        balance - distributed
+                    } else {
+                        let amount = fund_entry
+                            .amount
+                            .checked_mul(balance)
+                            .ok_or(ContractError::InvalidInput)?
+                            .checked_div(total_token_contributions)
+                            .ok_or(ContractError::InvalidInput)?;
+                        distributed += amount;
+                        amount
+                    };
+
+                    if refund_amount > 0 {
+                        token_client.transfer(
+                            &env.current_contract_address(),
+                            &fund_entry.funder,
+                            &refund_amount,
+                        );
+                        Events::emit_refund_issued(
+                            &env,
+                            grant_id,
+                            fund_entry.funder.clone(),
+                            refund_amount,
+                            token.clone(),
+                        );
+                    }
+                }
+            } else {
+                // No funders recorded for this token; send the entire balance to the council
+                // as a fallback to avoid permanently locking funds.
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &council,
+                    &balance,
+                );
+            }
+
+            total_clawed_back += balance;
+            grant.escrow_balances.set(token.clone(), 0);
+        }
+
+        grant.set_status(GrantStatus::Cancelled);
+        Storage::set_grant(&env, grant_id, &grant);
+
+        Events::emit_grant_clawbacked(&env, grant_id, council, total_clawed_back);
+
+        Ok(())
+    }
+
     /// Allows the grant owner to manually withdraw funds for an approved milestone.
     pub fn grant_withdraw(
         env: Env,
@@ -1425,6 +1543,16 @@ impl StellarGrantsContract {
 
         if !grant.reviewers.contains(reviewer.clone()) {
             return Err(ContractError::Unauthorized);
+        }
+
+        // Issue #164: enforce MinReviewerStake — reviewer must have staked at least
+        // the global minimum before they can cast a vote on any milestone.
+        let min_stake = Storage::get_min_reviewer_stake(&env);
+        if min_stake > 0 {
+            let reviewer_stake = Storage::get_reviewer_stake(&env, grant_id, &reviewer);
+            if reviewer_stake < min_stake {
+                return Err(ContractError::InsufficientStake);
+            }
         }
 
         // Duplicate-vote guard: return error if reviewer already voted

--- a/stellargrant-contracts/contracts/stellar-grants/src/test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/test.rs
@@ -5819,8 +5819,21 @@ mod tests {
 
         let mut reviewers = Vec::new(&env);
         reviewers.push_back(reviewer.clone());
-        create_grant(&env, &contract_id, grant_id, owner, token_id.clone(), reviewers);
-        create_milestone(&env, &contract_id, grant_id, milestone_idx, MilestoneState::Submitted);
+        create_grant(
+            &env,
+            &contract_id,
+            grant_id,
+            owner,
+            token_id.clone(),
+            reviewers,
+        );
+        create_milestone(
+            &env,
+            &contract_id,
+            grant_id,
+            milestone_idx,
+            MilestoneState::Submitted,
+        );
 
         // Set MinReviewerStake to 100 but reviewer has staked nothing.
         env.as_contract(&contract_id, || {
@@ -5859,8 +5872,21 @@ mod tests {
 
         let mut reviewers = Vec::new(&env);
         reviewers.push_back(reviewer.clone());
-        create_grant(&env, &contract_id, grant_id, owner.clone(), token_id.clone(), reviewers);
-        create_milestone(&env, &contract_id, grant_id, milestone_idx, MilestoneState::Submitted);
+        create_grant(
+            &env,
+            &contract_id,
+            grant_id,
+            owner.clone(),
+            token_id.clone(),
+            reviewers,
+        );
+        create_milestone(
+            &env,
+            &contract_id,
+            grant_id,
+            milestone_idx,
+            MilestoneState::Submitted,
+        );
 
         // Set MinReviewerStake to 100 and record that reviewer has staked 100.
         env.as_contract(&contract_id, || {
@@ -5899,8 +5925,21 @@ mod tests {
 
         let mut reviewers = Vec::new(&env);
         reviewers.push_back(reviewer.clone());
-        create_grant(&env, &contract_id, grant_id, owner.clone(), token_id.clone(), reviewers);
-        create_milestone(&env, &contract_id, grant_id, milestone_idx, MilestoneState::Submitted);
+        create_grant(
+            &env,
+            &contract_id,
+            grant_id,
+            owner.clone(),
+            token_id.clone(),
+            reviewers,
+        );
+        create_milestone(
+            &env,
+            &contract_id,
+            grant_id,
+            milestone_idx,
+            MilestoneState::Submitted,
+        );
 
         // MinReviewerStake is 0 by default — reviewer with zero stake should still be able to vote.
         let result = client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &None);
@@ -5976,7 +6015,10 @@ mod tests {
         env.as_contract(&contract_id, || {
             let updated = Storage::get_grant(&env, grant_id).unwrap();
             assert_eq!(updated.status(), GrantStatus::Cancelled);
-            assert_eq!(updated.escrow_balances.get(token_id.clone()).unwrap_or(0), 0);
+            assert_eq!(
+                updated.escrow_balances.get(token_id.clone()).unwrap_or(0),
+                0
+            );
         });
     }
 

--- a/stellargrant-contracts/contracts/stellar-grants/src/test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/test.rs
@@ -5796,4 +5796,249 @@ mod tests {
         );
         assert!(result.is_err(), "Should reject tags longer than 20 chars");
     }
+
+    // ── Issue #164: milestone_vote stake enforcement ──────────────────────────
+
+    #[test]
+    fn test_milestone_vote_fails_when_reviewer_has_insufficient_stake() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let council = Address::generate(&env);
+        client.initialize(&admin, &council);
+
+        let grant_id = 200u64;
+        let milestone_idx = 0u32;
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+        token_admin.mint(&contract_id, &500);
+
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+        create_grant(&env, &contract_id, grant_id, owner, token_id.clone(), reviewers);
+        create_milestone(&env, &contract_id, grant_id, milestone_idx, MilestoneState::Submitted);
+
+        // Set MinReviewerStake to 100 but reviewer has staked nothing.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&crate::storage::DataKey::MinReviewerStake, &100i128);
+        });
+
+        let result = client.try_milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &None);
+        assert_eq!(
+            result,
+            Err(Ok(ContractError::InsufficientStake.into())),
+            "vote should fail when reviewer stake < MinReviewerStake"
+        );
+    }
+
+    #[test]
+    fn test_milestone_vote_succeeds_when_reviewer_has_sufficient_stake() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let council = Address::generate(&env);
+        client.initialize(&admin, &council);
+
+        let grant_id = 201u64;
+        let milestone_idx = 0u32;
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+        // Mint enough for escrow payout + stake transfer
+        token_admin.mint(&contract_id, &500);
+        token_admin.mint(&reviewer, &200);
+
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+        create_grant(&env, &contract_id, grant_id, owner.clone(), token_id.clone(), reviewers);
+        create_milestone(&env, &contract_id, grant_id, milestone_idx, MilestoneState::Submitted);
+
+        // Set MinReviewerStake to 100 and record that reviewer has staked 100.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&crate::storage::DataKey::MinReviewerStake, &100i128);
+            env.storage().persistent().set(
+                &crate::storage::DataKey::ReviewerStake(grant_id, reviewer.clone()),
+                &100i128,
+            );
+        });
+
+        // Vote should succeed because stake meets the minimum.
+        let result = client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &None);
+        assert!(result, "vote should succeed when stake >= MinReviewerStake");
+    }
+
+    #[test]
+    fn test_milestone_vote_succeeds_when_no_min_stake_configured() {
+        // When MinReviewerStake is 0 (default), no stake check is applied.
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let council = Address::generate(&env);
+        client.initialize(&admin, &council);
+
+        let grant_id = 202u64;
+        let milestone_idx = 0u32;
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+        token_admin.mint(&contract_id, &500);
+
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+        create_grant(&env, &contract_id, grant_id, owner.clone(), token_id.clone(), reviewers);
+        create_milestone(&env, &contract_id, grant_id, milestone_idx, MilestoneState::Submitted);
+
+        // MinReviewerStake is 0 by default — reviewer with zero stake should still be able to vote.
+        let result = client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &None);
+        assert!(result, "vote should succeed when MinReviewerStake is 0");
+    }
+
+    // ── Issue #163: grant_clawback ────────────────────────────────────────────
+
+    #[test]
+    fn test_grant_clawback_council_returns_funds_pro_rata() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let council = Address::generate(&env);
+        client.initialize(&admin, &council);
+
+        let grant_id = 300u64;
+        let owner = Address::generate(&env);
+        let funder1 = Address::generate(&env);
+        let funder2 = Address::generate(&env);
+
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = token::StellarAssetClient::new(&env, &token_id);
+        let escrow_balance: i128 = 1000;
+        token_admin.mint(&contract_id, &escrow_balance);
+
+        let mut funders = Vec::new(&env);
+        funders.push_back(GrantFund {
+            funder: funder1.clone(),
+            amount: 600,
+            token: token_id.clone(),
+        });
+        funders.push_back(GrantFund {
+            funder: funder2.clone(),
+            amount: 400,
+            token: token_id.clone(),
+        });
+
+        env.as_contract(&contract_id, || {
+            let mut grant = Grant::new(
+                grant_id,
+                owner.clone(),
+                String::from_str(&env, "Fraudulent grant"),
+                String::from_str(&env, "Desc"),
+                token_id.clone(),
+                escrow_balance,
+                500,
+                Vec::new(&env),
+                GrantStatus::Active,
+                1,
+                2,
+                env.ledger().timestamp(),
+                0,
+                &env,
+            );
+            let mut escrow_balances = Map::new(&env);
+            escrow_balances.set(token_id.clone(), escrow_balance);
+            grant.escrow_balances = escrow_balances;
+            grant.funders = funders;
+            Storage::set_grant(&env, grant_id, &grant);
+        });
+
+        // Council claws back funds.
+        client.grant_clawback(&council, &grant_id);
+
+        // Verify pro-rata refunds: funder1 gets 600, funder2 gets 400.
+        let token_client = token::Client::new(&env, &token_id);
+        assert_eq!(token_client.balance(&funder1), 600);
+        assert_eq!(token_client.balance(&funder2), 400);
+
+        // Verify grant is now cancelled.
+        env.as_contract(&contract_id, || {
+            let updated = Storage::get_grant(&env, grant_id).unwrap();
+            assert_eq!(updated.status(), GrantStatus::Cancelled);
+            assert_eq!(updated.escrow_balances.get(token_id.clone()).unwrap_or(0), 0);
+        });
+    }
+
+    #[test]
+    fn test_grant_clawback_non_council_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let council = Address::generate(&env);
+        let impostor = Address::generate(&env);
+        client.initialize(&admin, &council);
+
+        let grant_id = 301u64;
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        create_grant(&env, &contract_id, grant_id, owner, token, Vec::new(&env));
+
+        let result = client.try_grant_clawback(&impostor, &grant_id);
+        assert_eq!(
+            result,
+            Err(Ok(ContractError::Unauthorized.into())),
+            "non-council caller must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_grant_clawback_on_cancelled_grant_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let council = Address::generate(&env);
+        client.initialize(&admin, &council);
+
+        let grant_id = 302u64;
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let mut grant = Grant::new(
+                grant_id,
+                owner,
+                String::from_str(&env, "Already cancelled"),
+                String::from_str(&env, "Desc"),
+                token,
+                500,
+                500,
+                Vec::new(&env),
+                GrantStatus::Cancelled,
+                1,
+                1,
+                env.ledger().timestamp(),
+                0,
+                &env,
+            );
+            Storage::set_grant(&env, grant_id, &grant);
+        });
+
+        let result = client.try_grant_clawback(&council, &grant_id);
+        assert_eq!(
+            result,
+            Err(Ok(ContractError::InvalidState.into())),
+            "clawback on an already-cancelled grant must be rejected"
+        );
+    }
 }


### PR DESCRIPTION
This PR addresses issues #163 and #164 in the StellarGrant contract.

### Changes:
1. **Issue #164 (Reviewer Stake Enforcement):**
   - Modified milestone_vote in lib.rs to verify that the reviewer has staked at least the MinReviewerStake amount before they are permitted to vote.
   - Returns ContractError::InsufficientStake if the requirement is not met.

2. **Issue #163 (Grant Clawback Mechanism):**
   - Implemented grant_clawback in lib.rs allowing the DAO Council to recover escrowed funds from fraudulent grants.
   - Added GrantClawbacked event in events.rs.
   - The clawback mechanism performs a pro-rata refund to all original funders across all tokens held in escrow.
   - Transitions grant status to Cancelled.

### Verification:
- Added unit tests in 	est.rs covering:
  - Stake enforcement (success and failure paths).
  - Clawback authorization (council-only).
  - Clawback refund logic (pro-rata distribution).
  - Clawback state transitions.

Closes #163
Closes #164