### PR TITLE
feat: pull-based refund_claim and milestone proof hash (#66 #78)

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -199,6 +199,30 @@ pub struct MilestoneSubmitted {
     pub timestamp: u64,
 }
 
+/// Emitted when a 32-byte proof hash is attached to a milestone via `milestone_submit_proof_hash`.
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProofHashSubmitted {
+    pub event_version: u32,
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub submitter: Address,
+    pub proof_hash: BytesN<32>,
+    pub timestamp: u64,
+}
+
+/// Emitted when a funder claims their pending refund after a grant is cancelled.
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RefundClaimed {
+    pub event_version: u32,
+    pub grant_id: u64,
+    pub funder: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub timestamp: u64,
+}
+
 #[contractevent]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BountyClaimed {
@@ -1124,6 +1148,44 @@ impl Events {
             grant_id,
             delegator,
             delegatee,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    /// Emit `ProofHashSubmitted` when a 32-byte hash is attached to a milestone.
+    pub fn emit_proof_hash_submitted(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        submitter: Address,
+        proof_hash: BytesN<32>,
+    ) {
+        let event = ProofHashSubmitted {
+            event_version: EVENT_VERSION,
+            grant_id,
+            milestone_idx,
+            submitter,
+            proof_hash,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    /// Emit `RefundClaimed` when a funder pulls their pending refund after cancellation.
+    pub fn emit_refund_claimed(
+        env: &Env,
+        grant_id: u64,
+        funder: Address,
+        amount: i128,
+        token: Address,
+    ) {
+        let event = RefundClaimed {
+            event_version: EVENT_VERSION,
+            grant_id,
+            funder,
+            amount,
+            token,
             timestamp: env.ledger().timestamp(),
         };
         event.publish(env);

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -1453,15 +1453,10 @@ impl StellarGrantsContract {
     /// each funder's pro-rata share is recorded in storage and must be claimed here.
     ///
     /// Callable by any address that has a recorded refund; the caller must be the funder.
-    pub fn refund_claim(
-        env: Env,
-        grant_id: u64,
-        funder: Address,
-    ) -> Result<(), ContractError> {
+    pub fn refund_claim(env: Env, grant_id: u64, funder: Address) -> Result<(), ContractError> {
         funder.require_auth();
         reentrancy::with_non_reentrant(&env, || {
-            let grant =
-                Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+            let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
 
             if grant.status() != GrantStatus::Cancelled {
                 return Err(ContractError::InvalidState);
@@ -1476,18 +1471,8 @@ impl StellarGrantsContract {
             for (token, amount) in pending.iter() {
                 if amount > 0 {
                     let token_client = token::Client::new(&env, &token);
-                    token_client.transfer(
-                        &env.current_contract_address(),
-                        &funder,
-                        &amount,
-                    );
-                    Events::emit_refund_claimed(
-                        &env,
-                        grant_id,
-                        funder.clone(),
-                        amount,
-                        token,
-                    );
+                    token_client.transfer(&env.current_contract_address(), &funder, &amount);
+                    Events::emit_refund_claimed(&env, grant_id, funder.clone(), amount, token);
                 }
             }
 
@@ -2294,13 +2279,7 @@ impl StellarGrantsContract {
         milestone.proof_hash = Some(proof_hash.clone());
         Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
 
-        Events::emit_proof_hash_submitted(
-            &env,
-            grant_id,
-            milestone_idx,
-            submitter,
-            proof_hash,
-        );
+        Events::emit_proof_hash_submitted(&env, grant_id, milestone_idx, submitter, proof_hash);
 
         Ok(())
     }
@@ -3388,8 +3367,7 @@ fn record_pending_refunds_for_funders(
 
         if refund_amount > 0 {
             // Append to any existing pending refunds for this funder (multiple tokens).
-            let mut pending =
-                Storage::get_pending_refund(env, grant_id, &fund_entry.funder);
+            let mut pending = Storage::get_pending_refund(env, grant_id, &fund_entry.funder);
             pending.push_back((token.clone(), refund_amount));
             Storage::set_pending_refund(env, grant_id, &fund_entry.funder, &pending);
         }

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -1100,6 +1100,7 @@ impl StellarGrantsContract {
                 bounty_winner: None,
                 additional_funds: soroban_sdk::Map::new(&env),
                 top_up_contributions: soroban_sdk::Vec::new(&env),
+                proof_hash: None,
             };
             milestone.set_idx(i);
             milestone.set_approvals(0);
@@ -1407,9 +1408,18 @@ impl StellarGrantsContract {
 
             refund_all_milestone_top_up_contributions_and_clear(&env, grant_id, &mut grant)?;
 
+            // Pull-based refund model: record each funder's entitlement instead of pushing
+            // transfers. This prevents gas exhaustion when a grant has hundreds of funders.
+            // Funders must call `refund_claim(grant_id, funder)` to receive their tokens.
             for (token, balance) in grant.escrow_balances.iter() {
                 if balance > 0 {
-                    refund_token_to_funders(&env, grant_id, &grant.funders, &token, balance)?;
+                    record_pending_refunds_for_funders(
+                        &env,
+                        grant_id,
+                        &grant.funders,
+                        &token,
+                        balance,
+                    )?;
                 }
             }
 
@@ -1436,6 +1446,58 @@ impl StellarGrantsContract {
             Ok(())
         })
     }
+    /// Claim a pending refund after a grant has been cancelled.
+    ///
+    /// Under the pull-based refund model introduced to fix the gas-limit issue in
+    /// `grant_cancel` (#66), cancellation no longer loops through all funders.  Instead,
+    /// each funder's pro-rata share is recorded in storage and must be claimed here.
+    ///
+    /// Callable by any address that has a recorded refund; the caller must be the funder.
+    pub fn refund_claim(
+        env: Env,
+        grant_id: u64,
+        funder: Address,
+    ) -> Result<(), ContractError> {
+        funder.require_auth();
+        reentrancy::with_non_reentrant(&env, || {
+            let grant =
+                Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+
+            if grant.status() != GrantStatus::Cancelled {
+                return Err(ContractError::InvalidState);
+            }
+
+            let pending = Storage::get_pending_refund(&env, grant_id, &funder);
+            if pending.is_empty() {
+                return Err(ContractError::NoRefundableAmount);
+            }
+
+            // Transfer each owed token and emit an event per token.
+            for (token, amount) in pending.iter() {
+                if amount > 0 {
+                    let token_client = token::Client::new(&env, &token);
+                    token_client.transfer(
+                        &env.current_contract_address(),
+                        &funder,
+                        &amount,
+                    );
+                    Events::emit_refund_claimed(
+                        &env,
+                        grant_id,
+                        funder.clone(),
+                        amount,
+                        token,
+                    );
+                }
+            }
+
+            // Clear the record so the funder cannot claim twice.
+            Storage::remove_pending_refund(&env, grant_id, &funder);
+
+            Ok(())
+        })
+    }
+
     pub fn grant_complete(env: Env, grant_id: u64) -> Result<(), ContractError> {
         reentrancy::with_non_reentrant(&env, || {
             let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
@@ -2186,6 +2248,63 @@ impl StellarGrantsContract {
         Storage::set_grant(&env, grant_id, &grant);
         Ok(())
     }
+    /// Attach a 32-byte cryptographic proof hash to an already-submitted milestone.
+    ///
+    /// The `proof_hash` is expected to be a raw 32-byte representation of an IPFS CIDv1
+    /// (multihash digest) or a Git commit SHA-256. Any 32-byte value is accepted on-chain;
+    /// format validation is the responsibility of the caller.
+    ///
+    /// Can be called multiple times to update a malformed hash before the milestone is approved.
+    /// Only the milestone submitter (grant owner or bounty winner) may call this.
+    pub fn milestone_submit_proof_hash(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        submitter: Address,
+        proof_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        submitter.require_auth();
+        assert_not_paused(&env)?;
+
+        let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+
+        if grant.status() != GrantStatus::Active {
+            return Err(ContractError::InvalidState);
+        }
+
+        let mut milestone = Storage::get_milestone(&env, grant_id, milestone_idx)
+            .ok_or(ContractError::MilestoneNotFound)?;
+
+        // Only the grant owner (or bounty winner if set) may attach a hash.
+        let authorised = if let Some(ref winner) = milestone.bounty_winner {
+            submitter == *winner
+        } else {
+            submitter == grant.owner
+        };
+        if !authorised {
+            return Err(ContractError::Unauthorized);
+        }
+
+        // Milestone must be submitted or in community review to accept a hash.
+        match milestone.state() {
+            MilestoneState::Submitted | MilestoneState::CommunityReview => {}
+            _ => return Err(ContractError::MilestoneNotSubmitted),
+        }
+
+        milestone.proof_hash = Some(proof_hash.clone());
+        Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
+
+        Events::emit_proof_hash_submitted(
+            &env,
+            grant_id,
+            milestone_idx,
+            submitter,
+            proof_hash,
+        );
+
+        Ok(())
+    }
+
     pub fn milestone_submit_batch(
         env: Env,
         grant_id: u64,
@@ -3220,6 +3339,63 @@ fn has_token_funders(funders: &Vec<GrantFund>, token: &Address) -> bool {
         }
     }
     false
+}
+
+/// Pull-based refund accounting (issue #66).
+///
+/// Instead of looping through all funders and pushing token transfers — which
+/// exceeds the Soroban gas limit for grants with many funders — this helper
+/// records each funder's pro-rata entitlement in persistent storage.  The
+/// actual token transfers happen lazily when each funder calls `refund_claim`.
+fn record_pending_refunds_for_funders(
+    env: &Env,
+    grant_id: u64,
+    funders: &Vec<GrantFund>,
+    token: &Address,
+    refundable_amount: i128,
+) -> Result<(), ContractError> {
+    let mut total_token_contributions: i128 = 0;
+    let mut token_funders = soroban_sdk::Vec::new(env);
+    for fund_entry in funders.iter() {
+        if fund_entry.token == *token {
+            total_token_contributions += fund_entry.amount;
+            token_funders.push_back(fund_entry);
+        }
+    }
+
+    if total_token_contributions == 0 {
+        return Ok(());
+    }
+
+    let token_funders_len = token_funders.len();
+    let mut distributed = 0i128;
+
+    for i in 0..token_funders_len {
+        let fund_entry = funder_entry_at(&token_funders, i)?;
+        let is_last = i + 1 == token_funders_len;
+        let refund_amount = if is_last {
+            refundable_amount - distributed
+        } else {
+            let amount = fund_entry
+                .amount
+                .checked_mul(refundable_amount)
+                .ok_or(ContractError::InvalidInput)?
+                .checked_div(total_token_contributions)
+                .ok_or(ContractError::InvalidInput)?;
+            distributed += amount;
+            amount
+        };
+
+        if refund_amount > 0 {
+            // Append to any existing pending refunds for this funder (multiple tokens).
+            let mut pending =
+                Storage::get_pending_refund(env, grant_id, &fund_entry.funder);
+            pending.push_back((token.clone(), refund_amount));
+            Storage::set_pending_refund(env, grant_id, &fund_entry.funder, &pending);
+        }
+    }
+
+    Ok(())
 }
 
 fn refund_token_to_funders(

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -36,6 +36,8 @@ pub enum DataKey {
     RoleMemberCount(u32),
     ExtensionRequest(u64, u32),
     BountySubmissions(u64, u32),
+    /// Pending refund for a funder after grant cancellation: (grant_id, funder) -> Vec<(token, amount)>.
+    PendingRefund(u64, soroban_sdk::Address),
 }
 
 pub struct Storage;
@@ -591,5 +593,38 @@ impl Storage {
         env.storage()
             .persistent()
             .remove(&DataKey::ExtensionRequest(grant_id, milestone_idx));
+    }
+
+    // ── Pull-based refund helpers (issue #66) ─────────────────────────────
+
+    /// Returns the pending refunds owed to `funder` for a cancelled grant.
+    /// Each entry is `(token_address, amount)`.
+    pub fn get_pending_refund(
+        env: &Env,
+        grant_id: u64,
+        funder: &soroban_sdk::Address,
+    ) -> Vec<(soroban_sdk::Address, i128)> {
+        let key = DataKey::PendingRefund(grant_id, funder.clone());
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(env))
+    }
+
+    pub fn set_pending_refund(
+        env: &Env,
+        grant_id: u64,
+        funder: &soroban_sdk::Address,
+        refunds: &Vec<(soroban_sdk::Address, i128)>,
+    ) {
+        let key = DataKey::PendingRefund(grant_id, funder.clone());
+        env.storage().persistent().set(&key, refunds);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn remove_pending_refund(env: &Env, grant_id: u64, funder: &soroban_sdk::Address) {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::PendingRefund(grant_id, funder.clone()));
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/test.rs
@@ -1189,7 +1189,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &m1);
@@ -1211,7 +1211,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 1, &m2);
@@ -1285,7 +1285,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &m1);
@@ -1628,7 +1628,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -3318,7 +3318,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
@@ -3877,7 +3877,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -3932,7 +3932,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -3984,7 +3984,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -4034,7 +4034,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -4081,7 +4081,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -4168,7 +4168,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
-                    proof_hash: None,
+                proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -6551,11 +6551,7 @@ mod tests {
             setup_funded_grant(&env, &client, &token, &contract_id, &tok);
 
         // Cancel the grant — should NOT push transfers immediately
-        client.grant_cancel(
-            &grant_id,
-            &owner,
-            &String::from_str(&env, "shutting down"),
-        );
+        client.grant_cancel(&grant_id, &owner, &String::from_str(&env, "shutting down"));
 
         let balance_before = token_client.balance(&funder);
 
@@ -6563,7 +6559,10 @@ mod tests {
         client.refund_claim(&grant_id, &funder);
 
         let balance_after = token_client.balance(&funder);
-        assert!(balance_after > balance_before, "funder should have received tokens");
+        assert!(
+            balance_after > balance_before,
+            "funder should have received tokens"
+        );
     }
 
     #[test]
@@ -6593,11 +6592,7 @@ mod tests {
         let (grant_id, owner, _funder) =
             setup_funded_grant(&env, &client, &token, &contract_id, &tok);
 
-        client.grant_cancel(
-            &grant_id,
-            &owner,
-            &String::from_str(&env, "done"),
-        );
+        client.grant_cancel(&grant_id, &owner, &String::from_str(&env, "done"));
 
         // A non-funder has no pending refund
         let outsider = Address::generate(&env);
@@ -6616,11 +6611,7 @@ mod tests {
         let (grant_id, owner, funder) =
             setup_funded_grant(&env, &client, &token, &contract_id, &tok);
 
-        client.grant_cancel(
-            &grant_id,
-            &owner,
-            &String::from_str(&env, "done"),
-        );
+        client.grant_cancel(&grant_id, &owner, &String::from_str(&env, "done"));
 
         // First claim succeeds
         client.refund_claim(&grant_id, &funder);

--- a/stellargrant-contracts/contracts/stellar-grants/src/test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/test.rs
@@ -743,6 +743,10 @@ mod tests {
         let reason = String::from_str(&env, "Project discontinued");
         client.grant_cancel(&grant_id, &owner, &reason);
 
+        // Pull-based refund: each funder must claim their refund.
+        client.refund_claim(&grant_id, &funder1);
+        client.refund_claim(&grant_id, &funder2);
+
         let token_client = token::Client::new(&env, &token_id);
         assert_eq!(token_client.balance(&funder1), 600);
         assert_eq!(token_client.balance(&funder2), 400);
@@ -880,6 +884,9 @@ mod tests {
         let reason = String::from_str(&env, "Malicious behavior detected");
         client.cancel_grant(&grant_id, &global_admin, &reason);
 
+        // Pull-based refund: funder must claim.
+        client.refund_claim(&grant_id, &funder);
+
         let token_client = token::Client::new(&env, &token_id);
         assert_eq!(token_client.balance(&funder), 500);
     }
@@ -999,6 +1006,11 @@ mod tests {
 
         client.cancel_grant(&grant_id, &owner, &String::from_str(&env, "Cancelled"));
 
+        // Pull-based refund.
+        client.refund_claim(&grant_id, &f1);
+        client.refund_claim(&grant_id, &f2);
+        client.refund_claim(&grant_id, &f3);
+
         let token_client = token::Client::new(&env, &token_id);
         assert_eq!(token_client.balance(&f1), 33);
         assert_eq!(token_client.balance(&f2), 33);
@@ -1087,6 +1099,7 @@ mod tests {
                     packed_stats: 0,
                     additional_funds: Map::new(&env),
                     top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                     bounty_winner: None,
                 };
                 Storage::set_milestone(&env, grant_id, i, &milestone);
@@ -1176,6 +1189,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &m1);
@@ -1197,6 +1211,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 1, &m2);
@@ -1270,6 +1285,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &m1);
@@ -1340,6 +1356,7 @@ mod tests {
                     packed_stats: 0,
                     additional_funds: Map::new(&env),
                     top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                     bounty_winner: None,
                 };
                 Storage::set_milestone(&env, grant_id, i, &milestone);
@@ -1412,6 +1429,7 @@ mod tests {
                     packed_stats: 0,
                     additional_funds: Map::new(&env),
                     top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                     bounty_winner: None,
                 };
                 Storage::set_milestone(&env, grant_id, i, &milestone);
@@ -1610,6 +1628,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -1873,6 +1892,7 @@ mod tests {
                     packed_stats: 0,
                     additional_funds: Map::new(&env),
                     top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                     bounty_winner: None,
                 };
                 milestone.set_idx(idx);
@@ -3298,6 +3318,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
@@ -3856,6 +3877,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -3910,6 +3932,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -3961,6 +3984,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -4010,6 +4034,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -4056,6 +4081,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -4142,6 +4168,7 @@ mod tests {
                 packed_stats: 0,
                 additional_funds: Map::new(&env),
                 top_up_contributions: Vec::new(&env),
+                    proof_hash: None,
                 bounty_winner: None,
             };
             Storage::set_milestone(&env, grant_id, 0, &milestone);
@@ -4388,7 +4415,7 @@ mod tests {
         // Advance past the 7-day grace period
         env.ledger().set_timestamp(crate::CANCEL_GRACE_PERIOD + 1);
 
-        // Second call → should now execute the refund
+        // Second call → should now record pending refunds (pull model)
         client.grant_cancel(&grant_id, &owner, &String::from_str(&env, "Going away"));
 
         env.as_contract(&contract_id, || {
@@ -4400,7 +4427,9 @@ mod tests {
             );
         });
 
-        // Funder should have received their tokens back
+        // Pull-based refund: funder claims their tokens.
+        client.refund_claim(&grant_id, &funder);
+
         let token_client = token::Client::new(&env, &token_id);
         assert_eq!(token_client.balance(&funder), 500);
     }
@@ -5949,6 +5978,10 @@ mod tests {
             &String::from_str(&env, "Not enough funding"),
         );
 
+        // Pull-based refund: each funder claims their respective token.
+        client.refund_claim(&grant_id, &funder1);
+        client.refund_claim(&grant_id, &funder2);
+
         // Verify refunds
         assert_eq!(token_a_client.balance(&funder1), 1000);
         assert_eq!(token_b_client.balance(&funder2), 1000);
@@ -6465,5 +6498,284 @@ mod tests {
 
         let r = client.try_mark_grant_inactive(&grant_id);
         assert_eq!(r, Err(Ok(ContractError::HeartbeatNotStale.into())));
+    }
+
+    // ── Tests for pull-based refund_claim (#66) ─────────────────────────────
+
+    fn setup_funded_grant<'a>(
+        env: &'a Env,
+        client: &StellarGrantsContractClient<'a>,
+        token: &Address,
+        contract_id: &Address,
+        tok: &token::StellarAssetClient<'a>,
+    ) -> (u64, Address, Address) {
+        let owner = Address::generate(env);
+        let reviewer = Address::generate(env);
+        let funder = Address::generate(env);
+        let mut reviewers = Vec::new(env);
+        reviewers.push_back(reviewer.clone());
+
+        let grant_id = client.grant_create(
+            &owner,
+            &String::from_str(env, "Pull Refund Grant"),
+            &String::from_str(env, "Desc"),
+            token,
+            &1000i128,
+            &500i128,
+            &1u32,
+            &reviewers,
+            &1u32,
+            &None,
+            &0i128,
+            &0i128,
+            &Vec::<String>::new(env),
+            &false,
+        );
+        client.grant_accept(&grant_id, &owner);
+        tok.mint(&funder, &600);
+        tok.mint(contract_id, &5000);
+        client.grant_fund(&grant_id, &funder, &600i128, token, &None);
+        (grant_id, owner, funder)
+    }
+
+    #[test]
+    fn test_refund_claim_succeeds_after_cancel() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+        let token_client = token::Client::new(&env, &token);
+
+        let (grant_id, owner, funder) =
+            setup_funded_grant(&env, &client, &token, &contract_id, &tok);
+
+        // Cancel the grant — should NOT push transfers immediately
+        client.grant_cancel(
+            &grant_id,
+            &owner,
+            &String::from_str(&env, "shutting down"),
+        );
+
+        let balance_before = token_client.balance(&funder);
+
+        // Funder claims their refund
+        client.refund_claim(&grant_id, &funder);
+
+        let balance_after = token_client.balance(&funder);
+        assert!(balance_after > balance_before, "funder should have received tokens");
+    }
+
+    #[test]
+    fn test_refund_claim_fails_on_non_cancelled_grant() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+
+        let (grant_id, _owner, funder) =
+            setup_funded_grant(&env, &client, &token, &contract_id, &tok);
+
+        // Grant is still Active — refund_claim should fail
+        let result = client.try_refund_claim(&grant_id, &funder);
+        assert_eq!(result, Err(Ok(ContractError::InvalidState.into())));
+    }
+
+    #[test]
+    fn test_refund_claim_fails_when_no_pending_refund() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+
+        let (grant_id, owner, _funder) =
+            setup_funded_grant(&env, &client, &token, &contract_id, &tok);
+
+        client.grant_cancel(
+            &grant_id,
+            &owner,
+            &String::from_str(&env, "done"),
+        );
+
+        // A non-funder has no pending refund
+        let outsider = Address::generate(&env);
+        let result = client.try_refund_claim(&grant_id, &outsider);
+        assert_eq!(result, Err(Ok(ContractError::NoRefundableAmount.into())));
+    }
+
+    #[test]
+    fn test_refund_claim_is_idempotency_protected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+
+        let (grant_id, owner, funder) =
+            setup_funded_grant(&env, &client, &token, &contract_id, &tok);
+
+        client.grant_cancel(
+            &grant_id,
+            &owner,
+            &String::from_str(&env, "done"),
+        );
+
+        // First claim succeeds
+        client.refund_claim(&grant_id, &funder);
+
+        // Second claim fails — record was removed
+        let result = client.try_refund_claim(&grant_id, &funder);
+        assert_eq!(result, Err(Ok(ContractError::NoRefundableAmount.into())));
+    }
+
+    // ── Tests for milestone_submit_proof_hash (#78) ─────────────────────────
+
+    #[test]
+    fn test_proof_hash_submission_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+        tok.mint(&contract_id, &5000);
+
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+
+        let grant_id = client.grant_create(
+            &owner,
+            &String::from_str(&env, "Hash Grant"),
+            &String::from_str(&env, "Desc"),
+            &token,
+            &1000i128,
+            &500i128,
+            &1u32,
+            &reviewers,
+            &1u32,
+            &None,
+            &0i128,
+            &0i128,
+            &Vec::<String>::new(&env),
+            &false,
+        );
+        client.grant_accept(&grant_id, &owner);
+        tok.mint(&owner, &1000);
+        client.grant_fund(&grant_id, &owner, &1000i128, &token, &None);
+
+        // Submit the milestone first
+        client.milestone_submit(
+            &grant_id,
+            &0u32,
+            &owner,
+            &String::from_str(&env, "Work done"),
+            &String::from_str(&env, "https://proof.url"),
+            &None,
+        );
+
+        // Attach a 32-byte proof hash
+        let hash = BytesN::<32>::from_array(&env, &[0xabu8; 32]);
+        client.milestone_submit_proof_hash(&grant_id, &0u32, &owner, &hash);
+
+        // Verify the hash is stored
+        let milestone = client.get_milestone(&grant_id, &0u32);
+        assert_eq!(milestone.proof_hash, Some(hash));
+    }
+
+    #[test]
+    fn test_proof_hash_resubmission_updates_value() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+        tok.mint(&contract_id, &5000);
+
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+
+        let grant_id = client.grant_create(
+            &owner,
+            &String::from_str(&env, "Hash Grant 2"),
+            &String::from_str(&env, "Desc"),
+            &token,
+            &1000i128,
+            &500i128,
+            &1u32,
+            &reviewers,
+            &1u32,
+            &None,
+            &0i128,
+            &0i128,
+            &Vec::<String>::new(&env),
+            &false,
+        );
+        client.grant_accept(&grant_id, &owner);
+        tok.mint(&owner, &1000);
+        client.grant_fund(&grant_id, &owner, &1000i128, &token, &None);
+
+        client.milestone_submit(
+            &grant_id,
+            &0u32,
+            &owner,
+            &String::from_str(&env, "Work done"),
+            &String::from_str(&env, "https://proof.url"),
+            &None,
+        );
+
+        let first_hash = BytesN::<32>::from_array(&env, &[0x01u8; 32]);
+        client.milestone_submit_proof_hash(&grant_id, &0u32, &owner, &first_hash);
+
+        // Re-submit with corrected hash
+        let corrected_hash = BytesN::<32>::from_array(&env, &[0x02u8; 32]);
+        client.milestone_submit_proof_hash(&grant_id, &0u32, &owner, &corrected_hash);
+
+        let milestone = client.get_milestone(&grant_id, &0u32);
+        assert_eq!(milestone.proof_hash, Some(corrected_hash));
+    }
+
+    #[test]
+    fn test_proof_hash_rejected_for_non_submitted_milestone() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, contract_id) = setup_test(&env);
+        let token = register_sep41_token(&env, admin.clone());
+        let tok = token::StellarAssetClient::new(&env, &token);
+        tok.mint(&contract_id, &5000);
+
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+
+        let grant_id = client.grant_create(
+            &owner,
+            &String::from_str(&env, "Hash Grant 3"),
+            &String::from_str(&env, "Desc"),
+            &token,
+            &1000i128,
+            &500i128,
+            &1u32,
+            &reviewers,
+            &1u32,
+            &None,
+            &0i128,
+            &0i128,
+            &Vec::<String>::new(&env),
+            &false,
+        );
+        client.grant_accept(&grant_id, &owner);
+        tok.mint(&owner, &1000);
+        client.grant_fund(&grant_id, &owner, &1000i128, &token, &None);
+
+        // Milestone is still Pending — cannot attach hash
+        let hash = BytesN::<32>::from_array(&env, &[0xffu8; 32]);
+        let result = client.try_milestone_submit_proof_hash(&grant_id, &0u32, &owner, &hash);
+        assert_eq!(result, Err(Ok(ContractError::MilestoneNotSubmitted.into())));
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracterror, contracttype, Address, Map, String, Vec};
+use soroban_sdk::{contracterror, contracttype, Address, BytesN, Map, String, Vec};
 #[contracterror]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]
@@ -227,6 +227,9 @@ pub struct Milestone {
     pub additional_funds: Map<Address, i128>,
     /// Per-deposit ledger so milestone top-ups can be refunded to the original funders on cancel.
     pub top_up_contributions: Vec<MilestoneTopUp>,
+    /// Optional 32-byte cryptographic hash of the milestone proof (e.g. IPFS CID or Git commit SHA).
+    /// Set via `milestone_submit_proof_hash`; `None` until explicitly provided.
+    pub proof_hash: Option<BytesN<32>>,
 }
 
 #[contracttype]
@@ -278,6 +281,7 @@ impl Milestone {
             bounty_winner: None,
             additional_funds,
             top_up_contributions,
+            proof_hash: None,
         };
         ms.set_idx(idx);
         ms.set_approvals(approvals);


### PR DESCRIPTION
Fixes #66
Fixes #78

## What changed

### #66 — Pull-based refund model for `grant_cancel`

**Problem:** `grant_cancel` called `refund_token_to_funders()` which loops through all funders and pushes token transfers. With hundreds of funders this hits Soroban's instruction/memory gas limit, bricking the grant.

**Solution:** Replace the push loop with pull-based accounting:

- `cancel_grant` now calls `record_pending_refunds_for_funders()` which writes each funder's pro-rata entitlement to `PendingRefund(grant_id, funder)` persistent storage — same proportional math, no token transfers at cancel time.
- New `refund_claim(grant_id, funder)` public function lets each funder pull their own tokens at any time after cancellation. Clears the storage record after transfer to prevent double claims.
- Added `DataKey::PendingRefund(u64, Address)` and three helpers (`get_pending_refund`, `set_pending_refund`, `remove_pending_refund`) to `storage.rs`.
- Added `RefundClaimed` event struct and `emit_refund_claimed()` to `events.rs`.
- Updated 5 existing cancel tests to add `refund_claim` calls (tests that checked funder balances after cancel).
- Added 4 new tests: success, failure on non-cancelled grant, failure for non-funder, and idempotency protection (second claim fails).

### #78 — Milestone proof hash submission

**Problem:** `proof_url` is an unvalidated `String`. The contract needs a structured cryptographic commitment for the milestone proof.

**Solution:**

- Added `proof_hash: Option<BytesN<32>>` to `Milestone` struct in `types.rs`. Field is `None` until explicitly set.
- New `milestone_submit_proof_hash(grant_id, milestone_idx, submitter, proof_hash: BytesN<32>)` public function:
  - Validates grant is `Active`
  - Validates milestone is `Submitted` or `CommunityReview`
  - Only grant owner (or bounty winner if set) may submit
  - Can be called multiple times to correct a malformed hash before approval
- Added `ProofHashSubmitted` event and `emit_proof_hash_submitted()` to `events.rs`.
- Added 3 new tests: successful hash submission with storage verification, re-submission overwrites the first value, rejection when milestone is still `Pending`.

## Test results
```
172 passed; 0 failed; 0 ignored
```