### PR TITLE
feat(stellar-grants): grant heartbeat, open bounty, milestone top-ups

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -201,6 +201,17 @@ pub struct MilestoneSubmitted {
 
 #[contractevent]
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BountyClaimed {
+    pub event_version: u32,
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub winner: Address,
+    pub submission_index: u32,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GrantFunded {
     pub event_version: u32,
     pub grant_id: u64,
@@ -208,6 +219,18 @@ pub struct GrantFunded {
     pub amount: i128,
     pub token: Address, // New: Specify which token was funded
     pub new_balance: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MilestoneTopUpFunded {
+    pub event_version: u32,
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub funder: Address,
+    pub token: Address,
+    pub amount: i128,
     pub timestamp: u64,
 }
 
@@ -510,6 +533,24 @@ impl Events {
         event.publish(env);
     }
 
+    pub fn emit_bounty_claimed(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        winner: Address,
+        submission_index: u32,
+    ) {
+        let event = BountyClaimed {
+            event_version: EVENT_VERSION,
+            grant_id,
+            milestone_idx,
+            winner,
+            submission_index,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
     pub fn emit_grant_funded(
         env: &Env,
         grant_id: u64,
@@ -525,6 +566,26 @@ impl Events {
             amount,
             token,
             new_balance,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_milestone_top_up_funded(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        funder: Address,
+        token: Address,
+        amount: i128,
+    ) {
+        let event = MilestoneTopUpFunded {
+            event_version: EVENT_VERSION,
+            grant_id,
+            milestone_idx,
+            funder,
+            token,
+            amount,
             timestamp: env.ledger().timestamp(),
         };
         event.publish(env);

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -12,15 +12,154 @@ mod types;
 pub use events::Events;
 pub use storage::Storage;
 pub use types::{
-    AccessControl, ContractError, DisputeInfo, EscrowLifecycleState, EscrowMode, EscrowState,
-    ExtensionRequest, Grant, GrantFund, GrantStatus, Milestone, MilestoneState,
-    MilestoneSubmission, Role,
+    AccessControl, BountySubmissionEntry, ContractError, DisputeInfo, EscrowLifecycleState,
+    EscrowMode, EscrowState, ExtensionRequest, Grant, GrantFund, GrantStatus, Milestone,
+    MilestoneState, MilestoneSubmission, MilestoneTopUp, Role,
 };
 
-use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, token, Address, BytesN, Env, Map, String, Vec};
 pub const COMMUNITY_REVIEW_PERIOD: u64 = 3 * 24 * 60 * 60;
 pub const CHALLENGE_PERIOD: u64 = 48 * 60 * 60;
 pub const CANCEL_GRACE_PERIOD: u64 = 7 * 24 * 60 * 60;
+/// No owner activity (heartbeat) for this long allows permissionless `mark_grant_inactive`.
+pub const HEARTBEAT_INACTIVITY_SECS: u64 = 60 * 24 * 60 * 60;
+
+const MAX_BOUNTY_SUBMISSIONS_PER_MILESTONE: u32 = 20;
+
+fn milestone_payee(milestone: &Milestone, grant: &Grant) -> Address {
+    milestone
+        .bounty_winner
+        .clone()
+        .unwrap_or_else(|| grant.owner.clone())
+}
+
+fn bounty_submission_approve_weight(env: &Env, entry: &BountySubmissionEntry) -> u32 {
+    let mut w = 0u32;
+    for (voter, approved) in entry.votes.iter() {
+        if approved {
+            w = w.saturating_add(Storage::get_reviewer_reputation(env, voter.clone()));
+        }
+    }
+    w
+}
+
+fn milestone_payout_amount_for_token(
+    milestone: &Milestone,
+    token: Address,
+) -> Result<i128, ContractError> {
+    let extra = milestone.additional_funds.get(token.clone()).unwrap_or(0);
+    if milestone.payout_token == token {
+        milestone
+            .amount
+            .checked_add(extra)
+            .ok_or(ContractError::InvalidInput)
+    } else {
+        Ok(extra)
+    }
+}
+
+fn clear_milestone_additional_funding(env: &Env, milestone: &mut Milestone) {
+    milestone.additional_funds = Map::new(env);
+    milestone.top_up_contributions = Vec::new(env);
+}
+
+fn refund_milestone_top_up_contributions_from_grant(
+    env: &Env,
+    grant: &mut Grant,
+    milestone: &Milestone,
+) -> Result<(), ContractError> {
+    for i in 0..milestone.top_up_contributions.len() {
+        let c = milestone
+            .top_up_contributions
+            .get(i)
+            .ok_or(ContractError::InvalidInput)?;
+        if c.amount <= 0 {
+            continue;
+        }
+        let cur = grant.escrow_balances.get(c.token.clone()).unwrap_or(0);
+        if cur < c.amount {
+            return Err(ContractError::InsufficientBalance);
+        }
+        token::Client::new(env, &c.token).transfer(
+            &env.current_contract_address(),
+            &c.funder,
+            &c.amount,
+        );
+        grant.escrow_balances.set(
+            c.token.clone(),
+            cur.checked_sub(c.amount)
+                .ok_or(ContractError::InsufficientBalance)?,
+        );
+    }
+    Ok(())
+}
+
+fn refund_all_milestone_top_up_contributions_and_clear(
+    env: &Env,
+    grant_id: u64,
+    grant: &mut Grant,
+) -> Result<(), ContractError> {
+    for milestone_idx in 0..grant.total_milestones() {
+        if let Some(mut milestone) = Storage::get_milestone(env, grant_id, milestone_idx) {
+            refund_milestone_top_up_contributions_from_grant(env, grant, &milestone)?;
+            clear_milestone_additional_funding(env, &mut milestone);
+            Storage::set_milestone(env, grant_id, milestone_idx, &milestone);
+        }
+    }
+    Ok(())
+}
+
+fn payout_milestone_locked_funds_from_escrow(
+    env: &Env,
+    grant: &mut Grant,
+    milestone: &mut Milestone,
+    payee: &Address,
+) -> Result<i128, ContractError> {
+    let payout_tok = milestone.payout_token.clone();
+    let primary_amt = milestone_payout_amount_for_token(milestone, payout_tok.clone())?;
+
+    let mut reputation_weight: i128 = 0;
+
+    if primary_amt > 0 {
+        let cur = grant.escrow_balances.get(payout_tok.clone()).unwrap_or(0);
+        if cur < primary_amt {
+            return Err(ContractError::InsufficientBalance);
+        }
+        token::Client::new(env, &payout_tok).transfer(
+            &env.current_contract_address(),
+            payee,
+            &primary_amt,
+        );
+        grant.escrow_balances.set(
+            payout_tok.clone(),
+            cur.checked_sub(primary_amt)
+                .ok_or(ContractError::InsufficientBalance)?,
+        );
+        reputation_weight = primary_amt;
+    }
+
+    for (tok, amt) in milestone.additional_funds.iter() {
+        if tok == payout_tok || amt <= 0 {
+            continue;
+        }
+        let cur = grant.escrow_balances.get(tok.clone()).unwrap_or(0);
+        if cur < amt {
+            return Err(ContractError::InsufficientBalance);
+        }
+        token::Client::new(env, &tok).transfer(&env.current_contract_address(), payee, &amt);
+        grant.escrow_balances.set(
+            tok.clone(),
+            cur.checked_sub(amt)
+                .ok_or(ContractError::InsufficientBalance)?,
+        );
+        reputation_weight = reputation_weight
+            .checked_add(amt)
+            .ok_or(ContractError::InvalidInput)?;
+    }
+
+    clear_milestone_additional_funding(env, milestone);
+    Ok(reputation_weight)
+}
 
 #[contract]
 pub struct StellarGrantsContract;
@@ -117,45 +256,44 @@ impl StellarGrantsContract {
             return Err(ContractError::QuorumNotReached);
         }
 
-        let amount = milestone.amount;
         let payout_token = milestone.payout_token.clone();
-        let current_balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
-
-        if current_balance < amount {
+        let total_primary = milestone_payout_amount_for_token(&milestone, payout_token.clone())?;
+        let primary_bal = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
+        if primary_bal < total_primary {
             return Err(ContractError::InsufficientBalance);
         }
+        for (tok, amt) in milestone.additional_funds.iter() {
+            if tok == payout_token || amt <= 0 {
+                continue;
+            }
+            let b = grant.escrow_balances.get(tok.clone()).unwrap_or(0);
+            if b < amt {
+                return Err(ContractError::InsufficientBalance);
+            }
+        }
 
-        // State Update
         milestone.set_state(MilestoneState::Approved);
         milestone.status_updated_at = env.ledger().timestamp();
 
-        let recipient = grant.owner.clone();
-
-        // Payout Execution & balance deduction
-        let new_balance = current_balance
-            .checked_sub(amount)
-            .ok_or(ContractError::InsufficientBalance)?;
-        grant.escrow_balances.set(payout_token.clone(), new_balance);
+        let recipient = milestone_payee(&milestone, grant);
         grant.set_milestones_paid_out(grant.milestones_paid_out() + 1);
+
+        let rep_amt =
+            payout_milestone_locked_funds_from_escrow(env, grant, &mut milestone, &recipient)?;
 
         Storage::set_milestone(env, grant_id, milestone_idx, &milestone);
 
-        let token_client = token::Client::new(env, &payout_token);
-        token_client.transfer(&env.current_contract_address(), &recipient, &amount);
+        Self::update_contributor_reputation(env, grant_id, milestone_idx, &recipient, rep_amt);
 
-        // Issue #151: credit reputation after payout
-        Self::update_contributor_reputation(env, grant_id, milestone_idx, &recipient, amount);
-
-        // Events
         Events::emit_milestone_approved(
             env,
             grant_id,
             milestone_idx,
-            amount,
+            total_primary,
             payout_token.clone(),
             recipient.clone(),
         );
-        Events::emit_payout_executed(env, grant_id, recipient, amount, payout_token);
+        Events::emit_payout_executed(env, grant_id, recipient, total_primary, payout_token);
 
         Ok(())
     }
@@ -220,43 +358,49 @@ impl StellarGrantsContract {
         let mut grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
 
         let payout_token = milestone.payout_token.clone();
+        let total_owed_primary =
+            milestone_payout_amount_for_token(&milestone, payout_token.clone())?;
         let current_payout_balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
-        let milestone_already_paid = current_payout_balance < milestone.amount;
-        let token_client = token::Client::new(&env, &payout_token);
+        let milestone_already_paid = current_payout_balance < total_owed_primary;
 
         if approve {
+            let emit_amount = if milestone_already_paid {
+                milestone.amount
+            } else {
+                total_owed_primary
+            };
             if !milestone_already_paid {
-                // Approve: payout milestone amount to grant owner (contributor)
                 let current_balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
-                if current_balance < milestone.amount {
+                if current_balance < total_owed_primary {
                     return Err(ContractError::InvalidInput);
                 }
-                token_client.transfer(
-                    &env.current_contract_address(),
-                    &grant.owner,
-                    &milestone.amount,
-                );
-
-                grant
-                    .escrow_balances
-                    .set(payout_token.clone(), current_balance - milestone.amount);
+                for (tok, amt) in milestone.additional_funds.iter() {
+                    if tok == payout_token || amt <= 0 {
+                        continue;
+                    }
+                    let b = grant.escrow_balances.get(tok.clone()).unwrap_or(0);
+                    if b < amt {
+                        return Err(ContractError::InvalidInput);
+                    }
+                }
+                let payee = milestone_payee(&milestone, &grant);
+                let rep_amt = payout_milestone_locked_funds_from_escrow(
+                    &env,
+                    &mut grant,
+                    &mut milestone,
+                    &payee,
+                )?;
                 grant.set_milestones_paid_out(grant.milestones_paid_out() + 1);
                 Storage::set_grant(&env, grant_id, &grant);
+                Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
 
-                // Issue #151: credit reputation for the payout
-                Self::update_contributor_reputation(
-                    &env,
-                    grant_id,
-                    milestone_idx,
-                    &grant.owner,
-                    milestone.amount,
-                );
+                Self::update_contributor_reputation(&env, grant_id, milestone_idx, &payee, rep_amt);
             }
             Events::emit_milestone_paid(
                 &env,
                 grant_id,
                 milestone_idx,
-                milestone.amount,
+                emit_amount,
                 payout_token.clone(),
             );
 
@@ -282,7 +426,9 @@ impl StellarGrantsContract {
                 Storage::remove_milestone_dispute_info(&env, grant_id, milestone_idx);
             }
         } else {
-            // Reject: refund milestone amount to funders (pro-rata)
+            // Reject: refund milestone top-ups to their funders, then base amount pro-rata to grant funders.
+            refund_milestone_top_up_contributions_from_grant(&env, &mut grant, &milestone)?;
+            clear_milestone_additional_funding(&env, &mut milestone);
             let total_refundable = milestone.amount;
             let current_balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
             if current_balance < total_refundable {
@@ -299,6 +445,7 @@ impl StellarGrantsContract {
                 .escrow_balances
                 .set(payout_token.clone(), current_balance - total_refundable);
             Storage::set_grant(&env, grant_id, &grant);
+            Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
 
             // Issue #152: slash dispute fee → treasury (dispute dismissed)
             if let Some(dispute_info) =
@@ -340,6 +487,8 @@ impl StellarGrantsContract {
         if grant.status() == GrantStatus::Cancelled || grant.status() == GrantStatus::Completed {
             return Err(ContractError::InvalidState);
         }
+
+        refund_all_milestone_top_up_contributions_and_clear(&env, grant_id, &mut grant)?;
 
         let mut total_clawed_back: i128 = 0;
 
@@ -393,22 +542,24 @@ impl StellarGrantsContract {
         }
 
         let payout_token = milestone.payout_token.clone();
-        let current_balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
-
-        if current_balance < milestone.amount {
+        let total_primary = milestone_payout_amount_for_token(&milestone, payout_token.clone())?;
+        let primary_bal = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
+        if primary_bal < total_primary {
             return Err(ContractError::InvalidInput);
         }
+        for (tok, amt) in milestone.additional_funds.iter() {
+            if tok == payout_token || amt <= 0 {
+                continue;
+            }
+            let b = grant.escrow_balances.get(tok.clone()).unwrap_or(0);
+            if b < amt {
+                return Err(ContractError::InvalidInput);
+            }
+        }
 
-        let token_client = token::Client::new(&env, &payout_token);
-        token_client.transfer(
-            &env.current_contract_address(),
-            &grant.owner,
-            &milestone.amount,
-        );
-
-        grant
-            .escrow_balances
-            .set(payout_token.clone(), current_balance - milestone.amount);
+        let payee = milestone_payee(&milestone, &grant);
+        let rep_amt =
+            payout_milestone_locked_funds_from_escrow(&env, &mut grant, &mut milestone, &payee)?;
         grant.set_milestones_paid_out(grant.milestones_paid_out() + 1);
         milestone.state = MilestoneState::Paid;
         milestone.status_updated_at = env.ledger().timestamp();
@@ -416,24 +567,10 @@ impl StellarGrantsContract {
         Storage::set_grant(&env, grant_id, &grant);
         Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
 
-        // Issue #151: credit reputation after manual withdrawal payout
-        let owner_clone = grant.owner.clone();
-        let amount_clone = milestone.amount;
-        Self::update_contributor_reputation(
-            &env,
-            grant_id,
-            milestone_idx,
-            &owner_clone,
-            amount_clone,
-        );
+        let payee_clone = payee.clone();
+        Self::update_contributor_reputation(&env, grant_id, milestone_idx, &payee_clone, rep_amt);
 
-        Events::emit_milestone_paid(
-            &env,
-            grant_id,
-            milestone_idx,
-            milestone.amount,
-            payout_token,
-        );
+        Events::emit_milestone_paid(&env, grant_id, milestone_idx, total_primary, payout_token);
         Events::milestone_status_changed(&env, grant_id, milestone_idx, MilestoneState::Paid);
 
         Ok(())
@@ -584,6 +721,25 @@ impl StellarGrantsContract {
             }
 
             let payout_token = milestone.payout_token.clone();
+            let total_owed_primary =
+                milestone_payout_amount_for_token(&milestone, payout_token.clone())?;
+            let primary_bal = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
+            if primary_bal < total_owed_primary {
+                return Err(ContractError::InsufficientBalance);
+            }
+            for (tok, amt) in milestone.additional_funds.iter() {
+                if tok == payout_token || amt <= 0 {
+                    continue;
+                }
+                let b = grant.escrow_balances.get(tok.clone()).unwrap_or(0);
+                if b < amt {
+                    return Err(ContractError::InsufficientBalance);
+                }
+            }
+
+            refund_milestone_top_up_contributions_from_grant(&env, &mut grant, &milestone)?;
+            clear_milestone_additional_funding(&env, &mut milestone);
+
             let current_balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
             if current_balance < milestone.amount {
                 return Err(ContractError::InsufficientBalance);
@@ -617,7 +773,7 @@ impl StellarGrantsContract {
                 grant_id,
                 milestone_idx,
                 caller,
-                milestone.amount,
+                total_owed_primary,
                 payout_token,
             );
             Ok(())
@@ -823,6 +979,7 @@ impl StellarGrantsContract {
         min_funding: i128,
         hard_cap: i128,
         tags: soroban_sdk::Vec<String>,
+        is_open_bounty: bool,
     ) -> Result<u64, ContractError> {
         owner.require_auth();
         assert_not_paused(&env)?;
@@ -897,6 +1054,7 @@ impl StellarGrantsContract {
             min_funding,
             hard_cap,
             tags: tags.clone(),
+            is_open_bounty,
             packed_config: 0,
         };
         grant.set_status(initial_status);
@@ -939,6 +1097,9 @@ impl StellarGrantsContract {
                 deadline_timestamp: deadline,
                 community_comments: soroban_sdk::Map::new(&env),
                 packed_stats: 0,
+                bounty_winner: None,
+                additional_funds: soroban_sdk::Map::new(&env),
+                top_up_contributions: soroban_sdk::Vec::new(&env),
             };
             milestone.set_idx(i);
             milestone.set_approvals(0);
@@ -1019,6 +1180,7 @@ impl StellarGrantsContract {
             0,
             0,
             soroban_sdk::Vec::new(&env),
+            false,
         )?;
         Storage::set_grant_min_reputation(&env, grant_id, min_reputation_score);
         Ok(grant_id)
@@ -1056,6 +1218,7 @@ impl StellarGrantsContract {
             0,
             0,
             soroban_sdk::Vec::new(&env),
+            false,
         )?;
 
         Storage::set_escrow_state(
@@ -1142,7 +1305,7 @@ impl StellarGrantsContract {
 
             let now = env.ledger().timestamp();
             let heartbeat_age = now.saturating_sub(grant.last_heartbeat);
-            let heartbeat_timeout_60d = heartbeat_age > 60 * 24 * 60 * 60;
+            let heartbeat_timeout_60d = heartbeat_age > HEARTBEAT_INACTIVITY_SECS;
 
             if !(caller_is_admin
                 || caller_is_owner
@@ -1210,6 +1373,8 @@ impl StellarGrantsContract {
             if grant.milestones_paid_out() >= grant.total_milestones() {
                 return Err(ContractError::InvalidState);
             }
+
+            refund_all_milestone_top_up_contributions_and_clear(&env, grant_id, &mut grant)?;
 
             for (token, balance) in grant.escrow_balances.iter() {
                 if balance > 0 {
@@ -1329,6 +1494,8 @@ impl StellarGrantsContract {
         grant_id: u64,
         total_milestones: u32,
     ) -> Result<i128, ContractError> {
+        let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        let primary = grant.token_address.clone();
         let mut total_paid: i128 = 0;
         let mut approved_count = 0;
         for milestone_idx in 0..total_milestones {
@@ -1339,7 +1506,12 @@ impl StellarGrantsContract {
                 {
                     return Err(ContractError::NotAllMilestonesApproved);
                 }
-                total_paid += milestone.amount;
+                total_paid = total_paid
+                    .checked_add(milestone_payout_amount_for_token(
+                        &milestone,
+                        primary.clone(),
+                    )?)
+                    .ok_or(ContractError::InvalidInput)?;
                 approved_count += 1;
             } else {
                 return Err(ContractError::NotAllMilestonesApproved);
@@ -1430,8 +1602,13 @@ impl StellarGrantsContract {
                     {
                         return Err(ContractError::DeadlinePassed);
                     }
+                    let paid_amt = milestone_payout_amount_for_token(
+                        &milestone,
+                        milestone.payout_token.clone(),
+                    )?;
                     milestone.set_state(MilestoneState::Paid);
                     milestone.status_updated_at = env.ledger().timestamp();
+                    clear_milestone_additional_funding(env, &mut milestone);
                     Storage::set_milestone(env, grant_id, milestone_idx, &milestone);
 
                     Events::milestone_status_changed(
@@ -1444,7 +1621,7 @@ impl StellarGrantsContract {
                         env,
                         grant_id,
                         milestone_idx,
-                        milestone.amount,
+                        paid_amt,
                         milestone.payout_token.clone(),
                     );
                 }
@@ -1509,6 +1686,7 @@ impl StellarGrantsContract {
         reviewer: Address,
         approve: bool,
         feedback: Option<String>,
+        bounty_submission_idx: Option<u32>,
     ) -> Result<bool, ContractError> {
         reviewer.require_auth();
         assert_not_paused(&env)?;
@@ -1526,6 +1704,22 @@ impl StellarGrantsContract {
         }
         if mark_milestone_expired_if_needed(&env, grant_id, milestone_idx, &mut milestone)? {
             return Err(ContractError::DeadlinePassed);
+        }
+
+        if grant.is_open_bounty && milestone.state() == MilestoneState::Pending {
+            let sub_idx = bounty_submission_idx.ok_or(ContractError::InvalidInput)?;
+            return Self::milestone_vote_open_bounty(
+                env,
+                grant_id,
+                milestone_idx,
+                reviewer,
+                approve,
+                feedback,
+                sub_idx,
+            );
+        }
+        if bounty_submission_idx.is_some() {
+            return Err(ContractError::InvalidInput);
         }
 
         if milestone.state() == MilestoneState::CommunityReview {
@@ -1621,6 +1815,138 @@ impl StellarGrantsContract {
 
         Ok(quorum_reached)
     }
+
+    fn milestone_vote_open_bounty(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        reviewer: Address,
+        approve: bool,
+        feedback: Option<String>,
+        submission_idx: u32,
+    ) -> Result<bool, ContractError> {
+        let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+
+        if !grant.reviewers.contains(reviewer.clone()) {
+            return Err(ContractError::Unauthorized);
+        }
+        access::require_optional_role(&env, &reviewer, Role::Reviewer)?;
+
+        let min_stake = Storage::get_min_reviewer_stake(&env);
+        if min_stake > 0 {
+            let reviewer_stake = Storage::get_reviewer_stake(&env, grant_id, &reviewer);
+            if reviewer_stake < min_stake {
+                return Err(ContractError::InsufficientStake);
+            }
+        }
+
+        let subs = Storage::get_bounty_submissions(&env, grant_id, milestone_idx)
+            .ok_or(ContractError::InvalidInput)?;
+        if submission_idx >= subs.len() {
+            return Err(ContractError::InvalidInput);
+        }
+
+        let mut entry = subs.get(submission_idx).unwrap();
+        if entry.votes.contains_key(reviewer.clone()) {
+            return Err(ContractError::AlreadyVoted);
+        }
+
+        if let Some(ref fb) = feedback {
+            if fb.len() > 256 {
+                return Err(ContractError::InvalidInput);
+            }
+            entry.reasons.set(reviewer.clone(), fb.clone());
+        }
+
+        entry.votes.set(reviewer.clone(), approve);
+
+        let approval_weight = bounty_submission_approve_weight(&env, &entry);
+        let quorum_reached = approve && approval_weight >= grant.quorum();
+
+        let mut new_subs = Vec::new(&env);
+        for i in 0..subs.len() {
+            if i == submission_idx {
+                new_subs.push_back(entry.clone());
+            } else {
+                new_subs.push_back(subs.get(i).unwrap());
+            }
+        }
+        Storage::set_bounty_submissions(&env, grant_id, milestone_idx, &new_subs);
+
+        if quorum_reached {
+            let winning = Storage::get_bounty_submissions(&env, grant_id, milestone_idx)
+                .unwrap()
+                .get(submission_idx)
+                .unwrap();
+
+            let mut milestone = Storage::get_milestone(&env, grant_id, milestone_idx)
+                .ok_or(ContractError::MilestoneNotFound)?;
+
+            milestone.description = winning.description.clone();
+            milestone.proof_url = Some(winning.proof_url.clone());
+            milestone.payout_token = winning.payout_token.clone();
+            milestone.bounty_winner = Some(winning.submitter.clone());
+            milestone.votes = winning.votes.clone();
+            milestone.reasons = winning.reasons.clone();
+            milestone.set_approvals(bounty_submission_approve_weight(&env, &winning));
+            milestone.set_state(MilestoneState::AwaitingPayout);
+            milestone.status_updated_at = env.ledger().timestamp();
+            milestone.submission_timestamp = env.ledger().timestamp();
+
+            Events::emit_quorum_reached(
+                &env,
+                grant_id,
+                milestone_idx,
+                milestone.approvals(),
+                grant.quorum(),
+            );
+
+            for (voter, voted_approve) in milestone.votes.iter() {
+                if voted_approve {
+                    let mut rep = Storage::get_reviewer_reputation(&env, voter.clone());
+                    rep += 1;
+                    Storage::set_reviewer_reputation(&env, voter.clone(), rep);
+                }
+            }
+
+            Events::milestone_status_changed(
+                &env,
+                grant_id,
+                milestone_idx,
+                MilestoneState::AwaitingPayout,
+            );
+            Events::emit_bounty_claimed(
+                &env,
+                grant_id,
+                milestone_idx,
+                winning.submitter.clone(),
+                submission_idx,
+            );
+
+            Storage::remove_bounty_submissions(&env, grant_id, milestone_idx);
+            Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
+            Events::milestone_voted(
+                &env,
+                grant_id,
+                milestone_idx,
+                reviewer.clone(),
+                approve,
+                feedback.clone(),
+            );
+            return Ok(true);
+        }
+
+        Events::milestone_voted(
+            &env,
+            grant_id,
+            milestone_idx,
+            reviewer.clone(),
+            approve,
+            feedback.clone(),
+        );
+        Ok(false)
+    }
+
     pub fn milestone_reject(
         env: Env,
         grant_id: u64,
@@ -1792,6 +2118,28 @@ impl StellarGrantsContract {
             return Err(ContractError::InvalidState);
         }
 
+        if grant.is_open_bounty {
+            if Storage::is_blacklisted(&env, &recipient) {
+                return Err(ContractError::Blacklisted);
+            }
+            Storage::get_contributor(&env, recipient.clone())
+                .ok_or(ContractError::ContributorProfileRequired)?;
+            ensure_min_reputation_for_grant(&env, grant_id, recipient.clone())?;
+            apply_open_bounty_submission(
+                &env,
+                grant_id,
+                &grant,
+                milestone_idx,
+                recipient,
+                description,
+                proof_url,
+                payout_token,
+            )?;
+            grant.last_heartbeat = env.ledger().timestamp();
+            Storage::set_grant(&env, grant_id, &grant);
+            return Ok(());
+        }
+
         if grant.owner != recipient {
             return Err(ContractError::Unauthorized);
         }
@@ -1806,7 +2154,10 @@ impl StellarGrantsContract {
             description,
             proof_url,
             payout_token,
-        )
+        )?;
+        grant.last_heartbeat = env.ledger().timestamp();
+        Storage::set_grant(&env, grant_id, &grant);
+        Ok(())
     }
     pub fn milestone_submit_batch(
         env: Env,
@@ -1824,7 +2175,13 @@ impl StellarGrantsContract {
             return Err(ContractError::BatchTooLarge);
         }
 
-        let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        let mut grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+
+        if grant.is_open_bounty {
+            return Err(ContractError::InvalidInput);
+        }
+
+        check_heartbeat(&env, &mut grant);
 
         if grant.status() == GrantStatus::Inactive {
             return Err(ContractError::HeartbeatMissed);
@@ -1851,6 +2208,8 @@ impl StellarGrantsContract {
             )?;
         }
 
+        grant.last_heartbeat = env.ledger().timestamp();
+        Storage::set_grant(&env, grant_id, &grant);
         Ok(())
     }
     pub fn grant_fund(
@@ -1953,6 +2312,83 @@ impl StellarGrantsContract {
             Ok(())
         })
     }
+
+    pub fn grant_fund_milestone(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        funder: Address,
+        token: Address,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        funder.require_auth();
+        assert_not_paused(&env)?;
+        reentrancy::with_non_reentrant(&env, || {
+            if amount <= 0 {
+                return Err(ContractError::InvalidInput);
+            }
+            ensure_token_interface(&env, &token)?;
+
+            let mut grant =
+                Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+            check_heartbeat(&env, &mut grant);
+
+            if grant.status() == GrantStatus::Inactive {
+                return Err(ContractError::HeartbeatMissed);
+            }
+            if grant.status() != GrantStatus::Active {
+                return Err(ContractError::InvalidState);
+            }
+
+            let mut milestone = Storage::get_milestone(&env, grant_id, milestone_idx)
+                .ok_or(ContractError::MilestoneNotFound)?;
+
+            let st = milestone.state();
+            if st == MilestoneState::Paid
+                || st == MilestoneState::Rejected
+                || st == MilestoneState::Expired
+                || st == MilestoneState::ExpiredClaimed
+            {
+                return Err(ContractError::InvalidState);
+            }
+
+            let token_client = token::Client::new(&env, &token);
+            let contract_address = env.current_contract_address();
+            token_client.transfer(&funder, &contract_address, &amount);
+
+            let current_balance = grant.escrow_balances.get(token.clone()).unwrap_or(0);
+            let new_balance = current_balance
+                .checked_add(amount)
+                .ok_or(ContractError::InvalidInput)?;
+            grant.escrow_balances.set(token.clone(), new_balance);
+
+            let prev_extra = milestone.additional_funds.get(token.clone()).unwrap_or(0);
+            let new_extra = prev_extra
+                .checked_add(amount)
+                .ok_or(ContractError::InvalidInput)?;
+            milestone.additional_funds.set(token.clone(), new_extra);
+            milestone.top_up_contributions.push_back(MilestoneTopUp {
+                funder: funder.clone(),
+                token: token.clone(),
+                amount,
+            });
+
+            Storage::set_grant(&env, grant_id, &grant);
+            Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
+
+            Events::emit_milestone_top_up_funded(
+                &env,
+                grant_id,
+                milestone_idx,
+                funder.clone(),
+                token,
+                amount,
+            );
+
+            Ok(())
+        })
+    }
+
     pub fn milestone_upvote(
         env: Env,
         grant_id: u64,
@@ -2430,6 +2866,38 @@ impl StellarGrantsContract {
             Ok(())
         })
     }
+
+    /// Anyone may call this to mark an abandoned grant inactive after the owner has not
+    /// refreshed `last_heartbeat` for [`HEARTBEAT_INACTIVITY_SECS`].
+    pub fn mark_grant_inactive(env: Env, grant_id: u64) -> Result<(), ContractError> {
+        assert_not_paused(&env)?;
+
+        let mut grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        if grant.status() != GrantStatus::Active {
+            return Err(ContractError::InvalidState);
+        }
+
+        let now = env.ledger().timestamp();
+        if now
+            <= grant
+                .last_heartbeat
+                .saturating_add(HEARTBEAT_INACTIVITY_SECS)
+        {
+            return Err(ContractError::HeartbeatNotStale);
+        }
+
+        grant.set_status(GrantStatus::Inactive);
+        Storage::set_grant(&env, grant_id, &grant);
+        Storage::index_transition(
+            &env,
+            GrantStatus::Active as u32,
+            GrantStatus::Inactive as u32,
+            grant_id,
+        );
+        Events::emit_grant_gone_inactive(&env, grant_id, now);
+        Ok(())
+    }
+
     pub fn grant_ping(env: Env, grant_id: u64, owner: Address) -> Result<(), ContractError> {
         owner.require_auth();
 
@@ -2519,25 +2987,30 @@ impl StellarGrantsContract {
                 return Err(ContractError::DeadlinePassed);
             }
 
-            let payout_amount = milestone.amount;
             let payout_token = milestone.payout_token.clone();
+            let payout_amount =
+                milestone_payout_amount_for_token(&milestone, payout_token.clone())?;
+            let primary_bal = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
+            if primary_bal < payout_amount {
+                return Err(ContractError::InvalidInput);
+            }
+            for (tok, amt) in milestone.additional_funds.iter() {
+                if tok == payout_token || amt <= 0 {
+                    continue;
+                }
+                let b = grant.escrow_balances.get(tok.clone()).unwrap_or(0);
+                if b < amt {
+                    return Err(ContractError::InvalidInput);
+                }
+            }
 
-            // Transfer milestone amount from contract escrow to grant owner
-            let token_client = token::Client::new(&env, &payout_token);
-            token_client.transfer(
-                &env.current_contract_address(),
-                &grant.owner,
-                &payout_amount,
-            );
-
-            // Update escrow accounting
-            let current_balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
-            grant.escrow_balances.set(
-                payout_token.clone(),
-                current_balance
-                    .checked_sub(payout_amount)
-                    .ok_or(ContractError::InvalidInput)?,
-            );
+            let payee = milestone_payee(&milestone, &grant);
+            let rep_amt = payout_milestone_locked_funds_from_escrow(
+                &env,
+                &mut grant,
+                &mut milestone,
+                &payee,
+            )?;
             grant.set_milestones_paid_out(
                 grant
                     .milestones_paid_out()
@@ -2562,27 +3035,20 @@ impl StellarGrantsContract {
             Events::emit_payout_executed(
                 &env,
                 grant_id,
-                grant.owner.clone(),
+                payee.clone(),
                 payout_amount,
                 payout_token.clone(),
             );
             Events::emit_payee_receipt(
                 &env,
                 grant_id,
-                grant.owner.clone(),
+                payee.clone(),
                 payout_token.clone(),
                 payout_amount,
                 Some(milestone_idx),
             );
 
-            // Reuse the shared idempotent reputation path for direct payouts too.
-            Self::update_contributor_reputation(
-                &env,
-                grant_id,
-                milestone_idx,
-                &grant.owner,
-                payout_amount,
-            );
+            Self::update_contributor_reputation(&env, grant_id, milestone_idx, &payee, rep_amt);
 
             Ok(())
         })
@@ -2680,8 +3146,7 @@ fn check_heartbeat(env: &Env, grant: &mut Grant) {
     let now = env.ledger().timestamp();
     let seconds_since_heartbeat = now.saturating_sub(grant.last_heartbeat);
 
-    // 30 days = 30 * 24 * 60 * 60 = 2,592,000 seconds
-    if seconds_since_heartbeat > 30 * 24 * 60 * 60 {
+    if seconds_since_heartbeat > HEARTBEAT_INACTIVITY_SECS {
         grant.set_status(GrantStatus::Inactive);
         Storage::set_grant(env, grant.id, grant);
         Storage::index_transition(
@@ -2843,6 +3308,61 @@ fn mark_milestone_expired_if_needed(
     Ok(true)
 }
 
+fn apply_open_bounty_submission(
+    env: &Env,
+    grant_id: u64,
+    grant: &Grant,
+    milestone_idx: u32,
+    submitter: Address,
+    description: String,
+    proof_url: String,
+    payout_token: Option<Address>,
+) -> Result<(), ContractError> {
+    if milestone_idx >= grant.total_milestones() {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let mut milestone = Storage::get_milestone(env, grant_id, milestone_idx)
+        .ok_or(ContractError::MilestoneNotFound)?;
+    if mark_milestone_expired_if_needed(env, grant_id, milestone_idx, &mut milestone)? {
+        return Err(ContractError::DeadlinePassed);
+    }
+
+    if milestone.state() != MilestoneState::Pending {
+        return Err(ContractError::MilestoneAlreadySubmitted);
+    }
+
+    let mut subs = Storage::get_bounty_submissions(env, grant_id, milestone_idx)
+        .unwrap_or_else(|| Vec::new(env));
+    if subs.len() >= MAX_BOUNTY_SUBMISSIONS_PER_MILESTONE {
+        return Err(ContractError::BountySubmissionsCap);
+    }
+
+    for i in 0..subs.len() {
+        if subs.get(i).unwrap().submitter == submitter {
+            return Err(ContractError::DuplicateBountySubmitter);
+        }
+    }
+
+    let payout = payout_token.unwrap_or_else(|| grant.token_address.clone());
+    ensure_token_interface(env, &payout)?;
+
+    let entry = BountySubmissionEntry {
+        submitter: submitter.clone(),
+        description: description.clone(),
+        proof_url: proof_url.clone(),
+        payout_token: payout,
+        submission_timestamp: env.ledger().timestamp(),
+        votes: Map::new(env),
+        reasons: Map::new(env),
+    };
+    subs.push_back(entry);
+    Storage::set_bounty_submissions(env, grant_id, milestone_idx, &subs);
+
+    Events::emit_milestone_submitted(env, grant_id, milestone_idx, description);
+    Ok(())
+}
+
 fn apply_milestone_submission(
     env: &Env,
     grant_id: u64,
@@ -2852,6 +3372,9 @@ fn apply_milestone_submission(
     proof_url: String,
     payout_token: Option<Address>,
 ) -> Result<(), ContractError> {
+    if grant.is_open_bounty {
+        return Err(ContractError::InvalidInput);
+    }
     if milestone_idx >= grant.total_milestones() {
         return Err(ContractError::InvalidInput);
     }

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -1,8 +1,8 @@
 use crate::types::{
-    AccessControl, DisputeInfo, EscrowLifecycleState, EscrowMode, EscrowState, ExtensionRequest,
-    Grant, Milestone, Role,
+    AccessControl, BountySubmissionEntry, DisputeInfo, EscrowLifecycleState, EscrowMode,
+    EscrowState, ExtensionRequest, Grant, Milestone, Role,
 };
-use soroban_sdk::{contracttype, Env};
+use soroban_sdk::{contracttype, Env, Vec};
 
 #[contracttype]
 pub enum DataKey {
@@ -32,6 +32,7 @@ pub enum DataKey {
     AccessControl(soroban_sdk::Address),
     RoleMemberCount(u32),
     ExtensionRequest(u64, u32),
+    BountySubmissions(u64, u32),
 }
 
 pub struct Storage;
@@ -186,6 +187,36 @@ impl Storage {
         let key = DataKey::Milestone(grant_id, milestone_idx);
         env.storage().persistent().set(&key, milestone);
         Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_bounty_submissions(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<Vec<BountySubmissionEntry>> {
+        let key = DataKey::BountySubmissions(grant_id, milestone_idx);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_bounty_submissions(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        entries: &Vec<BountySubmissionEntry>,
+    ) {
+        let key = DataKey::BountySubmissions(grant_id, milestone_idx);
+        env.storage().persistent().set(&key, entries);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn remove_bounty_submissions(env: &Env, grant_id: u64, milestone_idx: u32) {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::BountySubmissions(grant_id, milestone_idx));
     }
 
     pub fn increment_grant_counter(env: &Env) -> u64 {

--- a/stellargrant-contracts/contracts/stellar-grants/src/test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/test.rs
@@ -140,6 +140,7 @@ mod tests {
     };
     use crate::StellarGrantsContract;
     use crate::StellarGrantsContractClient;
+    use crate::HEARTBEAT_INACTIVITY_SECS;
     use soroban_sdk::testutils::Ledger as _;
     use soroban_sdk::{
         testutils::{storage::Persistent as _, Address as _},
@@ -198,7 +199,8 @@ mod tests {
                 0,                          // min_funding
                 0,                          // hard_cap
                 soroban_sdk::Vec::new(env), // tags
-                None,                       // cancellation_requested_at
+                false,
+                None, // cancellation_requested_at
             );
             Storage::set_grant(env, grant_id, &grant);
         });
@@ -229,6 +231,8 @@ mod tests {
                 0,             // approvals
                 0,             // rejections
                 0,             // community_upvotes
+                Map::new(env),
+                Vec::new(env),
             );
             Storage::set_milestone(env, grant_id, milestone_idx, &milestone);
         });
@@ -470,7 +474,8 @@ mod tests {
             MilestoneState::Submitted,
         );
 
-        let result = client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &None);
+        let result =
+            client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &None, &None);
 
         assert_eq!(result, true); // Quorum reached (1/1)
 
@@ -626,6 +631,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token_id.clone(), 1000);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Full quorum grant"),
@@ -659,9 +665,9 @@ mod tests {
             MilestoneState::Submitted,
         );
 
-        let r1 = client.milestone_vote(&grant_id, &milestone_idx, &reviewer1, &true, &None);
-        let r2 = client.milestone_vote(&grant_id, &milestone_idx, &reviewer2, &true, &None);
-        let r3 = client.milestone_vote(&grant_id, &milestone_idx, &reviewer3, &true, &None);
+        let r1 = client.milestone_vote(&grant_id, &milestone_idx, &reviewer1, &true, &None, &None);
+        let r2 = client.milestone_vote(&grant_id, &milestone_idx, &reviewer2, &true, &None, &None);
+        let r3 = client.milestone_vote(&grant_id, &milestone_idx, &reviewer3, &true, &None, &None);
 
         assert_eq!(r1, false);
         assert_eq!(r2, false);
@@ -705,6 +711,7 @@ mod tests {
         let mut escrow_balances = Map::new(&env);
         escrow_balances.set(token_id.clone(), remaining);
         let mut grant = Grant {
+            is_open_bounty: false,
             packed_config: 0,
             id: grant_id,
             title: String::from_str(&env, "Test"),
@@ -778,6 +785,7 @@ mod tests {
         let mut escrow_balances = Map::new(&env);
         escrow_balances.set(token.clone(), 0);
         let mut grant = Grant {
+            is_open_bounty: false,
             packed_config: 0,
             id: grant_id,
             title: String::from_str(&env, "Test"),
@@ -843,6 +851,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token_id.clone(), 500);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Admin Cancel"),
@@ -889,6 +898,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 0);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "No funds"),
@@ -960,6 +970,7 @@ mod tests {
         let mut escrow_balances = Map::new(&env);
         escrow_balances.set(token_id.clone(), 100);
         let grant = Grant {
+            is_open_bounty: false,
             packed_config: 0,
             id: grant_id,
             title: String::from_str(&env, "Dust"),
@@ -1031,6 +1042,7 @@ mod tests {
         let mut escrow_balances = Map::new(&env);
         escrow_balances.set(token_id.clone(), total_funded);
         let grant = Grant {
+            is_open_bounty: false,
             packed_config: 0,
             id: grant_id,
             title: String::from_str(&env, "Test"),
@@ -1073,6 +1085,9 @@ mod tests {
 
                     community_comments: Map::new(&env),
                     packed_stats: 0,
+                    additional_funds: Map::new(&env),
+                    top_up_contributions: Vec::new(&env),
+                    bounty_winner: None,
                 };
                 Storage::set_milestone(&env, grant_id, i, &milestone);
             }
@@ -1118,6 +1133,7 @@ mod tests {
         let mut escrow_balances = Map::new(&env);
         escrow_balances.set(token.clone(), 1000);
         let grant = Grant {
+            is_open_bounty: false,
             packed_config: 0,
             id: grant_id,
             title: String::from_str(&env, "Test"),
@@ -1158,6 +1174,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &m1);
 
@@ -1176,6 +1195,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 1, &m2);
         });
@@ -1205,6 +1227,7 @@ mod tests {
         let mut escrow_balances = Map::new(&env);
         escrow_balances.set(token_id.clone(), total_funded);
         let grant = Grant {
+            is_open_bounty: false,
             packed_config: 0,
             id: grant_id,
             title: String::from_str(&env, "Test"),
@@ -1245,6 +1268,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &m1);
         });
@@ -1312,6 +1338,9 @@ mod tests {
 
                     community_comments: Map::new(&env),
                     packed_stats: 0,
+                    additional_funds: Map::new(&env),
+                    top_up_contributions: Vec::new(&env),
+                    bounty_winner: None,
                 };
                 Storage::set_milestone(&env, grant_id, i, &milestone);
             }
@@ -1381,6 +1410,9 @@ mod tests {
 
                     community_comments: Map::new(&env),
                     packed_stats: 0,
+                    additional_funds: Map::new(&env),
+                    top_up_contributions: Vec::new(&env),
+                    bounty_winner: None,
                 };
                 Storage::set_milestone(&env, grant_id, i, &milestone);
             }
@@ -1447,6 +1479,7 @@ mod tests {
         let mut escrow_balances = Map::new(&env);
         escrow_balances.set(token_id.clone(), total_funded);
         let grant = Grant {
+            is_open_bounty: false,
             packed_config: 0,
             id: grant_id,
             title: String::from_str(&env, "Test"),
@@ -1551,6 +1584,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
 
         client.grant_accept(&grant_id, &owner);
@@ -1574,6 +1608,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
         });
@@ -1712,6 +1749,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 1000);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -1791,6 +1829,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 1000);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -1832,6 +1871,9 @@ mod tests {
 
                     community_comments: Map::new(&env),
                     packed_stats: 0,
+                    additional_funds: Map::new(&env),
+                    top_up_contributions: Vec::new(&env),
+                    bounty_winner: None,
                 };
                 milestone.set_idx(idx);
                 Storage::set_milestone(&env, grant_id, idx, &milestone);
@@ -2033,6 +2075,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 0);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -2091,6 +2134,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token_id.clone(), 0);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -2221,6 +2265,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), i128::MAX);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -2274,6 +2319,7 @@ mod tests {
         escrow_balances.set(token_id.clone(), 0);
         env.as_contract(&contract_id, || {
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -2337,6 +2383,7 @@ mod tests {
         escrow_balances.set(token_id.clone(), 0);
         env.as_contract(&contract_id, || {
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -2394,6 +2441,7 @@ mod tests {
         escrow_balances.set(token_id.clone(), 0);
         env.as_contract(&contract_id, || {
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -2458,6 +2506,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
 
         assert_eq!(grant_id, 1);
@@ -2509,6 +2558,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(res1, Err(Ok(ContractError::InvalidInput.into())));
 
@@ -2527,6 +2577,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(res2, Err(Ok(ContractError::InvalidInput.into())));
     }
@@ -2559,6 +2610,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(res1, Err(Ok(ContractError::InvalidInput.into())));
 
@@ -2577,6 +2629,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(res2, Err(Ok(ContractError::InvalidInput.into())));
     }
@@ -2608,6 +2661,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(res, Err(Ok(ContractError::InvalidInput.into())));
     }
@@ -2641,6 +2695,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(res, Err(Ok(ContractError::InvalidInput.into())));
     }
@@ -2672,6 +2727,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert!(res.is_err());
     }
@@ -2703,6 +2759,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(created, 1);
 
@@ -2747,6 +2804,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
 
         env.as_contract(&contract_id, || {
@@ -2808,8 +2866,14 @@ mod tests {
 
         // Total weight = 3 + 1 = 4. Quorum margin = (4 / 2) + 1 = 3.
         // high_rep_reviewer's vote (3 weight) should pass it alone.
-        let result =
-            client.milestone_vote(&grant_id, &milestone_idx, &high_rep_reviewer, &true, &None);
+        let result = client.milestone_vote(
+            &grant_id,
+            &milestone_idx,
+            &high_rep_reviewer,
+            &true,
+            &None,
+            &None,
+        );
         assert_eq!(result, true);
 
         env.as_contract(&contract_id, || {
@@ -2999,8 +3063,14 @@ mod tests {
 
         // Total weight = 3 + 1 = 4. Quorum margin = (4 / 2) + 1 = 3.
         // low_rep_reviewer's vote (1 weight) should not reach quorum alone.
-        let result =
-            client.milestone_vote(&grant_id, &milestone_idx, &low_rep_reviewer, &true, &None);
+        let result = client.milestone_vote(
+            &grant_id,
+            &milestone_idx,
+            &low_rep_reviewer,
+            &true,
+            &None,
+            &None,
+        );
         assert_eq!(result, false);
 
         env.as_contract(&contract_id, || {
@@ -3058,6 +3128,7 @@ mod tests {
             &reviewer_dissenting,
             &false,
             &None,
+            &None,
         );
         // Harmonious votes true, reaching quorum 2.
         let result = client.milestone_vote(
@@ -3065,6 +3136,7 @@ mod tests {
             &milestone_idx,
             &reviewer_harmonious,
             &true,
+            &None,
             &None,
         );
         assert_eq!(result, true);
@@ -3118,6 +3190,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
 
         env.as_contract(&client.address, || {
@@ -3162,6 +3235,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(result, Err(Ok(ContractError::InvalidInput.into())));
     }
@@ -3182,6 +3256,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 1000);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -3221,6 +3296,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
         });
@@ -3282,7 +3360,14 @@ mod tests {
 
         env.mock_all_auths();
         let feedback = Some(String::from_str(&env, "Great job!"));
-        client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &feedback);
+        client.milestone_vote(
+            &grant_id,
+            &milestone_idx,
+            &reviewer,
+            &true,
+            &feedback,
+            &None,
+        );
 
         let all_feedback = client.get_milestone_feedback(&grant_id, &milestone_idx);
         assert_eq!(
@@ -3330,6 +3415,7 @@ mod tests {
             &reviewer,
             &true,
             &too_long_feedback,
+            &None,
         );
         assert_eq!(result, Err(Ok(ContractError::InvalidInput.into())));
     }
@@ -3453,6 +3539,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 1000);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -3600,6 +3687,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 1000);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -3649,6 +3737,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 1000);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -3765,12 +3854,15 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
         });
 
         // Ledger timestamp is 0, period is 3 days — vote must be rejected
-        let result = client.try_milestone_vote(&grant_id, &0u32, &reviewer, &true, &None);
+        let result = client.try_milestone_vote(&grant_id, &0u32, &reviewer, &true, &None, &None);
         assert_eq!(result, Err(Ok(ContractError::CommunityReviewPeriod.into())));
     }
 
@@ -3816,6 +3908,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
         });
@@ -3825,7 +3920,7 @@ mod tests {
             .set_timestamp(crate::COMMUNITY_REVIEW_PERIOD + 1);
 
         // Vote should now be accepted (quorum 1/1 → true)
-        let result = client.milestone_vote(&grant_id, &0u32, &reviewer, &true, &None);
+        let result = client.milestone_vote(&grant_id, &0u32, &reviewer, &true, &None, &None);
         assert!(result);
     }
 
@@ -3864,6 +3959,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
         });
@@ -3910,6 +4008,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
         });
@@ -3953,6 +4054,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
         });
@@ -4036,6 +4140,9 @@ mod tests {
 
                 community_comments: Map::new(&env),
                 packed_stats: 0,
+                additional_funds: Map::new(&env),
+                top_up_contributions: Vec::new(&env),
+                bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
         });
@@ -4054,7 +4161,7 @@ mod tests {
             .set_timestamp(crate::COMMUNITY_REVIEW_PERIOD + 1);
 
         // Reviewer votes — milestone gets approved
-        let approved = client.milestone_vote(&grant_id, &0u32, &reviewer, &true, &None);
+        let approved = client.milestone_vote(&grant_id, &0u32, &reviewer, &true, &None, &None);
         assert!(approved);
 
         // Community signals are still stored and haven't affected the vote count
@@ -4096,6 +4203,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token_id.clone(), 500);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -4248,6 +4356,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token_id.clone(), 500);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Test"),
@@ -4381,6 +4490,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         client.grant_accept(&grant_id, &owner);
         client.grant_pause(&grant_id, &owner);
@@ -4403,6 +4513,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 0);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Done"),
@@ -4451,6 +4562,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token_id.clone(), 0);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Paused"),
@@ -4493,6 +4605,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 0);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Paused"),
@@ -4547,6 +4660,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 0);
             let mut grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Paused"),
@@ -4573,7 +4687,7 @@ mod tests {
         });
         create_milestone(&env, &contract_id, grant_id, 0, MilestoneState::Submitted);
 
-        let result = client.try_milestone_vote(&grant_id, &0, &reviewer, &true, &None);
+        let result = client.try_milestone_vote(&grant_id, &0, &reviewer, &true, &None, &None);
         assert_eq!(result, Err(Ok(ContractError::InvalidState.into())));
     }
 
@@ -4626,6 +4740,7 @@ mod tests {
             &500i128, // min_funding = 500
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
 
         env.as_contract(&client.address, || {
@@ -4659,6 +4774,7 @@ mod tests {
             &0i128, // no min_funding
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
 
         env.as_contract(&client.address, || {
@@ -4687,6 +4803,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token_id.clone(), 0);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Pending Grant"),
@@ -4741,6 +4858,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token.clone(), 0);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Pending Grant"),
@@ -4796,6 +4914,7 @@ mod tests {
             let mut escrow_balances = Map::new(&env);
             escrow_balances.set(token_id.clone(), 0);
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Pending Grant"),
@@ -5112,6 +5231,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(result, Err(Ok(ContractError::ContractPaused.into())));
 
@@ -5131,6 +5251,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
         assert_eq!(grant_id, 1);
     }
@@ -5200,7 +5321,7 @@ mod tests {
         create_grant(&env, &contract_id, grant_id, owner, token, reviewers);
         create_milestone(&env, &contract_id, grant_id, 0, MilestoneState::Submitted);
 
-        let result = client.try_milestone_vote(&grant_id, &0, &reviewer, &true, &None);
+        let result = client.try_milestone_vote(&grant_id, &0, &reviewer, &true, &None, &None);
         assert_eq!(result, Err(Ok(ContractError::ContractPaused.into())));
     }
 
@@ -5220,6 +5341,7 @@ mod tests {
 
         env.as_contract(&contract_id, || {
             let grant = Grant {
+                is_open_bounty: false,
                 packed_config: 0,
                 id: grant_id,
                 title: String::from_str(&env, "Emergency"),
@@ -5300,7 +5422,14 @@ mod tests {
         assert_eq!(token_client.balance(&owner), 0);
 
         let feedback = Some(String::from_str(&env, "Great job!"));
-        client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &feedback);
+        client.milestone_vote(
+            &grant_id,
+            &milestone_idx,
+            &reviewer,
+            &true,
+            &feedback,
+            &None,
+        );
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + crate::CHALLENGE_PERIOD + 1);
@@ -5308,6 +5437,73 @@ mod tests {
 
         // Milestone is paid out, owner balance increases by milestone amount (100)
         assert_eq!(token_client.balance(&owner), 100);
+    }
+
+    #[test]
+    fn test_milestone_top_up_payout_exceeds_base_amount() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let grant_id = 1;
+        let milestone_idx = 0;
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+
+        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = token_contract.address();
+        let token_admin = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+
+        let grant_funder = Address::generate(&env);
+        let top_up_funder = Address::generate(&env);
+        token_admin.mint(&grant_funder, &2000);
+        token_admin.mint(&top_up_funder, &500);
+
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+
+        create_grant(
+            &env,
+            &contract_id,
+            grant_id,
+            owner.clone(),
+            token_id.clone(),
+            reviewers,
+        );
+
+        client.grant_fund(&grant_id, &grant_funder, &1000, &token_id, &None);
+        create_milestone(
+            &env,
+            &contract_id,
+            grant_id,
+            milestone_idx,
+            MilestoneState::Submitted,
+        );
+        client.grant_fund_milestone(&grant_id, &milestone_idx, &top_up_funder, &token_id, &50);
+
+        let token_client = soroban_sdk::token::Client::new(&env, &token_id);
+        assert_eq!(token_client.balance(&owner), 0);
+
+        let feedback = Some(String::from_str(&env, "Great job!"));
+        client.milestone_vote(
+            &grant_id,
+            &milestone_idx,
+            &reviewer,
+            &true,
+            &feedback,
+            &None,
+        );
+
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + crate::CHALLENGE_PERIOD + 1);
+        client.milestone_payout(&grant_id, &milestone_idx, &owner);
+
+        // create_milestone uses amount 100; top-up adds 50 on the same payout token.
+        assert_eq!(token_client.balance(&owner), 150);
+        env.as_contract(&contract_id, || {
+            let ms = Storage::get_milestone(&env, grant_id, milestone_idx).unwrap();
+            assert_eq!(ms.additional_funds.len(), 0);
+            assert_eq!(ms.top_up_contributions.len(), 0);
+        });
     }
 
     #[test]
@@ -5360,7 +5556,14 @@ mod tests {
         });
 
         let feedback = Some(String::from_str(&env, "Great job!"));
-        client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &feedback);
+        client.milestone_vote(
+            &grant_id,
+            &milestone_idx,
+            &reviewer,
+            &true,
+            &feedback,
+            &None,
+        );
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + crate::CHALLENGE_PERIOD + 1);
@@ -5416,7 +5619,14 @@ mod tests {
         );
 
         let feedback = Some(String::from_str(&env, "Great job!"));
-        client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &feedback);
+        client.milestone_vote(
+            &grant_id,
+            &milestone_idx,
+            &reviewer,
+            &true,
+            &feedback,
+            &None,
+        );
 
         env.ledger()
             .set_timestamp(env.ledger().timestamp() + crate::CHALLENGE_PERIOD + 1);
@@ -5623,7 +5833,8 @@ mod tests {
             MilestoneState::Submitted,
         );
 
-        let result = client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &None);
+        let result =
+            client.milestone_vote(&grant_id, &milestone_idx, &reviewer, &true, &None, &None);
         assert_eq!(result, true); // Quorum reached
 
         env.as_contract(&contract_id, || {
@@ -5712,6 +5923,7 @@ mod tests {
             &0i128,
             &0i128,
             &Vec::<String>::new(&env),
+            &false,
         );
 
         client.grant_accept(&grant_id, &owner);
@@ -5782,6 +5994,7 @@ mod tests {
             &0i128,
             &500i128, // hard_cap = 500
             &Vec::<String>::new(&env),
+            &false,
         );
         client.grant_accept(&grant_id, &owner);
 
@@ -5831,6 +6044,7 @@ mod tests {
             &0i128,
             &500i128, // hard_cap = 500
             &Vec::<String>::new(&env),
+            &false,
         );
         client.grant_accept(&grant_id, &owner);
 
@@ -5878,6 +6092,7 @@ mod tests {
             &0i128,
             &0i128, // hard_cap = 0 means no cap
             &Vec::<String>::new(&env),
+            &false,
         );
         client.grant_accept(&grant_id, &owner);
 
@@ -5929,6 +6144,7 @@ mod tests {
             &0i128,
             &0i128,
             &tags,
+            &false,
         );
 
         env.as_contract(&contract_id, || {
@@ -5978,6 +6194,7 @@ mod tests {
             &0i128,
             &0i128,
             &tags,
+            &false,
         );
         assert!(result.is_err(), "Should reject more than 5 tags");
     }
@@ -6014,7 +6231,239 @@ mod tests {
             &0i128,
             &0i128,
             &tags,
+            &false,
         );
         assert!(result.is_err(), "Should reject tags longer than 20 chars");
+    }
+
+    #[test]
+    fn test_open_bounty_two_contributors_submit_distinct_proofs() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let token_admin = token::StellarAssetClient::new(&env, &token);
+        token_admin.mint(&contract_id, &10_000);
+
+        let owner = Address::generate(&env);
+        let reviewer1 = Address::generate(&env);
+        let reviewer2 = Address::generate(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        token_admin.mint(&owner, &2000);
+
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer1.clone());
+        reviewers.push_back(reviewer2.clone());
+
+        let grant_id = client.grant_create(
+            &owner,
+            &String::from_str(&env, "Open Bounty"),
+            &String::from_str(&env, "Community milestone"),
+            &token,
+            &1000i128,
+            &500i128,
+            &1u32,
+            &reviewers,
+            &2u32,
+            &None,
+            &0i128,
+            &0i128,
+            &Vec::<String>::new(&env),
+            &true,
+        );
+
+        client.grant_accept(&grant_id, &owner);
+
+        for (addr, name) in [(alice.clone(), "Alice"), (bob.clone(), "Bob")] {
+            client.contributor_register(
+                &addr,
+                &String::from_str(&env, name),
+                &String::from_str(&env, "Bio"),
+                &Vec::new(&env),
+                &String::from_str(&env, "https://gh.example/x"),
+            );
+        }
+
+        client.grant_fund(&grant_id, &owner, &1000i128, &token, &None);
+
+        client.milestone_submit(
+            &grant_id,
+            &0u32,
+            &alice,
+            &String::from_str(&env, "Alice implementation"),
+            &String::from_str(&env, "https://proof.alice"),
+            &None,
+        );
+        client.milestone_submit(
+            &grant_id,
+            &0u32,
+            &bob,
+            &String::from_str(&env, "Bob implementation"),
+            &String::from_str(&env, "https://proof.bob"),
+            &None,
+        );
+
+        env.as_contract(&contract_id, || {
+            let subs = Storage::get_bounty_submissions(&env, grant_id, 0u32).unwrap();
+            assert_eq!(subs.len(), 2);
+            assert_eq!(subs.get(0).unwrap().submitter, alice);
+            assert_eq!(subs.get(1).unwrap().submitter, bob);
+        });
+
+        client.milestone_vote(&grant_id, &0u32, &reviewer1, &true, &None, &Some(1u32));
+        let quorum = client.milestone_vote(&grant_id, &0u32, &reviewer2, &true, &None, &Some(1u32));
+        assert!(quorum);
+
+        let m = client.get_milestone(&grant_id, &0u32);
+        assert_eq!(m.state(), MilestoneState::AwaitingPayout);
+        assert_eq!(m.bounty_winner, Some(bob.clone()));
+        assert_eq!(m.description, String::from_str(&env, "Bob implementation"));
+    }
+
+    #[test]
+    fn test_mark_grant_inactive_permissionless_after_heartbeat_timeout() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+        tok.mint(&contract_id, &5000);
+
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+
+        let grant_id = client.grant_create(
+            &owner,
+            &String::from_str(&env, "HB Grant"),
+            &String::from_str(&env, "Desc"),
+            &token,
+            &1000i128,
+            &500i128,
+            &1u32,
+            &reviewers,
+            &1u32,
+            &None,
+            &0i128,
+            &0i128,
+            &Vec::<String>::new(&env),
+            &false,
+        );
+        client.grant_accept(&grant_id, &owner);
+        tok.mint(&owner, &1000);
+        client.grant_fund(&grant_id, &owner, &1000i128, &token, &None);
+
+        let ts = env.ledger().timestamp();
+        env.as_contract(&contract_id, || {
+            let mut g = Storage::get_grant(&env, grant_id).unwrap();
+            g.last_heartbeat = ts;
+            Storage::set_grant(&env, grant_id, &g);
+        });
+
+        env.ledger().set_timestamp(
+            ts.saturating_add(HEARTBEAT_INACTIVITY_SECS)
+                .saturating_add(1),
+        );
+
+        let _ = stranger;
+        client.mark_grant_inactive(&grant_id);
+
+        let g = client.get_grant(&grant_id);
+        assert_eq!(g.status(), GrantStatus::Inactive);
+    }
+
+    #[test]
+    fn test_grant_ping_restores_inactive_grant_to_active() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+        tok.mint(&contract_id, &5000);
+
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+
+        let grant_id = client.grant_create(
+            &owner,
+            &String::from_str(&env, "Ping Grant"),
+            &String::from_str(&env, "Desc"),
+            &token,
+            &1000i128,
+            &500i128,
+            &1u32,
+            &reviewers,
+            &1u32,
+            &None,
+            &0i128,
+            &0i128,
+            &Vec::<String>::new(&env),
+            &false,
+        );
+        client.grant_accept(&grant_id, &owner);
+        tok.mint(&owner, &1000);
+        client.grant_fund(&grant_id, &owner, &1000i128, &token, &None);
+
+        let ts = env.ledger().timestamp();
+        env.as_contract(&contract_id, || {
+            let mut g = Storage::get_grant(&env, grant_id).unwrap();
+            g.last_heartbeat = ts;
+            Storage::set_grant(&env, grant_id, &g);
+        });
+        env.ledger().set_timestamp(
+            ts.saturating_add(HEARTBEAT_INACTIVITY_SECS)
+                .saturating_add(1),
+        );
+        client.mark_grant_inactive(&grant_id);
+        assert_eq!(client.get_grant(&grant_id).status(), GrantStatus::Inactive);
+
+        client.grant_ping(&grant_id, &owner);
+        let g = client.get_grant(&grant_id);
+        assert_eq!(g.status(), GrantStatus::Active);
+        assert_eq!(g.last_heartbeat, env.ledger().timestamp());
+    }
+
+    #[test]
+    fn test_mark_grant_inactive_rejects_when_heartbeat_still_fresh() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+        tok.mint(&contract_id, &5000);
+
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+
+        let grant_id = client.grant_create(
+            &owner,
+            &String::from_str(&env, "Fresh HB"),
+            &String::from_str(&env, "Desc"),
+            &token,
+            &1000i128,
+            &500i128,
+            &1u32,
+            &reviewers,
+            &1u32,
+            &None,
+            &0i128,
+            &0i128,
+            &Vec::<String>::new(&env),
+            &false,
+        );
+        client.grant_accept(&grant_id, &owner);
+        tok.mint(&owner, &1000);
+        client.grant_fund(&grant_id, &owner, &1000i128, &token, &None);
+
+        let r = client.try_mark_grant_inactive(&grant_id);
+        assert_eq!(r, Err(Ok(ContractError::HeartbeatNotStale.into())));
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -48,6 +48,14 @@ pub enum ContractError {
     ExpiryNotReached = 43,
     /// `token_address` is missing SEP-41 / Soroban token interface (e.g. no `decimals`).
     InvalidTokenInterface = 44,
+    /// Open bounty milestone submitters must have registered a contributor profile.
+    ContributorProfileRequired = 45,
+    /// Same address already submitted for this milestone bounty.
+    DuplicateBountySubmitter = 46,
+    /// Too many bounty submissions for one milestone.
+    BountySubmissionsCap = 47,
+    /// Owner has checked in recently; grant cannot be marked inactive yet.
+    HeartbeatNotStale = 48,
 }
 
 #[contracttype]
@@ -192,6 +200,14 @@ pub enum MilestoneState {
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MilestoneTopUp {
+    pub funder: Address,
+    pub token: Address,
+    pub amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Milestone {
     pub description: String,
     pub amount: i128,
@@ -205,6 +221,24 @@ pub struct Milestone {
     pub deadline_timestamp: u64,
     pub community_comments: Map<Address, String>,
     pub packed_stats: u128,
+    /// When set, milestone payout and reputation go to this address (open bounty winner).
+    pub bounty_winner: Option<Address>,
+    /// Extra funds locked for this milestone, keyed by token (SEP-41 contract address).
+    pub additional_funds: Map<Address, i128>,
+    /// Per-deposit ledger so milestone top-ups can be refunded to the original funders on cancel.
+    pub top_up_contributions: Vec<MilestoneTopUp>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BountySubmissionEntry {
+    pub submitter: Address,
+    pub description: String,
+    pub proof_url: String,
+    pub payout_token: Address,
+    pub submission_timestamp: u64,
+    pub votes: Map<Address, bool>,
+    pub reasons: Map<Address, String>,
 }
 
 impl Milestone {
@@ -225,6 +259,8 @@ impl Milestone {
         approvals: u32,
         rejections: u32,
         community_upvotes: u32,
+        additional_funds: Map<Address, i128>,
+        top_up_contributions: Vec<MilestoneTopUp>,
     ) -> Self {
         let mut ms = Self {
             description,
@@ -239,6 +275,9 @@ impl Milestone {
             deadline_timestamp,
             community_comments,
             packed_stats: 0,
+            bounty_winner: None,
+            additional_funds,
+            top_up_contributions,
         };
         ms.set_idx(idx);
         ms.set_approvals(approvals);
@@ -361,6 +400,8 @@ pub struct Grant {
     pub min_funding: i128,
     pub hard_cap: i128,
     pub tags: Vec<String>,
+    /// When true, any registered contributor (non-blacklisted) may submit milestone proofs; reviewers pick a winner.
+    pub is_open_bounty: bool,
     pub packed_config: u128,
 }
 
@@ -387,6 +428,7 @@ impl Grant {
         min_funding: i128,
         hard_cap: i128,
         tags: Vec<String>,
+        is_open_bounty: bool,
         cancellation_requested_at: Option<u64>,
     ) -> Self {
         let mut g = Self {
@@ -407,6 +449,7 @@ impl Grant {
             min_funding,
             hard_cap,
             tags,
+            is_open_bounty,
             packed_config: 0,
         };
         g.set_status(status);

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_batch_milestone_approve.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_batch_milestone_approve.1.json
@@ -216,6 +216,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -345,11 +353,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -433,6 +455,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -472,11 +502,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -556,6 +600,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_blacklist_enforcement.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_blacklist_enforcement.1.json
@@ -271,6 +271,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_allowed_while_paused.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_allowed_while_paused.1.json
@@ -237,6 +237,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_deferred_when_milestone_in_community_review.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_deferred_when_milestone_in_community_review.1.json
@@ -124,6 +124,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -309,11 +317,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -393,6 +415,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_deferred_when_milestone_submitted.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_deferred_when_milestone_submitted.1.json
@@ -124,6 +124,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -309,11 +317,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -393,6 +415,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_executes_after_grace_period.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_executes_after_grace_period.1.json
@@ -252,6 +252,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -464,11 +472,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -548,6 +570,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_grace_period_not_elapsed_returns_error.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_grace_period_not_elapsed_returns_error.1.json
@@ -124,6 +124,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -309,11 +317,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -393,6 +415,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_grant_by_global_admin.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_grant_by_global_admin.1.json
@@ -329,6 +329,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_grant_refund_handles_rounding_dust.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_grant_refund_handles_rounding_dust.1.json
@@ -281,6 +281,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_grant_zero_escrow_succeeds.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_grant_zero_escrow_succeeds.1.json
@@ -112,6 +112,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_immediate_when_no_submitted_milestones.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_cancel_immediate_when_no_submitted_milestones.1.json
@@ -224,6 +224,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -436,11 +444,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -520,6 +542,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_comment_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_comment_success.1.json
@@ -125,6 +125,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -250,11 +258,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -341,6 +363,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_duplicate_upvote_rejected.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_duplicate_upvote_rejected.1.json
@@ -122,6 +122,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -247,11 +255,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -329,6 +351,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_upvote_rejected_when_not_in_review.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_upvote_rejected_when_not_in_review.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -222,11 +230,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -306,6 +328,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_upvote_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_upvote_success.1.json
@@ -122,6 +122,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -247,11 +255,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -329,6 +351,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_vote_allowed_after_period.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_vote_allowed_after_period.1.json
@@ -70,6 +70,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -207,6 +208,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -336,11 +345,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -418,6 +441,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_vote_blocked_during_period.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_review_vote_blocked_during_period.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -226,11 +234,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -308,6 +330,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_signals_stored_independently_of_vote_outcome.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_community_signals_stored_independently_of_vote_outcome.1.json
@@ -123,6 +123,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -261,6 +262,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -390,11 +399,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -481,6 +504,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_get_grant_refreshes_persistent_ttl.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_get_grant_refreshes_persistent_ttl.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_get_grant_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_get_grant_success.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_get_milestone_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_get_milestone_success.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -226,11 +234,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -310,6 +332,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_add_reviewer_duplicate_rejected.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_add_reviewer_duplicate_rejected.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_add_reviewer_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_add_reviewer_success.1.json
@@ -121,6 +121,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_add_reviewer_unauthorized.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_add_reviewer_unauthorized.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_cancel_invalid_state.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_cancel_invalid_state.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_cancel_success_multiple_funders.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_cancel_success_multiple_funders.1.json
@@ -253,6 +253,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_cancel_unauthorized.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_cancel_unauthorized.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_complete_exact_balance.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_complete_exact_balance.1.json
@@ -206,6 +206,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -389,11 +397,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -471,6 +493,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_complete_pending_milestones.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_complete_pending_milestones.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -221,11 +229,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -307,6 +329,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -346,11 +376,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -428,6 +472,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_complete_success_with_refunds.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_complete_success_with_refunds.1.json
@@ -266,6 +266,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -449,11 +457,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "300"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -531,6 +553,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {
@@ -574,11 +604,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "300"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -656,6 +700,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_success.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -235,6 +238,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -450,11 +461,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -536,6 +561,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -575,11 +608,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -657,6 +704,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_with_deadlines.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_with_deadlines.1.json
@@ -83,6 +83,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -244,6 +247,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -459,11 +470,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -545,6 +570,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -584,11 +617,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -666,6 +713,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_with_min_funding_starts_pending.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_with_min_funding_starts_pending.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -235,6 +238,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -450,11 +461,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -536,6 +561,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -575,11 +608,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -657,6 +704,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_with_tags.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_with_tags.1.json
@@ -84,6 +84,9 @@
                       "string": "Stellar"
                     }
                   ]
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -245,6 +248,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -470,11 +481,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -552,6 +577,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_zero_min_funding_starts_active.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_zero_min_funding_starts_active.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -235,6 +238,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -450,11 +461,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -536,6 +561,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -575,11 +608,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -657,6 +704,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_existing_funder.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_existing_funder.1.json
@@ -307,6 +307,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_invalid_amount.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_invalid_amount.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_multiple_funders.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_multiple_funders.1.json
@@ -357,6 +357,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_overflow.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_overflow.1.json
@@ -95,6 +95,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_success.1.json
@@ -259,6 +259,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_unauthorized.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_fund_unauthorized.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_pause_by_global_admin.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_pause_by_global_admin.1.json
@@ -246,6 +246,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_pause_invalid_state.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_pause_invalid_state.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_pause_unauthorized.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_pause_unauthorized.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_ping_restores_inactive_grant_to_active.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_ping_restores_inactive_grant_to_active.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 6,
+    "address": 5,
     "nonce": 0,
     "mux_id": 0
   },
@@ -8,15 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -31,23 +31,45 @@
         {
           "function": {
             "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "5000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "function_name": "grant_create",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "string": "Uncapped Grant"
+                  "string": "Ping Grant"
                 },
                 {
                   "string": "Desc"
                 },
                 {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "i128": "500"
+                  "i128": "1000"
                 },
                 {
                   "i128": "500"
@@ -58,7 +80,7 @@
                 {
                   "vec": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                     }
                   ]
                 },
@@ -87,7 +109,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -98,7 +120,7 @@
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -109,18 +131,18 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "i128": "10000"
+                  "i128": "1000"
                 }
               ]
             }
@@ -131,7 +153,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -142,13 +164,13 @@
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "i128": "5000"
+                  "i128": "1000"
                 },
                 {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 "void"
               ]
@@ -158,17 +180,17 @@
             {
               "function": {
                 "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+                  "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
                   "function_name": "transfer",
                   "args": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                     },
                     {
-                      "i128": "5000"
+                      "i128": "1000"
                     }
                   ]
                 }
@@ -179,53 +201,28 @@
         }
       ]
     ],
+    [],
+    [],
+    [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_fund",
+              "function_name": "grant_ping",
               "args": [
                 {
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
-                },
-                "void"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
               ]
             }
           },
-          "sub_invocations": [
-            {
-              "function": {
-                "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
-                  "function_name": "transfer",
-                  "args": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                    },
-                    {
-                      "i128": "5000"
-                    }
-                  ]
-                }
-              },
-              "sub_invocations": []
-            }
-          ]
+          "sub_invocations": []
         }
       ]
     ],
@@ -234,7 +231,7 @@
   "ledger": {
     "protocol_version": 25,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 5184001,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -246,7 +243,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -268,7 +265,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -360,10 +357,10 @@
                       "map": [
                         {
                           "key": {
-                            "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                            "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                           },
                           "val": {
-                            "i128": "10000"
+                            "i128": "1000"
                           }
                         }
                       ]
@@ -382,7 +379,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "10000"
+                                "i128": "1000"
                               }
                             },
                             {
@@ -390,7 +387,7 @@
                                 "symbol": "funder"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                               }
                             },
                             {
@@ -398,7 +395,7 @@
                                 "symbol": "token"
                               },
                               "val": {
-                                "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                                "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                               }
                             }
                           ]
@@ -435,7 +432,7 @@
                       "symbol": "last_heartbeat"
                     },
                     "val": {
-                      "u64": "0"
+                      "u64": "5184001"
                     }
                   },
                   {
@@ -459,7 +456,7 @@
                       "symbol": "owner"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   },
                   {
@@ -483,7 +480,7 @@
                     "val": {
                       "vec": [
                         {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                         }
                       ]
                     }
@@ -509,7 +506,7 @@
                       "symbol": "title"
                     },
                     "val": {
-                      "string": "Uncapped Grant"
+                      "string": "Ping Grant"
                     }
                   },
                   {
@@ -517,7 +514,7 @@
                       "symbol": "token_address"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
@@ -525,7 +522,7 @@
                       "symbol": "total_amount"
                     },
                     "val": {
-                      "i128": "500"
+                      "i128": "1000"
                     }
                   }
                 ]
@@ -611,6 +608,33 @@
                     "u64": "1"
                   }
                 ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GrantStatusIndex"
+                  },
+                  {
+                    "u32": 6
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": []
               }
             }
           },
@@ -727,7 +751,7 @@
                       "symbol": "payout_token"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
@@ -851,7 +875,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "1033654523790656264"
+                  "nonce": "2032731177588607455"
                 }
               },
               "durability": "temporary",
@@ -888,10 +912,10 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "2032731177588607455"
+                  "nonce": "1033654523790656264"
                 }
               },
               "durability": "temporary",
@@ -908,7 +932,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "4270020994084947596"
@@ -928,7 +952,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
@@ -948,7 +972,27 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "8370022561469687789"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
@@ -967,7 +1011,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "10000"
+                      "i128": "6000"
                     }
                   },
                   {
@@ -1000,14 +1044,14 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                   }
                 ]
               },
@@ -1052,7 +1096,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -1078,7 +1122,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
                             }
                           },
                           {
@@ -1101,7 +1145,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -1132,7 +1176,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
                                 }
                               }
                             ]

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_last_reviewer_rejected.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_last_reviewer_rejected.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_not_in_list_rejected.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_not_in_list_rejected.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_quorum_exceeds_new_count_rejected.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_quorum_exceeds_new_count_rejected.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_success.1.json
@@ -121,6 +121,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_unauthorized.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_remove_reviewer_unauthorized.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_update_metadata_non_active_fails.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_update_metadata_non_active_fails.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -236,6 +239,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -451,11 +462,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -537,6 +562,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -576,11 +609,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -658,6 +705,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_update_metadata_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_update_metadata_success.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -285,6 +288,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -527,11 +538,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -613,6 +638,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -652,11 +685,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -734,6 +781,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_withdraw_fails_if_already_paid.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_withdraw_fails_if_already_paid.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -222,11 +230,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -306,6 +328,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_withdraw_fails_if_not_approved.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_withdraw_fails_if_not_approved.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -222,11 +230,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -306,6 +328,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_withdraw_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_withdraw_success.1.json
@@ -203,6 +203,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -332,11 +340,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -416,6 +438,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_withdraw_unauthorized.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_withdraw_unauthorized.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -222,11 +230,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -306,6 +328,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_hard_cap_fund_up_to_exact_cap.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_hard_cap_fund_up_to_exact_cap.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -371,6 +374,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -609,11 +620,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -691,6 +716,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_hard_cap_rejects_over_cap_donation.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_hard_cap_rejects_over_cap_donation.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -371,6 +374,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -609,11 +620,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -691,6 +716,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_high_security_grant_complete_waits_for_multisig.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_high_security_grant_complete_waits_for_multisig.1.json
@@ -371,6 +371,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -609,11 +617,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -691,6 +713,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {
@@ -734,11 +764,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -816,6 +860,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_high_security_rejects_non_multisig_signer.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_high_security_rejects_non_multisig_signer.1.json
@@ -255,6 +255,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -493,11 +501,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -575,6 +597,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_high_security_release_on_final_signature.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_high_security_release_on_final_signature.1.json
@@ -407,6 +407,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -672,11 +680,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -754,6 +776,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {
@@ -797,11 +827,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -879,6 +923,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_mark_grant_inactive_permissionless_after_heartbeat_timeout.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_mark_grant_inactive_permissionless_after_heartbeat_timeout.1.json
@@ -8,15 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -31,23 +31,45 @@
         {
           "function": {
             "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "5000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "function_name": "grant_create",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "string": "Uncapped Grant"
+                  "string": "HB Grant"
                 },
                 {
                   "string": "Desc"
                 },
                 {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "i128": "500"
+                  "i128": "1000"
                 },
                 {
                   "i128": "500"
@@ -58,7 +80,7 @@
                 {
                   "vec": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                     }
                   ]
                 },
@@ -87,7 +109,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -98,7 +120,7 @@
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -109,18 +131,18 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "i128": "10000"
+                  "i128": "1000"
                 }
               ]
             }
@@ -131,7 +153,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -142,13 +164,13 @@
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "i128": "5000"
+                  "i128": "1000"
                 },
                 {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 "void"
               ]
@@ -158,17 +180,17 @@
             {
               "function": {
                 "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+                  "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
                   "function_name": "transfer",
                   "args": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                     },
                     {
-                      "i128": "5000"
+                      "i128": "1000"
                     }
                   ]
                 }
@@ -179,62 +201,14 @@
         }
       ]
     ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_fund",
-              "args": [
-                {
-                  "u64": "1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
-                },
-                "void"
-              ]
-            }
-          },
-          "sub_invocations": [
-            {
-              "function": {
-                "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
-                  "function_name": "transfer",
-                  "args": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                    },
-                    {
-                      "i128": "5000"
-                    }
-                  ]
-                }
-              },
-              "sub_invocations": []
-            }
-          ]
-        }
-      ]
-    ],
+    [],
+    [],
     []
   ],
   "ledger": {
     "protocol_version": 25,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 5184001,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -246,7 +220,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -268,7 +242,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -360,10 +334,10 @@
                       "map": [
                         {
                           "key": {
-                            "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                            "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                           },
                           "val": {
-                            "i128": "10000"
+                            "i128": "1000"
                           }
                         }
                       ]
@@ -382,7 +356,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "10000"
+                                "i128": "1000"
                               }
                             },
                             {
@@ -390,7 +364,7 @@
                                 "symbol": "funder"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                               }
                             },
                             {
@@ -398,7 +372,7 @@
                                 "symbol": "token"
                               },
                               "val": {
-                                "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                                "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                               }
                             }
                           ]
@@ -459,7 +433,7 @@
                       "symbol": "owner"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   },
                   {
@@ -467,7 +441,7 @@
                       "symbol": "packed_config"
                     },
                     "val": {
-                      "u128": "18446744078004518913"
+                      "u128": "18446744078004518918"
                     }
                   },
                   {
@@ -483,7 +457,7 @@
                     "val": {
                       "vec": [
                         {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                         }
                       ]
                     }
@@ -509,7 +483,7 @@
                       "symbol": "title"
                     },
                     "val": {
-                      "string": "Uncapped Grant"
+                      "string": "HB Grant"
                     }
                   },
                   {
@@ -517,7 +491,7 @@
                       "symbol": "token_address"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
@@ -525,7 +499,7 @@
                       "symbol": "total_amount"
                     },
                     "val": {
-                      "i128": "500"
+                      "i128": "1000"
                     }
                   }
                 ]
@@ -601,6 +575,33 @@
                   },
                   {
                     "u32": 1
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": []
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GrantStatusIndex"
+                  },
+                  {
+                    "u32": 6
                   }
                 ]
               },
@@ -727,7 +728,7 @@
                       "symbol": "payout_token"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
@@ -851,7 +852,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "1033654523790656264"
+                  "nonce": "2032731177588607455"
                 }
               },
               "durability": "temporary",
@@ -888,10 +889,10 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "2032731177588607455"
+                  "nonce": "1033654523790656264"
                 }
               },
               "durability": "temporary",
@@ -908,7 +909,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "4270020994084947596"
@@ -928,7 +929,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
@@ -948,7 +949,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
@@ -967,7 +968,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "10000"
+                      "i128": "6000"
                     }
                   },
                   {
@@ -1000,14 +1001,14 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                   }
                 ]
               },
@@ -1052,7 +1053,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -1078,7 +1079,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
                             }
                           },
                           {
@@ -1101,7 +1102,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -1132,7 +1133,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
                                 }
                               }
                             ]

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_mark_grant_inactive_rejects_when_heartbeat_still_fresh.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_mark_grant_inactive_rejects_when_heartbeat_still_fresh.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 6,
+    "address": 5,
     "nonce": 0,
     "mux_id": 0
   },
@@ -8,15 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -31,23 +31,45 @@
         {
           "function": {
             "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                },
+                {
+                  "i128": "5000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
               "function_name": "grant_create",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "string": "Uncapped Grant"
+                  "string": "Fresh HB"
                 },
                 {
                   "string": "Desc"
                 },
                 {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
-                  "i128": "500"
+                  "i128": "1000"
                 },
                 {
                   "i128": "500"
@@ -58,7 +80,7 @@
                 {
                   "vec": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                     }
                   ]
                 },
@@ -87,7 +109,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -98,7 +120,7 @@
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 }
               ]
             }
@@ -109,18 +131,18 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "i128": "10000"
+                  "i128": "1000"
                 }
               ]
             }
@@ -131,7 +153,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -142,13 +164,13 @@
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "i128": "5000"
+                  "i128": "1000"
                 },
                 {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 "void"
               ]
@@ -158,67 +180,17 @@
             {
               "function": {
                 "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+                  "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
                   "function_name": "transfer",
                   "args": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                     },
                     {
-                      "i128": "5000"
-                    }
-                  ]
-                }
-              },
-              "sub_invocations": []
-            }
-          ]
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_fund",
-              "args": [
-                {
-                  "u64": "1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
-                },
-                "void"
-              ]
-            }
-          },
-          "sub_invocations": [
-            {
-              "function": {
-                "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
-                  "function_name": "transfer",
-                  "args": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                    },
-                    {
-                      "i128": "5000"
+                      "i128": "1000"
                     }
                   ]
                 }
@@ -246,7 +218,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -268,7 +240,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -360,10 +332,10 @@
                       "map": [
                         {
                           "key": {
-                            "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                            "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                           },
                           "val": {
-                            "i128": "10000"
+                            "i128": "1000"
                           }
                         }
                       ]
@@ -382,7 +354,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "10000"
+                                "i128": "1000"
                               }
                             },
                             {
@@ -390,7 +362,7 @@
                                 "symbol": "funder"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                               }
                             },
                             {
@@ -398,7 +370,7 @@
                                 "symbol": "token"
                               },
                               "val": {
-                                "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                                "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                               }
                             }
                           ]
@@ -459,7 +431,7 @@
                       "symbol": "owner"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   },
                   {
@@ -483,7 +455,7 @@
                     "val": {
                       "vec": [
                         {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
                         }
                       ]
                     }
@@ -509,7 +481,7 @@
                       "symbol": "title"
                     },
                     "val": {
-                      "string": "Uncapped Grant"
+                      "string": "Fresh HB"
                     }
                   },
                   {
@@ -517,7 +489,7 @@
                       "symbol": "token_address"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
@@ -525,7 +497,7 @@
                       "symbol": "total_amount"
                     },
                     "val": {
-                      "i128": "500"
+                      "i128": "1000"
                     }
                   }
                 ]
@@ -727,7 +699,7 @@
                       "symbol": "payout_token"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
@@ -851,7 +823,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "1033654523790656264"
+                  "nonce": "2032731177588607455"
                 }
               },
               "durability": "temporary",
@@ -888,10 +860,10 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "2032731177588607455"
+                  "nonce": "1033654523790656264"
                 }
               },
               "durability": "temporary",
@@ -908,7 +880,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "4270020994084947596"
@@ -928,7 +900,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
@@ -948,7 +920,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
@@ -967,7 +939,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "10000"
+                      "i128": "6000"
                     }
                   },
                   {
@@ -1000,14 +972,14 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                   }
                 ]
               },
@@ -1052,7 +1024,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -1078,7 +1050,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
                             }
                           },
                           {
@@ -1101,7 +1073,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -1132,7 +1104,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
                                 }
                               }
                             ]

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_approve_already_approved.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_approve_already_approved.1.json
@@ -157,6 +157,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -286,11 +294,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -370,6 +392,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_approve_insufficient_balance.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_approve_insufficient_balance.1.json
@@ -158,6 +158,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -287,11 +295,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -371,6 +393,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_approve_quorum_not_reached.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_approve_quorum_not_reached.1.json
@@ -157,6 +157,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -286,11 +294,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -370,6 +392,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_approve_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_approve_success.1.json
@@ -284,6 +284,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -413,11 +421,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -497,6 +519,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_challenge_flow.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_challenge_flow.1.json
@@ -142,6 +142,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -500,6 +501,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -629,11 +638,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -713,6 +736,14 @@
                     },
                     "val": {
                       "u64": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_deadline_extension.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_deadline_extension.1.json
@@ -234,6 +234,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -366,11 +374,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -450,6 +472,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_dispute_by_owner.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_dispute_by_owner.1.json
@@ -153,6 +153,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -282,11 +290,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -375,6 +397,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_dispute_resolved_by_council.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_dispute_resolved_by_council.1.json
@@ -287,6 +287,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -416,11 +424,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -509,6 +531,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_feedback_length_limit.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_feedback_length_limit.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -226,11 +234,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -310,6 +332,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_feedback_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_feedback_success.1.json
@@ -72,7 +72,8 @@
                 },
                 {
                   "string": "Great job!"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -210,6 +211,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -339,11 +348,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -432,6 +455,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_payout_event_emitted.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_payout_event_emitted.1.json
@@ -122,7 +122,8 @@
                 },
                 {
                   "string": "Great job!"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -313,6 +314,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -442,11 +451,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -535,6 +558,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_payout_on_quorum_escrow_decremented.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_payout_on_quorum_escrow_decremented.1.json
@@ -123,7 +123,8 @@
                 },
                 {
                   "string": "Great job!"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -315,6 +316,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -444,11 +453,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -537,6 +560,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_payout_on_quorum_recipient_balance_increases.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_payout_on_quorum_recipient_balance_increases.1.json
@@ -123,7 +123,8 @@
                 },
                 {
                   "string": "Great job!"
-                }
+                },
+                "void"
               ]
             }
           },
@@ -315,6 +316,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -444,11 +453,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -537,6 +560,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_storage_refreshes_persistent_ttl.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_storage_refreshes_persistent_ttl.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -222,11 +230,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -306,6 +328,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_batch_three_milestones.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_batch_three_milestones.1.json
@@ -226,6 +226,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -351,11 +359,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "333"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -439,6 +461,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -478,11 +508,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "333"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -566,6 +610,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -605,11 +657,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "333"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -689,6 +755,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_deadline_passed.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_deadline_passed.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -221,11 +229,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -303,6 +325,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_duplicate.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_duplicate.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -222,11 +230,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -306,6 +328,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_inactive_grant.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_inactive_grant.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_invalid_milestone_idx.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_invalid_milestone_idx.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_sets_community_review_state.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_sets_community_review_state.1.json
@@ -129,6 +129,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -258,11 +266,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -342,6 +364,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_success.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_success.1.json
@@ -129,6 +129,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -254,11 +262,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -338,6 +360,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_unauthorized.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_submit_unauthorized.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -222,11 +230,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -306,6 +328,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_top_up_payout_exceeds_base_amount.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_top_up_payout_exceeds_base_amount.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 6,
+    "address": 7,
     "nonce": 0,
     "mux_id": 0
   },
@@ -8,15 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -31,97 +31,174 @@
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_create",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Uncapped Grant"
-                },
-                {
-                  "string": "Desc"
-                },
-                {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
-                },
-                {
-                  "i128": "500"
-                },
-                {
-                  "i128": "500"
-                },
-                {
-                  "u32": 1
-                },
-                {
-                  "vec": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                    }
-                  ]
-                },
-                {
-                  "u32": 1
-                },
-                "void",
-                {
-                  "i128": "0"
-                },
-                {
-                  "i128": "0"
-                },
-                {
-                  "vec": []
-                },
-                {
-                  "bool": false
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_accept",
-              "args": [
-                {
-                  "u64": "1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                 },
                 {
-                  "i128": "10000"
+                  "i128": "2000"
                 }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                },
+                {
+                  "i128": "500"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "grant_fund",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "i128": "1000"
+                },
+                {
+                  "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
+                },
+                "void"
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "1000"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "grant_fund_milestone",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u32": 0
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                },
+                {
+                  "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
+                },
+                {
+                  "i128": "50"
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "50"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "milestone_vote",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u32": 0
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "bool": true
+                },
+                {
+                  "string": "Great job!"
+                },
+                "void"
               ]
             }
           },
@@ -136,105 +213,31 @@
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_fund",
+              "function_name": "milestone_payout",
               "args": [
                 {
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
-                },
-                "void"
-              ]
-            }
-          },
-          "sub_invocations": [
-            {
-              "function": {
-                "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
-                  "function_name": "transfer",
-                  "args": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                    },
-                    {
-                      "i128": "5000"
-                    }
-                  ]
-                }
-              },
-              "sub_invocations": []
-            }
-          ]
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_fund",
-              "args": [
-                {
-                  "u64": "1"
+                  "u32": 0
                 },
                 {
                   "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "i128": "5000"
-                },
-                {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
-                },
-                "void"
+                }
               ]
             }
           },
-          "sub_invocations": [
-            {
-              "function": {
-                "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
-                  "function_name": "transfer",
-                  "args": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                    },
-                    {
-                      "i128": "5000"
-                    }
-                  ]
-                }
-              },
-              "sub_invocations": []
-            }
-          ]
+          "sub_invocations": []
         }
       ]
     ],
+    [],
     []
   ],
   "ledger": {
     "protocol_version": 25,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 172801,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -246,7 +249,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -268,7 +271,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -281,42 +284,6 @@
           "ext": "v0"
         },
         "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "EscrowState"
-                  },
-                  {
-                    "u64": "1"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "packed_stats"
-                    },
-                    "val": {
-                      "u128": "4294967297"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
       },
       {
         "entry": {
@@ -360,10 +327,10 @@
                       "map": [
                         {
                           "key": {
-                            "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                            "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
                           },
                           "val": {
-                            "i128": "10000"
+                            "i128": "1900"
                           }
                         }
                       ]
@@ -382,7 +349,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "10000"
+                                "i128": "1000"
                               }
                             },
                             {
@@ -390,7 +357,7 @@
                                 "symbol": "funder"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                               }
                             },
                             {
@@ -398,7 +365,7 @@
                                 "symbol": "token"
                               },
                               "val": {
-                                "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                                "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
                               }
                             }
                           ]
@@ -459,7 +426,7 @@
                       "symbol": "owner"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   },
                   {
@@ -467,7 +434,7 @@
                       "symbol": "packed_config"
                     },
                     "val": {
-                      "u128": "18446744078004518913"
+                      "u128": "79228162532711081671548469249"
                     }
                   },
                   {
@@ -509,7 +476,7 @@
                       "symbol": "title"
                     },
                     "val": {
-                      "string": "Uncapped Grant"
+                      "string": "Test"
                     }
                   },
                   {
@@ -517,7 +484,7 @@
                       "symbol": "token_address"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
                     }
                   },
                   {
@@ -525,119 +492,10 @@
                       "symbol": "total_amount"
                     },
                     "val": {
-                      "i128": "500"
+                      "i128": "1000"
                     }
                   }
                 ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "GrantCounter"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "u64": "1"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "GrantMinReputation"
-                  },
-                  {
-                    "u64": "1"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "u64": "0"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "GrantStatusIndex"
-                  },
-                  {
-                    "u32": 1
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "vec": [
-                  {
-                    "u64": "1"
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "GrantStatusIndex"
-                  },
-                  {
-                    "u32": 8
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "vec": []
               }
             }
           },
@@ -681,7 +539,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "500"
+                      "i128": "100"
                     }
                   },
                   {
@@ -711,7 +569,7 @@
                       "symbol": "description"
                     },
                     "val": {
-                      "string": ""
+                      "string": "Description"
                     }
                   },
                   {
@@ -719,7 +577,7 @@
                       "symbol": "packed_stats"
                     },
                     "val": {
-                      "u128": "0"
+                      "u128": "4294967296"
                     }
                   },
                   {
@@ -727,21 +585,32 @@
                       "symbol": "payout_token"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
                     }
                   },
                   {
                     "key": {
                       "symbol": "proof_url"
                     },
-                    "val": "void"
+                    "val": {
+                      "string": "https://proof.url"
+                    }
                   },
                   {
                     "key": {
                       "symbol": "reasons"
                     },
                     "val": {
-                      "map": []
+                      "map": [
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          },
+                          "val": {
+                            "string": "Great job!"
+                          }
+                        }
+                      ]
                     }
                   },
                   {
@@ -749,7 +618,7 @@
                       "symbol": "state"
                     },
                     "val": {
-                      "u32": 0
+                      "u32": 3
                     }
                   },
                   {
@@ -757,7 +626,7 @@
                       "symbol": "status_updated_at"
                     },
                     "val": {
-                      "u64": "0"
+                      "u64": "172801"
                     }
                   },
                   {
@@ -781,7 +650,16 @@
                       "symbol": "votes"
                     },
                     "val": {
-                      "map": []
+                      "map": [
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          },
+                          "val": {
+                            "bool": true
+                          }
+                        }
+                      ]
                     }
                   }
                 ]
@@ -802,16 +680,46 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "MultisigSigners"
+                    "symbol": "MilestoneReputationApplied"
                   },
                   {
                     "u64": "1"
+                  },
+                  {
+                    "u32": 0
                   }
                 ]
               },
               "durability": "persistent",
               "val": {
-                "vec": []
+                "bool": true
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ReviewerReputation"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u32": 2
               }
             }
           },
@@ -891,7 +799,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "2032731177588607455"
+                  "nonce": "8370022561469687789"
                 }
               },
               "durability": "temporary",
@@ -908,7 +816,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "4270020994084947596"
@@ -928,7 +836,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
@@ -948,7 +856,27 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "2032731177588607455"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
               "key": {
                 "vec": [
                   {
@@ -967,7 +895,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "10000"
+                      "i128": "900"
                     }
                   },
                   {
@@ -1000,7 +928,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
               "key": {
                 "vec": [
                   {
@@ -1019,7 +947,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "0"
+                      "i128": "150"
                     }
                   },
                   {
@@ -1052,7 +980,111 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Balance"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "authorized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "clawback"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 518400
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Balance"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "450"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "authorized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "clawback"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 518400
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -1078,7 +1110,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
                             }
                           },
                           {
@@ -1101,7 +1133,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -1132,7 +1164,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000005"
                                 }
                               }
                             ]

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_vote_requires_full_quorum_three_of_three.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_vote_requires_full_quorum_three_of_three.1.json
@@ -70,6 +70,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -99,6 +100,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -128,6 +130,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -261,6 +264,14 @@
                     },
                     "val": {
                       "u64": "21"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -400,11 +411,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -484,6 +509,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_multi_token_funding_and_cancellation_refund.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_multi_token_funding_and_cancellation_refund.1.json
@@ -137,6 +137,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -554,6 +557,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -848,11 +859,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -934,6 +959,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -973,11 +1006,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1055,6 +1102,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_no_reputation_increment_for_dissenting_voter.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_no_reputation_increment_for_dissenting_voter.1.json
@@ -71,6 +71,7 @@
                 {
                   "bool": false
                 },
+                "void",
                 "void"
               ]
             }
@@ -100,6 +101,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -238,6 +240,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -370,11 +380,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -454,6 +478,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_open_bounty_two_contributors_submit_distinct_proofs.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_open_bounty_two_contributors_submit_distinct_proofs.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 6,
+    "address": 8,
     "nonce": 0,
     "mux_id": 0
   },
@@ -8,15 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -31,93 +31,11 @@
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_create",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                },
-                {
-                  "string": "Uncapped Grant"
-                },
-                {
-                  "string": "Desc"
-                },
-                {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
-                },
-                {
-                  "i128": "500"
-                },
-                {
-                  "i128": "500"
-                },
-                {
-                  "u32": 1
-                },
-                {
-                  "vec": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                    }
-                  ]
-                },
-                {
-                  "u32": 1
-                },
-                "void",
-                {
-                  "i128": "0"
-                },
-                {
-                  "i128": "0"
-                },
-                {
-                  "vec": []
-                },
-                {
-                  "bool": false
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_accept",
-              "args": [
-                {
-                  "u64": "1"
-                },
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
                   "i128": "10000"
@@ -131,7 +49,176 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "i128": "2000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "grant_create",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "string": "Open Bounty"
+                },
+                {
+                  "string": "Community milestone"
+                },
+                {
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
+                },
+                {
+                  "i128": "1000"
+                },
+                {
+                  "i128": "500"
+                },
+                {
+                  "u32": 1
+                },
+                {
+                  "vec": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                    }
+                  ]
+                },
+                {
+                  "u32": 2
+                },
+                "void",
+                {
+                  "i128": "0"
+                },
+                {
+                  "i128": "0"
+                },
+                {
+                  "vec": []
+                },
+                {
+                  "bool": true
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "grant_accept",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "contributor_register",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                },
+                {
+                  "string": "Alice"
+                },
+                {
+                  "string": "Bio"
+                },
+                {
+                  "vec": []
+                },
+                {
+                  "string": "https://gh.example/x"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "contributor_register",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                },
+                {
+                  "string": "Bob"
+                },
+                {
+                  "string": "Bio"
+                },
+                {
+                  "vec": []
+                },
+                {
+                  "string": "https://gh.example/x"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -142,13 +229,13 @@
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
-                  "i128": "5000"
+                  "i128": "1000"
                 },
                 {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 "void"
               ]
@@ -158,17 +245,17 @@
             {
               "function": {
                 "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+                  "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
                   "function_name": "transfer",
                   "args": [
                     {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     },
                     {
                       "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                     },
                     {
-                      "i128": "5000"
+                      "i128": "1000"
                     }
                   ]
                 }
@@ -181,51 +268,130 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "grant_fund",
+              "function_name": "milestone_submit",
               "args": [
                 {
                   "u64": "1"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "u32": 0
                 },
                 {
-                  "i128": "5000"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
                 },
                 {
-                  "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                  "string": "Alice implementation"
+                },
+                {
+                  "string": "https://proof.alice"
                 },
                 "void"
               ]
             }
           },
-          "sub_invocations": [
-            {
-              "function": {
-                "contract_fn": {
-                  "contract_address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
-                  "function_name": "transfer",
-                  "args": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                    },
-                    {
-                      "i128": "5000"
-                    }
-                  ]
-                }
-              },
-              "sub_invocations": []
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "milestone_submit",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u32": 0
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                },
+                {
+                  "string": "Bob implementation"
+                },
+                {
+                  "string": "https://proof.bob"
+                },
+                "void"
+              ]
             }
-          ]
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "milestone_vote",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u32": 0
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "bool": true
+                },
+                "void",
+                {
+                  "u32": 1
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "milestone_vote",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "u32": 0
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                },
+                {
+                  "bool": true
+                },
+                "void",
+                {
+                  "u32": 1
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
         }
       ]
     ],
@@ -246,7 +412,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -268,7 +434,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -281,6 +447,206 @@
           "ext": "v0"
         },
         "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Contributor"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bio"
+                    },
+                    "val": {
+                      "string": "Bio"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "contributor"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "github_url"
+                    },
+                    "val": {
+                      "string": "https://gh.example/x"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grants_count"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "Alice"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registration_timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reputation_score"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "skills"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_earned"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Contributor"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bio"
+                    },
+                    "val": {
+                      "string": "Bio"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "contributor"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "github_url"
+                    },
+                    "val": {
+                      "string": "https://gh.example/x"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grants_count"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "Bob"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registration_timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reputation_score"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "skills"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_earned"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
       },
       {
         "entry": {
@@ -349,7 +715,7 @@
                       "symbol": "description"
                     },
                     "val": {
-                      "string": "Desc"
+                      "string": "Community milestone"
                     }
                   },
                   {
@@ -360,10 +726,10 @@
                       "map": [
                         {
                           "key": {
-                            "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                            "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                           },
                           "val": {
-                            "i128": "10000"
+                            "i128": "1000"
                           }
                         }
                       ]
@@ -382,7 +748,7 @@
                                 "symbol": "amount"
                               },
                               "val": {
-                                "i128": "10000"
+                                "i128": "1000"
                               }
                             },
                             {
@@ -390,7 +756,7 @@
                                 "symbol": "funder"
                               },
                               "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                               }
                             },
                             {
@@ -398,7 +764,7 @@
                                 "symbol": "token"
                               },
                               "val": {
-                                "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                                "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                               }
                             }
                           ]
@@ -427,7 +793,7 @@
                       "symbol": "is_open_bounty"
                     },
                     "val": {
-                      "bool": false
+                      "bool": true
                     }
                   },
                   {
@@ -459,7 +825,7 @@
                       "symbol": "owner"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   },
                   {
@@ -467,7 +833,7 @@
                       "symbol": "packed_config"
                     },
                     "val": {
-                      "u128": "18446744078004518913"
+                      "u128": "18446744082299486209"
                     }
                   },
                   {
@@ -483,7 +849,10 @@
                     "val": {
                       "vec": [
                         {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        },
+                        {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
                         }
                       ]
                     }
@@ -509,7 +878,7 @@
                       "symbol": "title"
                     },
                     "val": {
-                      "string": "Uncapped Grant"
+                      "string": "Open Bounty"
                     }
                   },
                   {
@@ -517,7 +886,7 @@
                       "symbol": "token_address"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
@@ -525,7 +894,7 @@
                       "symbol": "total_amount"
                     },
                     "val": {
-                      "i128": "500"
+                      "i128": "1000"
                     }
                   }
                 ]
@@ -688,7 +1057,9 @@
                     "key": {
                       "symbol": "bounty_winner"
                     },
-                    "val": "void"
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    }
                   },
                   {
                     "key": {
@@ -711,7 +1082,7 @@
                       "symbol": "description"
                     },
                     "val": {
-                      "string": ""
+                      "string": "Bob implementation"
                     }
                   },
                   {
@@ -719,7 +1090,7 @@
                       "symbol": "packed_stats"
                     },
                     "val": {
-                      "u128": "0"
+                      "u128": "8589934592"
                     }
                   },
                   {
@@ -727,14 +1098,16 @@
                       "symbol": "payout_token"
                     },
                     "val": {
-                      "address": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
                     "key": {
                       "symbol": "proof_url"
                     },
-                    "val": "void"
+                    "val": {
+                      "string": "https://proof.bob"
+                    }
                   },
                   {
                     "key": {
@@ -749,7 +1122,7 @@
                       "symbol": "state"
                     },
                     "val": {
-                      "u32": 0
+                      "u32": 8
                     }
                   },
                   {
@@ -781,7 +1154,24 @@
                       "symbol": "votes"
                     },
                     "val": {
-                      "map": []
+                      "map": [
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          },
+                          "val": {
+                            "bool": true
+                          }
+                        },
+                        {
+                          "key": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                          },
+                          "val": {
+                            "bool": true
+                          }
+                        }
+                      ]
                     }
                   }
                 ]
@@ -812,6 +1202,60 @@
               "durability": "persistent",
               "val": {
                 "vec": []
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ReviewerReputation"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u32": 2
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ReviewerReputation"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u32": 2
               }
             }
           },
@@ -888,7 +1332,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "2032731177588607455"
@@ -908,27 +1352,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "key": {
-                "ledger_key_nonce": {
-                  "nonce": "4270020994084947596"
-                }
-              },
-              "durability": "temporary",
-              "val": "void"
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "4837995959683129791"
@@ -948,7 +1372,147 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "6277191135259896685"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "115220454072064130"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "3126073502131104533"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "4270020994084947596"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5806905060045992000"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1194852393571756375"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "8370022561469687789"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
@@ -967,7 +1531,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "10000"
+                      "i128": "11000"
                     }
                   },
                   {
@@ -1000,14 +1564,14 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                   }
                 ]
               },
@@ -1019,7 +1583,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "0"
+                      "i128": "1000"
                     }
                   },
                   {
@@ -1052,7 +1616,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CACMVW2KK4H5FZDFF2AUCAKQTEJMZZWJUIZF23XMRVYQBSXYLHZ6BKWN",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -1078,7 +1642,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANHUF"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
                             }
                           },
                           {
@@ -1101,7 +1665,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -1132,7 +1696,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000006"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
                                 }
                               }
                             ]

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_pause_milestone_submit_fail.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_pause_milestone_submit_fail.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -279,6 +282,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -548,11 +559,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -634,6 +659,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -673,11 +706,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -755,6 +802,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_blocks_grant_create.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_blocks_grant_create.1.json
@@ -135,6 +135,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -383,6 +386,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -594,11 +605,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -680,6 +705,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -719,11 +752,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -801,6 +848,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_blocks_grant_fund.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_blocks_grant_fund.1.json
@@ -221,6 +221,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_blocks_milestone_submit.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_blocks_milestone_submit.1.json
@@ -222,6 +222,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -347,11 +355,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -431,6 +453,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_blocks_milestone_vote.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_blocks_milestone_vote.1.json
@@ -222,6 +222,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -351,11 +359,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -435,6 +457,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_grant_rejects_fund.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_grant_rejects_fund.1.json
@@ -178,6 +178,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_grant_rejects_milestone_submit.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_grant_rejects_milestone_submit.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -222,11 +230,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -306,6 +328,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_grant_rejects_milestone_vote.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_paused_grant_rejects_milestone_vote.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -226,11 +234,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -310,6 +332,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_pending_funding_exceeds_threshold_activates.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_pending_funding_exceeds_threshold_activates.1.json
@@ -257,6 +257,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_pending_funding_rejects_milestone_submit.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_pending_funding_rejects_milestone_submit.1.json
@@ -97,6 +97,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -222,11 +230,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -306,6 +328,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_pending_funding_transitions_to_active_on_threshold.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_pending_funding_transitions_to_active_on_threshold.1.json
@@ -308,6 +308,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reentrancy_guard_allows_sequential_grant_funds.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reentrancy_guard_allows_sequential_grant_funds.1.json
@@ -307,6 +307,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_increases_after_grant_release.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_increases_after_grant_release.1.json
@@ -105,6 +105,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -495,6 +498,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -760,11 +771,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -842,6 +867,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_increment_on_rejection.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_increment_on_rejection.1.json
@@ -153,6 +153,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -285,11 +293,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -386,6 +408,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_requirement_blocks_low_score_submission.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_requirement_blocks_low_score_submission.1.json
@@ -415,6 +415,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -653,11 +661,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -741,6 +763,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -780,11 +810,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "500"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -862,6 +906,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_weighted_quorum.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_weighted_quorum.1.json
@@ -71,6 +71,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -236,6 +237,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -368,11 +377,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -452,6 +475,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_weighted_vote_failure.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reputation_weighted_vote_failure.1.json
@@ -30,6 +30,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -123,6 +124,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -259,11 +268,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -343,6 +366,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reviewer_removal_does_not_affect_already_approved_milestone.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_reviewer_removal_does_not_affect_already_approved_milestone.1.json
@@ -122,6 +122,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -251,11 +259,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -335,6 +357,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_set_grant_extends_persistent_ttl.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_set_grant_extends_persistent_ttl.1.json
@@ -96,6 +96,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_successful_vote.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_successful_vote.1.json
@@ -70,6 +70,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -233,6 +234,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -362,11 +371,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "100"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -446,6 +469,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_dispute_and_resolve_flow.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_dispute_and_resolve_flow.1.json
@@ -96,6 +96,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -251,6 +254,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -751,6 +755,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -989,11 +1001,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1073,6 +1099,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_dispute_fee_deducted_from_caller.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_dispute_fee_deducted_from_caller.1.json
@@ -118,6 +118,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -341,6 +344,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -961,6 +965,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -1199,11 +1211,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1283,6 +1309,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_dispute_fee_refunded_when_upheld.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_dispute_fee_refunded_when_upheld.1.json
@@ -118,6 +118,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -341,6 +344,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -1009,6 +1013,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -1247,11 +1259,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1331,6 +1357,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_dispute_fee_sent_to_treasury_when_dismissed.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_dispute_fee_sent_to_treasury_when_dismissed.1.json
@@ -143,6 +143,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -366,6 +369,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -1054,6 +1058,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -1292,11 +1304,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1376,6 +1402,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_event_emission_on_grant_create_and_fund.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_event_emission_on_grant_create_and_fund.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -370,6 +373,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -608,11 +619,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -690,6 +715,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_event_emission_on_milestone_vote.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_event_emission_on_milestone_vote.1.json
@@ -74,6 +74,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -229,6 +232,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -427,6 +431,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -669,11 +681,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -753,6 +779,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_milestone_double_voting_panics.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_milestone_double_voting_panics.1.json
@@ -102,6 +102,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -185,6 +188,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -346,6 +350,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -594,11 +606,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -682,6 +708,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -730,11 +764,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -816,6 +864,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -855,11 +911,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -937,6 +1007,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_milestone_vote_after_quorum_panics.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_milestone_vote_after_quorum_panics.1.json
@@ -102,6 +102,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -185,6 +188,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -214,6 +218,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -375,6 +380,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -623,11 +636,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -711,6 +738,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -767,11 +802,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -853,6 +902,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -892,11 +949,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -974,6 +1045,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_milestone_voting_quorum_and_events.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_milestone_voting_quorum_and_events.1.json
@@ -102,6 +102,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -129,6 +132,78 @@
             }
           },
           "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": "1000"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "grant_fund",
+              "args": [
+                {
+                  "u64": "1"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "i128": "100"
+                },
+                {
+                  "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                },
+                "void"
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": "100"
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
         }
       ]
     ],
@@ -185,6 +260,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -214,6 +290,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -382,7 +459,7 @@
                             "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
                           },
                           "val": {
-                            "i128": "-10"
+                            "i128": "90"
                           }
                         }
                       ]
@@ -393,7 +470,36 @@
                       "symbol": "funders"
                     },
                     "val": {
-                      "vec": []
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "amount"
+                              },
+                              "val": {
+                                "i128": "100"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "funder"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "token"
+                              },
+                              "val": {
+                                "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   },
                   {
@@ -410,6 +516,14 @@
                     },
                     "val": {
                       "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
                     }
                   },
                   {
@@ -658,11 +772,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -746,6 +874,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -802,11 +938,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -888,6 +1038,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "votes"
                     },
                     "val": {
@@ -927,11 +1085,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "10"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1009,6 +1181,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {
@@ -1190,7 +1370,27 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "2032731177588607455"
+                  "nonce": "1194852393571756375"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "4270020994084947596"
                 }
               },
               "durability": "temporary",
@@ -1230,7 +1430,27 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "6277191135259896685"
+                  "nonce": "8370022561469687789"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "2032731177588607455"
                 }
               },
               "durability": "temporary",
@@ -1270,7 +1490,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "4270020994084947596"
+                  "nonce": "6277191135259896685"
                 }
               },
               "durability": "temporary",
@@ -1290,7 +1510,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "8370022561469687789"
+                  "nonce": "5806905060045992000"
                 }
               },
               "durability": "temporary",
@@ -1326,7 +1546,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "990"
+                      "i128": "1090"
                     }
                   },
                   {
@@ -1378,7 +1598,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "10"
+                      "i128": "910"
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_only_council_can_resolve_dispute.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_only_council_can_resolve_dispute.1.json
@@ -96,6 +96,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -251,6 +254,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -703,6 +707,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -941,11 +953,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1025,6 +1051,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_reputation_idempotent_per_milestone.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_reputation_idempotent_per_milestone.1.json
@@ -127,6 +127,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -350,6 +353,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -984,6 +988,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -1222,11 +1234,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1306,6 +1332,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_reputation_increases_after_milestone_approve.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_reputation_increases_after_milestone_approve.1.json
@@ -127,6 +127,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -350,6 +353,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -983,6 +987,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -1221,11 +1233,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1305,6 +1331,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_reputation_skipped_gracefully_without_profile.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_reputation_skipped_gracefully_without_profile.1.json
@@ -96,6 +96,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -319,6 +322,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -830,6 +834,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -1068,11 +1080,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1152,6 +1178,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_vote_blocked_during_dispute.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_vote_blocked_during_dispute.1.json
@@ -96,6 +96,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -251,6 +254,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -703,6 +707,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -941,11 +953,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1025,6 +1051,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_zero_fee_dispute_requires_no_transfer.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_zero_fee_dispute_requires_no_transfer.1.json
@@ -96,6 +96,9 @@
                 },
                 {
                   "vec": []
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -319,6 +322,7 @@
                 {
                   "bool": true
                 },
+                "void",
                 "void"
               ]
             }
@@ -831,6 +835,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "last_heartbeat"
                     },
                     "val": {
@@ -1069,11 +1081,25 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "additional_funds"
+                    },
+                    "val": {
+                      "map": []
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "amount"
                     },
                     "val": {
                       "i128": "1000"
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "bounty_winner"
+                    },
+                    "val": "void"
                   },
                   {
                     "key": {
@@ -1153,6 +1179,14 @@
                     },
                     "val": {
                       "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "top_up_contributions"
+                    },
+                    "val": {
+                      "vec": []
                     }
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/tests/test_event_emission.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/tests/test_event_emission.rs
@@ -34,6 +34,7 @@ fn test_event_emission_on_grant_create_and_fund() {
         &0i128,
         &0i128,
         &soroban_sdk::Vec::<soroban_sdk::String>::new(&env),
+        &false,
     );
     let funder = <Address as TestAddress>::generate(&env);
     client.grant_accept(&grant_id, &owner);
@@ -86,6 +87,7 @@ fn test_event_emission_on_milestone_vote() {
         &0i128,
         &0i128,
         &soroban_sdk::Vec::<soroban_sdk::String>::new(&env),
+        &false,
     );
     let funder = <Address as TestAddress>::generate(&env);
     client.grant_accept(&grant_id, &owner);
@@ -104,7 +106,7 @@ fn test_event_emission_on_milestone_vote() {
     let now = env.ledger().timestamp();
     env.ledger()
         .set_timestamp(now + COMMUNITY_REVIEW_PERIOD + 1);
-    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None);
+    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None, &None);
     let events = env.events().all();
     // Debug print all events
     println!("All events:");

--- a/stellargrant-contracts/contracts/stellar-grants/tests/test_milestone_dispute.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/tests/test_milestone_dispute.rs
@@ -36,6 +36,7 @@ fn test_dispute_and_resolve_flow() {
         &0i128,
         &0i128,
         &soroban_sdk::Vec::<soroban_sdk::String>::new(&env),
+        &false,
     );
     client.grant_accept(&grant_id, &owner);
     let funder = Address::generate(&env);
@@ -52,7 +53,7 @@ fn test_dispute_and_resolve_flow() {
     let now = env.ledger().timestamp();
     env.ledger()
         .set_timestamp(now + COMMUNITY_REVIEW_PERIOD + 1);
-    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None);
+    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None, &None);
     client.dispute_milestone(&grant_id, &0, &owner);
     client.resolve_dispute(&council, &grant_id, &0, &true);
     let milestone = client.get_milestone(&grant_id, &0);
@@ -92,6 +93,7 @@ fn test_vote_blocked_during_dispute() {
         &0i128,
         &0i128,
         &soroban_sdk::Vec::<soroban_sdk::String>::new(&env),
+        &false,
     );
     client.grant_accept(&grant_id, &owner);
     let funder = Address::generate(&env);
@@ -108,10 +110,10 @@ fn test_vote_blocked_during_dispute() {
     let now = env.ledger().timestamp();
     env.ledger()
         .set_timestamp(now + COMMUNITY_REVIEW_PERIOD + 1);
-    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None);
+    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None, &None);
     client.dispute_milestone(&grant_id, &0, &owner);
     // This should panic
-    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None);
+    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None, &None);
 }
 
 #[test]
@@ -147,6 +149,7 @@ fn test_only_council_can_resolve_dispute() {
         &0i128,
         &0i128,
         &soroban_sdk::Vec::<soroban_sdk::String>::new(&env),
+        &false,
     );
     client.grant_accept(&grant_id, &owner);
     let funder = Address::generate(&env);
@@ -163,7 +166,7 @@ fn test_only_council_can_resolve_dispute() {
     let now = env.ledger().timestamp();
     env.ledger()
         .set_timestamp(now + COMMUNITY_REVIEW_PERIOD + 1);
-    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None);
+    client.milestone_vote(&grant_id, &0, &reviewer, &true, &None, &None);
     client.dispute_milestone(&grant_id, &0, &owner);
     // This should panic (not council)
     client.resolve_dispute(&owner, &grant_id, &0, &true);

--- a/stellargrant-contracts/contracts/stellar-grants/tests/test_milestone_quorum.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/tests/test_milestone_quorum.rs
@@ -39,9 +39,13 @@ fn test_milestone_voting_quorum_and_events() {
         &0i128,
         &0i128,
         &soroban_sdk::Vec::<soroban_sdk::String>::new(&env),
+        &false,
     );
 
     client.grant_accept(&grant_id, &owner);
+
+    token_admin.mint(&owner, &1000);
+    client.grant_fund(&grant_id, &owner, &100, &token_id, &None);
 
     let _ = client.milestone_submit(
         &grant_id,
@@ -57,9 +61,23 @@ fn test_milestone_voting_quorum_and_events() {
     env.ledger()
         .set_timestamp(ts.saturating_add(COMMUNITY_REVIEW_PERIOD).saturating_add(1));
 
-    let res1 = client.milestone_vote(&grant_id, &0, &reviewers.get(0).unwrap(), &true, &None);
+    let res1 = client.milestone_vote(
+        &grant_id,
+        &0,
+        &reviewers.get(0).unwrap(),
+        &true,
+        &None,
+        &None,
+    );
     assert_eq!(res1, false); // Quorum not reached yet
-    let res2 = client.milestone_vote(&grant_id, &0, &reviewers.get(1).unwrap(), &true, &None);
+    let res2 = client.milestone_vote(
+        &grant_id,
+        &0,
+        &reviewers.get(1).unwrap(),
+        &true,
+        &None,
+        &None,
+    );
     assert_eq!(res2, true);
 
     let milestone = client.get_milestone(&grant_id, &0);
@@ -112,6 +130,7 @@ fn test_milestone_vote_after_quorum_panics() {
         &0i128,
         &0i128,
         &soroban_sdk::Vec::<soroban_sdk::String>::new(&env),
+        &false,
     );
     client.grant_accept(&grant_id, &owner);
     let _ = client.milestone_submit(
@@ -125,10 +144,31 @@ fn test_milestone_vote_after_quorum_panics() {
     let ts = env.ledger().timestamp();
     env.ledger()
         .set_timestamp(ts.saturating_add(COMMUNITY_REVIEW_PERIOD).saturating_add(1));
-    let _ = client.milestone_vote(&grant_id, &0, &reviewers.get(0).unwrap(), &true, &None);
-    let _ = client.milestone_vote(&grant_id, &0, &reviewers.get(1).unwrap(), &true, &None);
+    let _ = client.milestone_vote(
+        &grant_id,
+        &0,
+        &reviewers.get(0).unwrap(),
+        &true,
+        &None,
+        &None,
+    );
+    let _ = client.milestone_vote(
+        &grant_id,
+        &0,
+        &reviewers.get(1).unwrap(),
+        &true,
+        &None,
+        &None,
+    );
     // This vote should panic (milestone already approved — MilestoneNotSubmitted #7)
-    let _ = client.milestone_vote(&grant_id, &0, &reviewers.get(2).unwrap(), &true, &None);
+    let _ = client.milestone_vote(
+        &grant_id,
+        &0,
+        &reviewers.get(2).unwrap(),
+        &true,
+        &None,
+        &None,
+    );
 }
 
 #[test]
@@ -166,6 +206,7 @@ fn test_milestone_double_voting_panics() {
         &0i128,
         &0i128,
         &soroban_sdk::Vec::<soroban_sdk::String>::new(&env),
+        &false,
     );
 
     client.grant_accept(&grant_id, &owner);
@@ -183,6 +224,20 @@ fn test_milestone_double_voting_panics() {
     env.ledger()
         .set_timestamp(ts.saturating_add(COMMUNITY_REVIEW_PERIOD).saturating_add(1));
 
-    let _ = client.milestone_vote(&grant_id, &0, &reviewers.get(0).unwrap(), &true, &None);
-    let _ = client.milestone_vote(&grant_id, &0, &reviewers.get(0).unwrap(), &true, &None);
+    let _ = client.milestone_vote(
+        &grant_id,
+        &0,
+        &reviewers.get(0).unwrap(),
+        &true,
+        &None,
+        &None,
+    );
+    let _ = client.milestone_vote(
+        &grant_id,
+        &0,
+        &reviewers.get(0).unwrap(),
+        &true,
+        &None,
+        &None,
+    );
 }

--- a/stellargrant-contracts/contracts/stellar-grants/tests/test_reputation_and_dispute_fee.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/tests/test_reputation_and_dispute_fee.rs
@@ -68,6 +68,7 @@ fn create_funded_submitted_voted(
         &0i128,
         &0i128,
         &Vec::<String>::new(env),
+        &false,
     );
     client.grant_accept(&gid, owner);
     tok_admin.mint(funder, &2000);
@@ -85,7 +86,7 @@ fn create_funded_submitted_voted(
     let now = env.ledger().timestamp();
     env.ledger()
         .set_timestamp(now + COMMUNITY_REVIEW_PERIOD + 1);
-    client.milestone_vote(&gid, &0, reviewer, &true, &None);
+    client.milestone_vote(&gid, &0, reviewer, &true, &None, &None);
     gid
 }
 

--- a/stellargrant-contracts/fuzz/fuzz_targets/grant_lifecycle.rs
+++ b/stellargrant-contracts/fuzz/fuzz_targets/grant_lifecycle.rs
@@ -35,6 +35,10 @@ fuzz_target!(|data: &[u8]| {
             reviewers,
             quorum,
             milestone_deadlines,
+            0i128,
+            0i128,
+            Vec::new(&env),
+            false,
         );
 
         let funder = Address::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHH");

--- a/stellargrant-contracts/fuzz/fuzz_targets/milestone_submit.rs
+++ b/stellargrant-contracts/fuzz/fuzz_targets/milestone_submit.rs
@@ -30,12 +30,16 @@ fuzz_target!(|data: &[u8]| {
             reviewers,
             quorum,
             None,
+            0i128,
+            0i128,
+            Vec::new(&env),
+            false,
         );
         // Fuzz milestone_submit with random description and proof_url
         let recipient = owner;
         let desc = String::from_str(&env, "desc");
         let proof = String::from_str(&env, "proof");
-        let _ = StellarGrantsContract::milestone_submit(env, 0, 0, recipient, desc, proof);
+        let _ = StellarGrantsContract::milestone_submit(env, 0, 0, recipient, desc, proof, None);
     });
     // If a panic occurred, treat as a fuzz failure only if input was not obviously invalid
     if result.is_err() && !data.is_empty() {

--- a/stellargrant-contracts/fuzz/fuzz_targets/milestone_vote.rs
+++ b/stellargrant-contracts/fuzz/fuzz_targets/milestone_vote.rs
@@ -1,21 +1,30 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use soroban_sdk::{Address, Env, String as SorobanString, Vec};
 use stellar_grants::{StellarGrantsContract, Storage};
-use soroban_sdk::{Env, Address, String as SorobanString, Vec};
 
 fuzz_target!(|data: &[u8]| {
-    if data.len() < 2 { return; }
+    if data.len() < 2 {
+        return;
+    }
 
     let env = Env::default();
 
-
-    let owner   = Address::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
-    let token   = Address::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHG");
-    let reviewer = Address::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHJ");
+    let owner = Address::from_str(
+        &env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    );
+    let token = Address::from_str(
+        &env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHG",
+    );
+    let reviewer = Address::from_str(
+        &env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHJ",
+    );
     let mut reviewers: Vec<Address> = Vec::new(&env);
     reviewers.push_back(reviewer.clone());
 
-    // Step 1: create grant — skip if invalid (not a bug)
     let milestone_amount: i128 = 10;
     let total_milestones: u32 = 1;
     let quorum: u32 = 1;
@@ -31,13 +40,15 @@ fuzz_target!(|data: &[u8]| {
         reviewers.clone(),
         quorum,
         None,
+        0i128,
+        0i128,
+        Vec::new(&env),
+        false,
     ) {
         Ok(id) => id,
         Err(_) => return,
     };
 
-
-    // Step 2: submit milestone — skip if invalid
     let milestone_idx = data[1] as u32 % 4;
     let _ = StellarGrantsContract::milestone_submit(
         env.clone(),
@@ -46,9 +57,9 @@ fuzz_target!(|data: &[u8]| {
         owner.clone(),
         SorobanString::from_str(&env, "desc"),
         SorobanString::from_str(&env, "proof"),
+        None,
     );
 
-    // Step 3: vote — this must never panic, only return Err
     let approve = data[0] % 2 == 0;
     let _ = StellarGrantsContract::milestone_vote(
         env.clone(),
@@ -57,11 +68,13 @@ fuzz_target!(|data: &[u8]| {
         reviewer.clone(),
         approve,
         None,
+        None,
     );
 
-    // Invariant: no double votes — this is the real fuzz oracle
     if let Some(milestone) = Storage::get_milestone(&env, grant_id, milestone_idx) {
-        let count = milestone.votes.iter()
+        let count = milestone
+            .votes
+            .iter()
             .filter(|(v, _)| v == &reviewer)
             .count();
         assert!(count <= 1, "Double vote invariant violated!");


### PR DESCRIPTION
## Summary

Contract work for **stellar-grants** covering three related features: grant heartbeat / inactive handling, open-bounty milestones, and milestone top-up funding.

Closes #110  
Closes #155  
Closes #156  

---

### #110 — Grant heartbeat & inactive lifecycle
- Added owner **heartbeat** via `grant_ping` so active grants can record continued engagement.
- Added **`mark_grant_inactive`** after prolonged inactivity (`HEARTBEAT_INACTIVITY_SECS`), with `HeartbeatNotStale` when the heartbeat is still fresh.
- Wired inactive checks into funding, milestone flows, and cancellation where appropriate.
- Tests for ping restoring inactive → active and permissionless inactive marking after timeout.

### #155 — Open bounty milestones
- **`is_open_bounty`** on `Grant` and `grant_create` flag.
- **`BountySubmissionEntry`** and persistent **`BountySubmissions(grant_id, milestone_idx)`** storage (get / set / remove).
- Contributor **submit** path with profile / blacklist / reputation gates, **cap** on submissions, **duplicate submitter** rejection.
- Reviewer **weighted voting** on submissions; quorum reached selects **winner**, copies proof into milestone, sets **`bounty_winner`**, clears submissions, emits **`BountyClaimed`**.
- Integration-style unit test: two contributors, distinct proofs.

### #156 — Milestone top-up funding
- **`Milestone.additional_funds`** (`Map<Address, i128>`) plus **`top_up_contributions`** (`Vec<MilestoneTopUp>`) for per-funder refunds on cancel / clawback / dispute reject / expired flows.
- **`grant_fund_milestone`** (authenticated funder, token transfer into escrow, map + ledger updates, **`MilestoneTopUpFunded`** event).
- Payout paths pay **base milestone amount + additional** per token (`internal_milestone_approve`, **`grant_withdraw`**, **`milestone_payout`**, dispute council approve path); **`finalize_grant_release`** / **`compute_total_paid_if_quorum_ready`** use primary-token totals including top-ups; milestone paid bookkeeping clears extra state where needed.
- **Cancel / clawback**: refund each top-up row to its funder, then existing pro-rata refunds on remaining escrow.
- Unit test **`test_milestone_top_up_payout_exceeds_base_amount`**; integration test funds escrow before **`milestone_payout`** in **`test_milestone_voting_quorum_and_events`**.

---

## How to test
```bash
cd stellargrant-contracts && cargo test -p stellar-grants