### PR TITLE
feat: SDK Enhancements (Wallet Adapters, Dynamic Fees, Footprints, Event Stream)

### DIFF
--- a/client/src/StellarGrantsSDK.ts
+++ b/client/src/StellarGrantsSDK.ts
@@ -36,7 +36,7 @@ export class StellarGrantsSDK {
   /**
    * Creates a new grant.
    */
-  async grantCreate(input: GrantCreateInput): Promise<unknown> {
+  async grantCreate(input: GrantCreateInput, options?: any): Promise<unknown> {
     return this.invokeWrite("grant_create", [
       nativeToScVal(input.owner, { type: "address" }),
       nativeToScVal(input.title),
@@ -44,40 +44,40 @@ export class StellarGrantsSDK {
       nativeToScVal(input.budget, { type: "i128" }),
       nativeToScVal(input.deadline, { type: "u64" }),
       nativeToScVal(input.milestoneCount, { type: "u32" }),
-    ]);
+    ], options);
   }
 
   /**
    * Funds an existing grant.
    */
-  async grantFund(input: GrantFundInput): Promise<unknown> {
+  async grantFund(input: GrantFundInput, options?: any): Promise<unknown> {
     return this.invokeWrite("grant_fund", [
       nativeToScVal(input.grantId, { type: "u32" }),
       nativeToScVal(input.token, { type: "address" }),
       nativeToScVal(input.amount, { type: "i128" }),
-    ]);
+    ], options);
   }
 
   /**
    * Submits milestone proof for a grant.
    */
-  async milestoneSubmit(input: MilestoneSubmitInput): Promise<unknown> {
+  async milestoneSubmit(input: MilestoneSubmitInput, options?: any): Promise<unknown> {
     return this.invokeWrite("milestone_submit", [
       nativeToScVal(input.grantId, { type: "u32" }),
       nativeToScVal(input.milestoneIdx, { type: "u32" }),
       nativeToScVal(input.proofHash),
-    ]);
+    ], options);
   }
 
   /**
    * Casts an approval/rejection vote for a milestone.
    */
-  async milestoneVote(input: MilestoneVoteInput): Promise<unknown> {
+  async milestoneVote(input: MilestoneVoteInput, options?: any): Promise<unknown> {
     return this.invokeWrite("milestone_vote", [
       nativeToScVal(input.grantId, { type: "u32" }),
       nativeToScVal(input.milestoneIdx, { type: "u32" }),
       nativeToScVal(input.approve),
-    ]);
+    ], options);
   }
 
   /**
@@ -108,13 +108,50 @@ export class StellarGrantsSDK {
     }
   }
 
-  private async invokeWrite(method: string, args: xdr.ScVal[]): Promise<unknown> {
-    try {
-      const tx = await this.buildTx(method, args);
-      const simulation = await this.server.simulateTransaction(tx);
-      this.ensureSimulationSuccess(simulation);
+  public async simulateTransaction(method: string, args: xdr.ScVal[]): Promise<any> {
+    const tx = await this.buildTx(method, args);
+    const simulation = await this.server.simulateTransaction(tx);
+    this.ensureSimulationSuccess(simulation);
+    return simulation;
+  }
 
-      const prepared = await this.server.prepareTransaction(tx);
+  private async invokeWrite(
+    method: string, 
+    args: xdr.ScVal[],
+    options?: {
+      feeMultiplier?: number;
+      transactionData?: string | xdr.SorobanTransactionData;
+      simulatedFee?: string;
+    }
+  ): Promise<unknown> {
+    try {
+      let finalFee = this.config.defaultFee ?? "100";
+      let manualSim = false;
+
+      if (!options?.transactionData || options?.feeMultiplier) {
+        const txForSim = await this.buildTx(method, args);
+        const simulation = await this.server.simulateTransaction(txForSim);
+        this.ensureSimulationSuccess(simulation);
+        
+        if (options?.feeMultiplier) {
+          finalFee = String(Math.ceil(Number(simulation.minResourceFee) * options.feeMultiplier));
+        } else {
+          finalFee = String(Number(simulation.minResourceFee || 0) + 10000);
+        }
+        manualSim = true;
+      }
+
+      if (options?.simulatedFee && !options?.feeMultiplier) {
+        finalFee = options.simulatedFee;
+      }
+
+      const tx = await this.buildTx(method, args, finalFee, options?.transactionData);
+      let prepared = tx;
+
+      if (!options?.transactionData) {
+        prepared = await this.server.prepareTransaction(tx);
+      }
+
       const signedXdr = await this.config.signer.signTransaction(
         prepared.toXDR(),
         this.config.networkPassphrase,
@@ -131,16 +168,21 @@ export class StellarGrantsSDK {
     }
   }
 
-  private async buildTx(method: string, args: xdr.ScVal[]) {
+  private async buildTx(method: string, args: xdr.ScVal[], overrideFee?: string, sorobanData?: string | xdr.SorobanTransactionData) {
     const source = await this.config.signer.getPublicKey();
     const account = await this.server.getAccount(source);
-    return new TransactionBuilder(account, {
-      fee: this.config.defaultFee ?? "100",
+    const builder = new TransactionBuilder(account, {
+      fee: overrideFee ?? this.config.defaultFee ?? "100",
       networkPassphrase: this.config.networkPassphrase,
     })
       .addOperation(this.contract.call(method, ...args))
-      .setTimeout(60)
-      .build();
+      .setTimeout(60);
+      
+    if (sorobanData) {
+      builder.setSorobanData(sorobanData);
+    }
+      
+    return builder.build();
   }
 
   private ensureSimulationSuccess(simulation: any) {
@@ -153,5 +195,53 @@ export class StellarGrantsSDK {
     const retval = simulation?.result?.retval;
     if (!retval) return null;
     return scValToNative(retval);
+  }
+
+  public subscribeToEvents(
+    callback: (event: any) => void,
+    options?: { eventName?: string; startLedger?: number },
+  ): () => void {
+    let active = true;
+    let currentCursor: string | undefined = undefined;
+
+    const poll = async () => {
+      if (!active) return;
+      try {
+        const req: any = {
+           filters: [{ type: "contract", contractIds: [this.config.contractId] }],
+        };
+        if (!currentCursor && options?.startLedger) {
+          req.startLedger = options.startLedger;
+        }
+        if (currentCursor) {
+          req.pagination = { cursor: currentCursor };
+        }
+        
+        const response = await this.server.getEvents(req);
+        if (response.events) {
+          for (const ev of response.events) {
+            currentCursor = ev.id || ev.pagingToken || currentCursor; 
+            
+            if (options?.eventName) {
+              const topicMatches = ev.topic && ev.topic.some((t: string) => {
+                 try { 
+                    const scVal = xdr.ScVal.fromXDR(t, "base64");
+                    const parsed = scValToNative(scVal);
+                    return parsed === options.eventName || String(parsed) === options.eventName;
+                 } catch { return false; }
+              });
+              if (!topicMatches) continue;
+            }
+            callback(ev);
+          }
+        }
+      } catch (err) {
+         console.warn("Event poll error, continuing...", err);
+      }
+      if (active) setTimeout(poll, 5000);
+    };
+    
+    poll();
+    return () => { active = false; };
   }
 }

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,4 +1,8 @@
 export { StellarGrantsSDK } from "./StellarGrantsSDK";
+export * from "./types";
+export * from "./errors/StellarGrantsError";
+export * from "./errors/parseSorobanError";
+export * from "./wallets";
 export { parseSorobanError } from "./errors/parseSorobanError";
 export { SorobanRevertError, StellarGrantsError } from "./errors/StellarGrantsError";
 export type {
@@ -7,5 +11,5 @@ export type {
   MilestoneSubmitInput,
   MilestoneVoteInput,
   StellarGrantsSDKConfig,
-  StellarGrantsSigner,
+  WalletAdapter,
 } from "./types";

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,13 +1,13 @@
-export type StellarGrantsSigner = {
+export interface WalletAdapter {
   getPublicKey(): Promise<string>;
   signTransaction(txXdr: string, networkPassphrase: string): Promise<string>;
-};
+}
 
 export type StellarGrantsSDKConfig = {
   contractId: string;
   rpcUrl: string;
   networkPassphrase: string;
-  signer: StellarGrantsSigner;
+  signer: WalletAdapter;
   defaultFee?: string;
 };
 

--- a/client/src/wallets/AlbedoAdapter.ts
+++ b/client/src/wallets/AlbedoAdapter.ts
@@ -1,0 +1,39 @@
+import { WalletAdapter } from "../types";
+
+export class AlbedoAdapter implements WalletAdapter {
+  private publicKeyCache: string | null = null;
+  private network: "testnet" | "public" = "testnet";
+
+  constructor(networkPassphrase?: string) {
+    if (networkPassphrase?.includes("Public")) {
+      this.network = "public";
+    }
+  }
+
+  async getPublicKey(): Promise<string> {
+    if (this.publicKeyCache) return this.publicKeyCache;
+    const albedo = (window as any).albedo;
+    if (!albedo) throw new Error("Albedo is not installed or available");
+
+    const response = await albedo.publicKey({});
+    this.publicKeyCache = response.pubkey;
+    return response.pubkey;
+  }
+
+  async signTransaction(txXdr: string, networkPassphrase: string): Promise<string> {
+    const albedo = (window as any).albedo;
+    if (!albedo) throw new Error("Albedo is not installed or available");
+
+    let network = "testnet";
+    if (networkPassphrase.includes("Public")) {
+      network = "public";
+    }
+
+    const response = await albedo.tx({
+      xdr: txXdr,
+      network,
+    });
+
+    return response.signed_envelope_xdr;
+  }
+}

--- a/client/src/wallets/FreighterAdapter.ts
+++ b/client/src/wallets/FreighterAdapter.ts
@@ -1,0 +1,45 @@
+import { WalletAdapter } from "../types";
+
+export class FreighterAdapter implements WalletAdapter {
+  async getPublicKey(): Promise<string> {
+    const isAllowed = await (window as any).freighterApi?.setAllowed();
+    if (!isAllowed) {
+      throw new Error("Freighter not allowed or installed");
+    }
+    const result = await (window as any).freighterApi?.getPublicKey();
+    if (result) return result;
+    throw new Error("No public key returned by Freighter");
+  }
+
+  async signTransaction(txXdr: string, networkPassphrase: string): Promise<string> {
+    // network: "TESTNET" | "PUBLIC" | "FUTURENET"
+    // freighter expects network string instead of passphrase mostly, but accepts both in newer versions
+    let network = "TESTNET";
+    if (networkPassphrase.includes("Public")) {
+      network = "PUBLIC";
+    }
+
+    const { getNetworkDetails } = (window as any).freighterApi || {};
+    if (getNetworkDetails) {
+      const details = await getNetworkDetails();
+      if (details.networkPassphrase !== networkPassphrase) {
+        throw new Error(`Freighter is on wrong network. Expected: ${networkPassphrase}`);
+      }
+      network = details.network;
+    }
+
+    const signed = await (window as any).freighterApi?.signTransaction(txXdr, {
+      network,
+      networkPassphrase,
+    });
+    
+    // Some versions return raw xdr or an object
+    if (!signed) throw new Error("Failed to sign transaction with Freighter");
+    // Depending on Freighter api standard (v1 vs v2)
+    // usually signTransaction resolves to a signed XDR string
+    if (typeof signed === "string") return signed;
+    if (signed instanceof Object && Buffer.isBuffer(signed)) return signed.toString('base64');
+    // If wrapping object
+    return signed as string;
+  }
+}

--- a/client/src/wallets/index.ts
+++ b/client/src/wallets/index.ts
@@ -1,0 +1,2 @@
+export * from "./FreighterAdapter";
+export * from "./AlbedoAdapter";


### PR DESCRIPTION
## Description
This PR fundamentally enhances the StellarGrants client SDK by wrapping up four requested core functionality improvements into a single pipeline. 

## Changes Made
* **Multiple Wallet Providers (#229):** Refactored the [StellarGrantsSDKConfig](cci:2://file:///home/nanle/Desktop/OpenSource/drips/StellarGrant-fe/client/src/types/index.ts:5:0-11:2) to accept a standardized [WalletAdapter](cci:2://file:///home/nanle/Desktop/OpenSource/drips/StellarGrant-fe/client/src/types/index.ts:0:0-3:1) interface. Added built-in global implementations for [FreighterAdapter](cci:2://file:///home/nanle/Desktop/OpenSource/drips/StellarGrant-fe/client/src/wallets/FreighterAdapter.ts:2:0-44:1) and [AlbedoAdapter](cci:2://file:///home/nanle/Desktop/OpenSource/drips/StellarGrant-fe/client/src/wallets/AlbedoAdapter.ts:2:0-38:1) out of the box.
* **Dynamic Fee Estimation (#232):** Modified [invokeWrite](cci:1://file:///home/nanle/Desktop/OpenSource/drips/StellarGrant-fe/client/src/StellarGrantsSDK.ts:117:2-168:3) to utilize the `minResourceFee` generated by RPC simulations. Added a `feeMultiplier` config option to let developers bump execution fees automatically. 
* **Footprint Management (#236):** Exposed the internal [simulateTransaction()](cci:1://file:///home/nanle/Desktop/OpenSource/drips/StellarGrant-fe/client/tests/sdk.test.ts:10:4-15:5) utility to allow manual footprint simulation. [invokeWrite](cci:1://file:///home/nanle/Desktop/OpenSource/drips/StellarGrant-fe/client/src/StellarGrantsSDK.ts:117:2-168:3) now accepts an injected `transactionData` footprint so developers can avoid redundant simulations during preparation. 
* **Contract Event Stream Listener (#235):** Implemented an async [subscribeToEvents(callback, options)](cci:1://file:///home/nanle/Desktop/OpenSource/drips/StellarGrant-fe/client/src/StellarGrantsSDK.ts:199:2-245:3) mechanism that recursively polls the network for new events based on standard cursors.

## Testing & Verification
- Unit and read/write mock tests pass successfully (`npm run test`).
- TypeScript definitions compile securely (`npm run build`).

Closes #229
Closes #232
Closes #235
Closes #236
