### PR TITLE
feat(contracts): add reviewer vote delegation

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -230,6 +230,16 @@ pub struct ContractWasmUpgraded {
     pub timestamp: u64,
 }
 
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReviewerDelegated {
+    pub event_version: u32,
+    pub grant_id: u64,
+    pub delegator: Address,
+    pub delegatee: Address,
+    pub timestamp: u64,
+}
+
 pub struct Events;
 
 #[contractevent]
@@ -885,6 +895,17 @@ impl Events {
             grant_id,
             council,
             total_clawed_back,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn reviewer_delegated(env: &Env, grant_id: u64, delegator: Address, delegatee: Address) {
+        let event = ReviewerDelegated {
+            event_version: EVENT_VERSION,
+            grant_id,
+            delegator,
+            delegatee,
             timestamp: env.ledger().timestamp(),
         };
         event.publish(env);

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -986,6 +986,35 @@ impl StellarGrantsContract {
         Ok(grant_id)
     }
 
+    /// Allow a reviewer to delegate milestone voting power for a specific grant.
+    /// Passing `delegatee == delegator` revokes any active delegation.
+    pub fn grant_delegate(
+        env: Env,
+        delegator: Address,
+        delegatee: Address,
+        grant_id: u64,
+    ) -> Result<(), ContractError> {
+        delegator.require_auth();
+        assert_not_paused(&env)?;
+
+        let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        if grant.status() != GrantStatus::Active {
+            return Err(ContractError::InvalidState);
+        }
+        if !grant.reviewers.contains(delegator.clone()) {
+            return Err(ContractError::Unauthorized);
+        }
+
+        if delegatee == delegator {
+            Storage::remove_delegation(&env, grant_id, &delegator);
+        } else {
+            Storage::set_delegation(&env, grant_id, &delegator, &delegatee);
+        }
+
+        Events::reviewer_delegated(&env, grant_id, delegator, delegatee);
+        Ok(())
+    }
+
     /// Register a contributor profile on-chain
     pub fn contributor_register(
         env: Env,
@@ -1505,12 +1534,8 @@ impl StellarGrantsContract {
         approve: bool,
         feedback: Option<String>,
     ) -> Result<bool, ContractError> {
-        reviewer.require_auth();
+        authorize_reviewer_vote_actor(&env, grant_id, &reviewer)?;
         assert_not_paused(&env)?;
-
-        if Storage::is_blacklisted(&env, &reviewer) {
-            return Err(ContractError::Blacklisted);
-        }
 
         let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
         let mut milestone = Storage::get_milestone(&env, grant_id, milestone_idx)
@@ -2154,6 +2179,7 @@ impl StellarGrantsContract {
 
         grant.reviewers = new_reviewers;
         Storage::set_grant(&env, grant_id, &grant);
+        Storage::remove_delegation(&env, grant_id, &old_reviewer);
 
         Events::emit_reviewer_removed(&env, grant_id, owner, old_reviewer);
         Ok(())
@@ -2874,6 +2900,27 @@ fn ensure_min_reputation_for_grant(
     let profile = Storage::get_contributor(env, contributor).ok_or(ContractError::Unauthorized)?;
     if profile.reputation_score < min_reputation {
         return Err(ContractError::InsufficientReputation);
+    }
+
+    Ok(())
+}
+
+fn authorize_reviewer_vote_actor(
+    env: &Env,
+    grant_id: u64,
+    reviewer: &Address,
+) -> Result<(), ContractError> {
+    if Storage::is_blacklisted(env, reviewer) {
+        return Err(ContractError::Blacklisted);
+    }
+
+    if let Some(delegatee) = Storage::get_delegation(env, grant_id, reviewer) {
+        if Storage::is_blacklisted(env, &delegatee) {
+            return Err(ContractError::Blacklisted);
+        }
+        delegatee.require_auth();
+    } else {
+        reviewer.require_auth();
     }
 
     Ok(())

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::types::{DisputeInfo, EscrowLifecycleState, EscrowMode, EscrowState, Grant, Milestone};
-use soroban_sdk::{contracttype, Env};
+use soroban_sdk::{contracttype, Address, Env, Map};
 
 #[contracttype]
 pub enum DataKey {
@@ -31,6 +31,8 @@ pub enum DataKey {
     StorageVersion,
     /// Global contract pause flag stored in instance storage.
     IsPaused,
+    /// Per-grant reviewer delegation map: grant_id -> (delegator -> delegatee).
+    Delegation,
     /// Tracks whether reputation was already credited for a milestone payout (issue #151).
     MilestoneReputationApplied(u64, u32),
     /// Global dispute fee amount in the primary token (issue #152).
@@ -380,6 +382,66 @@ impl Storage {
 
     pub fn set_paused(env: &Env, paused: bool) {
         env.storage().instance().set(&DataKey::IsPaused, &paused);
+    }
+
+    // --- Reviewer delegation helpers ---
+
+    pub fn get_delegation(env: &Env, grant_id: u64, delegator: &Address) -> Option<Address> {
+        let key = DataKey::Delegation;
+        let delegations: Map<u64, Map<Address, Address>> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Map::new(env));
+        if !delegations.is_empty() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+
+        delegations
+            .get(grant_id)
+            .and_then(|grant_delegations| grant_delegations.get(delegator.clone()))
+    }
+
+    pub fn set_delegation(env: &Env, grant_id: u64, delegator: &Address, delegatee: &Address) {
+        let key = DataKey::Delegation;
+        let mut delegations: Map<u64, Map<Address, Address>> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Map::new(env));
+        let mut grant_delegations = delegations.get(grant_id).unwrap_or(Map::new(env));
+
+        grant_delegations.set(delegator.clone(), delegatee.clone());
+        delegations.set(grant_id, grant_delegations);
+
+        env.storage().persistent().set(&key, &delegations);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn remove_delegation(env: &Env, grant_id: u64, delegator: &Address) {
+        let key = DataKey::Delegation;
+        let mut delegations: Map<u64, Map<Address, Address>> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Map::new(env));
+        let Some(mut grant_delegations) = delegations.get(grant_id) else {
+            return;
+        };
+
+        if !grant_delegations.contains_key(delegator.clone()) {
+            return;
+        }
+
+        grant_delegations.remove(delegator.clone());
+        if grant_delegations.is_empty() {
+            delegations.remove(grant_id);
+        } else {
+            delegations.set(grant_id, grant_delegations);
+        }
+
+        env.storage().persistent().set(&key, &delegations);
+        Self::bump_persistent_ttl(env, &key);
     }
 
     // --- Issue #151: milestone reputation tracking ---

--- a/stellargrant-contracts/contracts/stellar-grants/tests/test_delegate_voting.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/tests/test_delegate_voting.rs
@@ -1,0 +1,306 @@
+use soroban_sdk::{
+    testutils::{Address as TestAddress, Events, Ledger as _, MockAuth, MockAuthInvoke},
+    Address, Env, IntoVal, String, Vec,
+};
+use stellar_grants::{
+    ContractError, StellarGrantsContract, StellarGrantsContractClient, Storage,
+    COMMUNITY_REVIEW_PERIOD,
+};
+
+fn setup_active_grant<'a>(
+    env: &'a Env,
+    reviewers: &Vec<Address>,
+) -> (StellarGrantsContractClient<'a>, Address, u64) {
+    let contract_id = env.register(StellarGrantsContract, ());
+    let client = StellarGrantsContractClient::new(env, &contract_id);
+    let owner = <Address as TestAddress>::generate(env);
+    let admin = <Address as TestAddress>::generate(env);
+
+    let token_contract = env.register_stellar_asset_contract_v2(admin);
+    let token_id = token_contract.address();
+    let quorum = (reviewers.len() / 2) + 1;
+    let title = String::from_str(env, "Delegation Test");
+    let description = String::from_str(env, "Reviewer delegation");
+    let milestone_deadlines: Option<Vec<u64>> = None;
+    let tags = Vec::<String>::new(env);
+
+    let grant_id = client
+        .mock_auths(&[MockAuth {
+            address: &owner,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "grant_create",
+                args: (
+                    &owner,
+                    &title,
+                    &description,
+                    &token_id,
+                    &100i128,
+                    &10i128,
+                    &1u32,
+                    reviewers,
+                    &quorum,
+                    &milestone_deadlines,
+                    &0i128,
+                    &0i128,
+                    &tags,
+                )
+                    .into_val(env),
+                sub_invokes: &[],
+            },
+        }])
+        .grant_create(
+            &owner,
+            &title,
+            &description,
+            &token_id,
+            &100,
+            &10,
+            &1,
+            reviewers,
+            &quorum,
+            &milestone_deadlines,
+            &0i128,
+            &0i128,
+            &tags,
+        );
+    client
+        .mock_auths(&[MockAuth {
+            address: &owner,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "grant_accept",
+                args: (&grant_id, &owner).into_val(env),
+                sub_invokes: &[],
+            },
+        }])
+        .grant_accept(&grant_id, &owner);
+    client
+        .mock_auths(&[MockAuth {
+            address: &owner,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "milestone_submit",
+                args: (
+                    &grant_id,
+                    &0u32,
+                    &owner,
+                    &String::from_str(env, "Milestone"),
+                    &String::from_str(env, "proof"),
+                    &None::<Address>,
+                )
+                    .into_val(env),
+                sub_invokes: &[],
+            },
+        }])
+        .milestone_submit(
+            &grant_id,
+            &0,
+            &owner,
+            &String::from_str(env, "Milestone"),
+            &String::from_str(env, "proof"),
+            &None,
+        );
+
+    let ts = env.ledger().timestamp();
+    env.ledger()
+        .set_timestamp(ts.saturating_add(COMMUNITY_REVIEW_PERIOD).saturating_add(1));
+
+    (client, contract_id, grant_id)
+}
+
+#[test]
+fn test_delegatee_vote_counts_for_reviewer_and_emits_event() {
+    let env = Env::default();
+    let reviewer = <Address as TestAddress>::generate(&env);
+    let delegatee = <Address as TestAddress>::generate(&env);
+    let mut reviewers = Vec::new(&env);
+    reviewers.push_back(reviewer.clone());
+
+    let (client, contract_id, grant_id) = setup_active_grant(&env, &reviewers);
+    let feedback: Option<String> = None;
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &reviewer,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "grant_delegate",
+                args: (&reviewer, &delegatee, &grant_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .grant_delegate(&reviewer, &delegatee, &grant_id);
+
+    let mut found_delegate_event = false;
+    extern crate std;
+    for event in env.events().all().events() {
+        let rendered = std::format!("{:?}", event);
+        if rendered.contains("reviewer_delegated") {
+            found_delegate_event = true;
+        }
+    }
+    assert!(
+        found_delegate_event,
+        "ReviewerDelegated event was not emitted"
+    );
+
+    let approved = client
+        .mock_auths(&[MockAuth {
+            address: &delegatee,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "milestone_vote",
+                args: (&grant_id, &0u32, &reviewer, &true, &feedback).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .milestone_vote(&grant_id, &0, &reviewer, &true, &feedback);
+    assert!(approved);
+
+    env.as_contract(&contract_id, || {
+        let milestone = Storage::get_milestone(&env, grant_id, 0).unwrap();
+        assert_eq!(milestone.votes.get(reviewer.clone()), Some(true));
+        assert_eq!(milestone.votes.get(delegatee.clone()), None);
+    });
+}
+
+#[test]
+fn test_delegate_update_and_revocation_work_for_same_grant() {
+    let env = Env::default();
+    let reviewer = <Address as TestAddress>::generate(&env);
+    let first_delegatee = <Address as TestAddress>::generate(&env);
+    let second_delegatee = <Address as TestAddress>::generate(&env);
+    let mut reviewers = Vec::new(&env);
+    reviewers.push_back(reviewer.clone());
+
+    let (client, contract_id, grant_id) = setup_active_grant(&env, &reviewers);
+    let feedback: Option<String> = None;
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &reviewer,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "grant_delegate",
+                args: (&reviewer, &first_delegatee, &grant_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .grant_delegate(&reviewer, &first_delegatee, &grant_id);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &reviewer,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "grant_delegate",
+                args: (&reviewer, &second_delegatee, &grant_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .grant_delegate(&reviewer, &second_delegatee, &grant_id);
+
+    env.as_contract(&contract_id, || {
+        assert_eq!(
+            Storage::get_delegation(&env, grant_id, &reviewer),
+            Some(second_delegatee.clone())
+        );
+    });
+
+    let approved = client
+        .mock_auths(&[MockAuth {
+            address: &second_delegatee,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "milestone_vote",
+                args: (&grant_id, &0u32, &reviewer, &true, &feedback).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .milestone_vote(&grant_id, &0, &reviewer, &true, &feedback);
+    assert!(approved);
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &reviewer,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "grant_delegate",
+                args: (&reviewer, &reviewer, &grant_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .grant_delegate(&reviewer, &reviewer, &grant_id);
+
+    env.as_contract(&contract_id, || {
+        assert_eq!(Storage::get_delegation(&env, grant_id, &reviewer), None);
+    });
+}
+
+#[test]
+fn test_delegated_vote_uses_reviewer_slot_for_double_vote_protection() {
+    let env = Env::default();
+    let reviewer = <Address as TestAddress>::generate(&env);
+    let other_reviewer = <Address as TestAddress>::generate(&env);
+    let delegatee = <Address as TestAddress>::generate(&env);
+    let mut reviewers = Vec::new(&env);
+    reviewers.push_back(reviewer.clone());
+    reviewers.push_back(other_reviewer);
+
+    let (client, contract_id, grant_id) = setup_active_grant(&env, &reviewers);
+    let feedback: Option<String> = None;
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &reviewer,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "grant_delegate",
+                args: (&reviewer, &delegatee, &grant_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .grant_delegate(&reviewer, &delegatee, &grant_id);
+
+    let delegated_vote = client
+        .mock_auths(&[MockAuth {
+            address: &delegatee,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "milestone_vote",
+                args: (&grant_id, &0u32, &reviewer, &true, &feedback).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .milestone_vote(&grant_id, &0, &reviewer, &true, &feedback);
+    assert!(
+        !delegated_vote,
+        "single delegated vote should not reach quorum"
+    );
+
+    client
+        .mock_auths(&[MockAuth {
+            address: &reviewer,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "grant_delegate",
+                args: (&reviewer, &reviewer, &grant_id).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .grant_delegate(&reviewer, &reviewer, &grant_id);
+
+    let second_vote = client
+        .mock_auths(&[MockAuth {
+            address: &reviewer,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "milestone_vote",
+                args: (&grant_id, &0u32, &reviewer, &true, &feedback).into_val(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .try_milestone_vote(&grant_id, &0, &reviewer, &true, &feedback);
+    assert_eq!(second_vote, Err(Ok(ContractError::AlreadyVoted.into())));
+}


### PR DESCRIPTION
## Summary
- add per-grant reviewer delegation storage
- add `grant_delegate` contract entrypoint
- allow delegatees to cast milestone votes on behalf of reviewers
- emit `ReviewerDelegated` events and clean up delegation on reviewer removal
- add integration tests for delegation, updates/revocation, and double-vote protection

## Testing
- `cargo check -p stellar-grants --lib`
- `cargo test -p stellar-grants --test test_delegate_voting`


closes #136
