### PR TITLE
feat: add WalletConnect/xBull adapters, fee estimation, and SDK versioning

### DIFF
--- a/client/src/StellarGrantsSDK.ts
+++ b/client/src/StellarGrantsSDK.ts
@@ -10,6 +10,8 @@ import {
 import { parseSorobanError } from "./errors/parseSorobanError";
 import { StellarGrantsError } from "./errors/StellarGrantsError";
 import {
+  FeeEstimate,
+  FeePriority,
   GrantCreateInput,
   GrantFundInput,
   MilestoneSubmitInput,
@@ -24,11 +26,28 @@ const READ_ONLY_SIMULATION_ACCOUNT =
   "GB3KJPLFUYN5VL6R3GU3EGCGVCKFDSD7BEDX42HWG5BWFKB3KQGJJRMA";
 
 /**
+ * The SDK's current contract interface version.
+ *
+ * Increment this whenever the on-chain contract ABI changes in a way that is
+ * incompatible with this SDK. `checkCompatibility()` compares this value
+ * against the version stored in the deployed contract.
+ */
+export const CONTRACT_INTERFACE_VERSION = 1;
+
+/** Multipliers applied to `minResourceFee` for each priority tier. */
+const FEE_PRIORITY_MULTIPLIERS: Record<FeePriority, number> = {
+  low: 1.0,
+  medium: 1.5,
+  high: 2.0,
+};
+
+/**
  * Encapsulated client for StellarGrants Soroban contract interactions.
- * 
- * This SDK provides a high-level interface to interact with the StellarGrants smart contract.
- * It handles transaction building, simulation, signing (via a provided signer), and submission.
- * 
+ *
+ * This SDK provides a high-level interface to interact with the StellarGrants
+ * smart contract. It handles transaction building, simulation, signing (via a
+ * provided signer), and submission.
+ *
  * @example
  * ```typescript
  * const sdk = new StellarGrantsSDK({
@@ -58,7 +77,7 @@ export class StellarGrantsSDK {
 
   /**
    * Creates a new grant in the system.
-   * 
+   *
    * @param input Details of the grant to create.
    * @param options Optional transaction configuration.
    * @returns A promise that resolves to the transaction submission result.
@@ -76,7 +95,7 @@ export class StellarGrantsSDK {
 
   /**
    * Funds an existing grant with tokens.
-   * 
+   *
    * @param input Funding details including grant ID, token address, and amount.
    * @param options Optional transaction configuration.
    * @returns A promise that resolves to the transaction submission result.
@@ -91,7 +110,7 @@ export class StellarGrantsSDK {
 
   /**
    * Submits a proof hash for a specific milestone.
-   * 
+   *
    * @param input Milestone details and the proof hash.
    * @param options Optional transaction configuration.
    * @returns A promise that resolves to the transaction submission result.
@@ -106,7 +125,7 @@ export class StellarGrantsSDK {
 
   /**
    * Casts a vote (approval or rejection) for a milestone.
-   * 
+   *
    * @param input Vote details including grant ID, milestone index, and approval flag.
    * @param options Optional transaction configuration.
    * @returns A promise that resolves to the transaction submission result.
@@ -121,7 +140,7 @@ export class StellarGrantsSDK {
 
   /**
    * Retrieves the details of a grant from the contract (read-only).
-   * 
+   *
    * @param grantId The unique numeric ID of the grant.
    * @returns A promise that resolves to the grant data.
    */
@@ -131,7 +150,7 @@ export class StellarGrantsSDK {
 
   /**
    * Retrieves milestone details for a specific grant (read-only).
-   * 
+   *
    * @param grantId The unique numeric ID of the grant.
    * @param milestoneIdx The 0-based index of the milestone.
    * @returns A promise that resolves to the milestone data.
@@ -144,8 +163,43 @@ export class StellarGrantsSDK {
   }
 
   /**
-   * Polls the RPC server for the status of a transaction until it reaches a terminal state.
-   * 
+   * Estimates transaction fees for a contract method at all priority tiers
+   * without submitting a transaction.
+   *
+   * Use this to give users a cost preview before they sign.
+   *
+   * @param method The contract method name.
+   * @param args The ScVal arguments for the method.
+   * @returns Fee estimates at low / medium / high priority tiers.
+   *
+   * @example
+   * ```typescript
+   * const fees = await sdk.estimateFees("grant_create", args);
+   * console.log(`Medium fee: ${fees.medium} stroops`);
+   * ```
+   */
+  async estimateFees(method: string, args: xdr.ScVal[]): Promise<FeeEstimate> {
+    const tx = await this.buildTx(method, args, { skipAccountLookup: true });
+    const simulation = await this.server.simulateTransaction(tx) as any;
+    this.ensureSimulationSuccess(simulation);
+
+    const base = Number(simulation.minResourceFee ?? 0);
+
+    const calc = (multiplier: number) =>
+      String(Math.ceil(base * multiplier));
+
+    return {
+      base: String(base),
+      low: calc(FEE_PRIORITY_MULTIPLIERS.low),
+      medium: calc(FEE_PRIORITY_MULTIPLIERS.medium),
+      high: calc(FEE_PRIORITY_MULTIPLIERS.high),
+    };
+  }
+
+  /**
+   * Polls the RPC server for the status of a transaction until it reaches a
+   * terminal state.
+   *
    * @param hash The transaction hash to wait for.
    * @param intervalMs The polling interval in milliseconds.
    * @param timeoutMs The total timeout in milliseconds.
@@ -174,7 +228,7 @@ export class StellarGrantsSDK {
 
   /**
    * Extracts and parses contract events from a successful transaction response.
-   * 
+   *
    * @param response The successful transaction response.
    * @returns An array of parsed events.
    */
@@ -184,7 +238,7 @@ export class StellarGrantsSDK {
 
   /**
    * Simulates a transaction without submitting it.
-   * 
+   *
    * @param method The contract method to call.
    * @param args The arguments for the method.
    * @returns The simulation response.
@@ -197,8 +251,64 @@ export class StellarGrantsSDK {
   }
 
   /**
+   * Checks whether the SDK is compatible with the deployed contract.
+   *
+   * Queries the `sdk_version` read-only method on the contract. If the method
+   * is not present the check is skipped and the result is marked as unknown.
+   * A warning is emitted (via `console.warn`) when a mismatch is detected.
+   *
+   * @returns A compatibility report.
+   *
+   * @example
+   * ```typescript
+   * const report = await sdk.checkCompatibility();
+   * if (!report.compatible) {
+   *   console.warn(report.warning);
+   * }
+   * ```
+   */
+  async checkCompatibility(): Promise<{
+    compatible: boolean;
+    sdkVersion: number;
+    contractVersion: number | null;
+    warning?: string;
+  }> {
+    let contractVersion: number | null = null;
+
+    try {
+      const raw = await this.invokeRead("sdk_version", []);
+      contractVersion = typeof raw === "number" ? raw : Number(raw);
+    } catch {
+      // Contract does not expose sdk_version — compatibility is unknown.
+      return {
+        compatible: true,
+        sdkVersion: CONTRACT_INTERFACE_VERSION,
+        contractVersion: null,
+        warning:
+          "Could not determine contract interface version. " +
+          "The contract may not expose an `sdk_version` method.",
+      };
+    }
+
+    const compatible = contractVersion === CONTRACT_INTERFACE_VERSION;
+
+    if (!compatible) {
+      const msg =
+        `SDK interface version (${CONTRACT_INTERFACE_VERSION}) does not match ` +
+        `contract version (${contractVersion}). ` +
+        (contractVersion > CONTRACT_INTERFACE_VERSION
+          ? "Please upgrade the SDK to the latest version."
+          : "The deployed contract may be outdated.");
+      console.warn(`[StellarGrantsSDK] ${msg}`);
+      return { compatible, sdkVersion: CONTRACT_INTERFACE_VERSION, contractVersion, warning: msg };
+    }
+
+    return { compatible: true, sdkVersion: CONTRACT_INTERFACE_VERSION, contractVersion };
+  }
+
+  /**
    * Subscribes to contract events.
-   * 
+   *
    * @param callback Function called for each new event.
    * @param options Filter options for events.
    * @returns A function to unsubscribe.
@@ -214,7 +324,7 @@ export class StellarGrantsSDK {
       if (!active) return;
       try {
         const req: any = {
-           filters: [{ type: "contract", contractIds: [this.config.contractId] }],
+          filters: [{ type: "contract", contractIds: [this.config.contractId] }],
         };
         if (!currentCursor && options?.startLedger) {
           req.startLedger = options.startLedger;
@@ -222,19 +332,19 @@ export class StellarGrantsSDK {
         if (currentCursor) {
           req.pagination = { cursor: currentCursor };
         }
-        
+
         const response = await this.server.getEvents(req);
         if (response.events) {
           for (const ev of response.events) {
-            currentCursor = ev.id || ev.pagingToken || currentCursor; 
-            
+            currentCursor = ev.id || ev.pagingToken || currentCursor;
+
             if (options?.eventName) {
               const topicMatches = ev.topic && ev.topic.some((t: any) => {
-                 try { 
-                    const scVal = typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : t;
-                    const parsed = scValToNative(scVal);
-                    return parsed === options.eventName || String(parsed) === options.eventName;
-                 } catch { return false; }
+                try {
+                  const scVal = typeof t === "string" ? xdr.ScVal.fromXDR(t, "base64") : t;
+                  const parsed = scValToNative(scVal);
+                  return parsed === options.eventName || String(parsed) === options.eventName;
+                } catch { return false; }
               });
               if (!topicMatches) continue;
             }
@@ -242,14 +352,18 @@ export class StellarGrantsSDK {
           }
         }
       } catch (err) {
-         console.warn("Event poll error, continuing...", err);
+        console.warn("Event poll error, continuing...", err);
       }
       if (active) setTimeout(poll, 5000);
     };
-    
+
     poll();
     return () => { active = false; };
   }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
 
   /**
    * Internal helper for read-only contract invocations.
@@ -267,28 +381,42 @@ export class StellarGrantsSDK {
 
   /**
    * Internal helper for state-changing contract invocations.
+   *
+   * Fee resolution order (highest precedence first):
+   *  1. `options.simulatedFee`   – explicit override (wins unless feeMultiplier is also set).
+   *  2. `options.feeMultiplier`  – multiply simulated resource fee.
+   *  3. `options.feePriority`    – use a predefined tier multiplier ("low" | "medium" | "high").
+   *  4. Default                  – medium priority (1.5× simulated resource fee).
+   *
+   * Simulation is skipped only when `transactionData` is supplied without `feeMultiplier`.
    */
   private async invokeWrite(
-    method: string, 
+    method: string,
     args: xdr.ScVal[],
-    options?: WriteOptions
+    options?: WriteOptions,
   ): Promise<rpc.Api.SendTransactionResponse | unknown> {
     const signer = this.requireSigner();
     try {
       let finalFee = this.config.defaultFee ?? "100";
 
+      // Simulate when there is no pre-built transaction data OR when the caller
+      // wants to override the fee with a multiplier (mirrors original behaviour).
       if (!options?.transactionData || options?.feeMultiplier) {
         const txForSim = await this.buildTx(method, args);
         const simulation = await this.server.simulateTransaction(txForSim) as any;
         this.ensureSimulationSuccess(simulation);
-        
+
+        const base = Number(simulation.minResourceFee ?? 0);
+
         if (options?.feeMultiplier) {
-          finalFee = String(Math.ceil(Number(simulation.minResourceFee) * options.feeMultiplier));
+          finalFee = String(Math.ceil(base * options.feeMultiplier));
         } else {
-          finalFee = String(Number(simulation.minResourceFee || 0) + 10000);
+          const priority: FeePriority = options?.feePriority ?? "medium";
+          finalFee = String(Math.ceil(base * FEE_PRIORITY_MULTIPLIERS[priority]));
         }
       }
 
+      // simulatedFee is the highest-priority override unless feeMultiplier is present.
       if (options?.simulatedFee && !options?.feeMultiplier) {
         finalFee = options.simulatedFee;
       }
@@ -324,13 +452,13 @@ export class StellarGrantsSDK {
    * Builds a transaction for a contract call.
    */
   private async buildTx(
-    method: string, 
-    args: xdr.ScVal[], 
+    method: string,
+    args: xdr.ScVal[],
     options?: {
       overrideFee?: string;
       sorobanData?: string | xdr.SorobanTransactionData;
       skipAccountLookup?: boolean;
-    }
+    },
   ) {
     const account = await this.getSourceAccount(options?.skipAccountLookup);
     const networkPassphrase = await this.resolveNetworkPassphrase();
@@ -340,11 +468,11 @@ export class StellarGrantsSDK {
     })
       .addOperation(this.contract.call(method, ...args))
       .setTimeout(60);
-      
+
     if (options?.sorobanData) {
       builder.setSorobanData(options.sorobanData);
     }
-      
+
     return builder.build();
   }
 
@@ -367,7 +495,6 @@ export class StellarGrantsSDK {
         "SIGNER_REQUIRED",
       );
     }
-
     return this.config.signer;
   }
 

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,4 +1,4 @@
-export { StellarGrantsSDK } from "./StellarGrantsSDK";
+export { StellarGrantsSDK, CONTRACT_INTERFACE_VERSION } from "./StellarGrantsSDK";
 export * from "./types";
 export * from "./errors/StellarGrantsError";
 export * from "./errors/parseSorobanError";
@@ -12,6 +12,9 @@ export type {
   MilestoneVoteInput,
   StellarGrantsSDKConfig,
   WalletAdapter,
+  WriteOptions,
+  FeePriority,
+  FeeEstimate,
 } from "./types";
 export { EventParser } from "./events";
 export type {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -90,6 +90,32 @@ export type MilestoneVoteInput = {
 };
 
 /**
+ * Fee priority tiers used by the SDK when estimating transaction fees.
+ *
+ * - `"low"`    – 1.0× the simulated resource fee. Cheapest but may be slow
+ *               during network congestion.
+ * - `"medium"` – 1.5× the simulated resource fee (default). Balances cost
+ *               and inclusion speed.
+ * - `"high"`   – 2.0× the simulated resource fee. Prioritises fast inclusion
+ *               at higher cost.
+ */
+export type FeePriority = "low" | "medium" | "high";
+
+/**
+ * Per-priority fee estimate returned by `StellarGrantsSDK.estimateFees()`.
+ */
+export type FeeEstimate = {
+  /** Raw simulated resource fee (in stroops) before any multiplier. */
+  base: string;
+  /** Fee at low priority (1.0× base). */
+  low: string;
+  /** Fee at medium priority (1.5× base). */
+  medium: string;
+  /** Fee at high priority (2.0× base). */
+  high: string;
+};
+
+/**
  * Options for state-changing transaction invocations.
  */
 export type WriteOptions = {
@@ -99,4 +125,12 @@ export type WriteOptions = {
   transactionData?: any; // xdr.SorobanTransactionData
   /** Explicit fee to use, bypassing automatic calculation. */
   simulatedFee?: string;
+  /**
+   * Fee priority tier. When set this takes precedence over `feeMultiplier`
+   * (unless `simulatedFee` is also provided, which always wins).
+   *
+   * Defaults to `"medium"` when neither `feeMultiplier` nor `simulatedFee`
+   * is specified.
+   */
+  feePriority?: FeePriority;
 };

--- a/client/src/wallets/WalletConnectAdapter.ts
+++ b/client/src/wallets/WalletConnectAdapter.ts
@@ -1,0 +1,158 @@
+import { WalletAdapter } from "../types";
+
+/**
+ * WalletConnect v2 adapter for the StellarGrants SDK.
+ *
+ * Accepts a pre-initialized `@walletconnect/sign-client` instance so the host
+ * application retains full control over project-ID configuration, QR-code
+ * display, and URI sharing.
+ *
+ * @example
+ * ```typescript
+ * import SignClient from "@walletconnect/sign-client";
+ *
+ * const signClient = await SignClient.init({
+ *   projectId: "YOUR_WALLETCONNECT_PROJECT_ID",
+ *   metadata: {
+ *     name: "StellarGrants",
+ *     description: "Decentralised grant platform on Stellar",
+ *     url: "https://stellargrants.io",
+ *     icons: ["https://stellargrants.io/logo.png"],
+ *   },
+ * });
+ *
+ * const adapter = new WalletConnectAdapter(signClient);
+ *
+ * // Pair with a wallet (display uri as a QR code in your UI)
+ * const { uri, approval } = await adapter.connect("Test SDF Network ; September 2015");
+ * console.log("Scan this URI:", uri);
+ * await approval(); // resolves once the user approves in their wallet
+ *
+ * const sdk = new StellarGrantsSDK({ ..., signer: adapter });
+ * ```
+ */
+export class WalletConnectAdapter implements WalletAdapter {
+  private readonly signClient: any;
+  private session: any | null = null;
+
+  /**
+   * @param signClient An initialised `@walletconnect/sign-client` SignClient instance.
+   */
+  constructor(signClient: any) {
+    if (!signClient) {
+      throw new Error("WalletConnectAdapter: a SignClient instance is required.");
+    }
+    this.signClient = signClient;
+    this._restoreSession();
+  }
+
+  /**
+   * Initiates a WalletConnect pairing.
+   *
+   * Returns a `uri` to display as a QR code and an `approval` callback that
+   * resolves once the user approves the session in their wallet app.
+   *
+   * @param networkPassphrase Stellar network passphrase used to select the chain ID.
+   */
+  async connect(networkPassphrase: string): Promise<{ uri: string; approval: () => Promise<void> }> {
+    const chainId = networkPassphrase.includes("Public")
+      ? "stellar:pubnet"
+      : "stellar:testnet";
+
+    const { uri, approval } = await this.signClient.connect({
+      requiredNamespaces: {
+        stellar: {
+          methods: ["stellar_signTransaction"],
+          chains: [chainId],
+          events: [],
+        },
+      },
+    });
+
+    return {
+      uri: uri ?? "",
+      approval: async () => {
+        this.session = await approval();
+      },
+    };
+  }
+
+  /**
+   * Disconnects the current WalletConnect session.
+   */
+  async disconnect(): Promise<void> {
+    if (!this.session) return;
+    try {
+      await this.signClient.disconnect({
+        topic: this.session.topic,
+        reason: { code: 6000, message: "USER_DISCONNECTED" },
+      });
+    } finally {
+      this.session = null;
+    }
+  }
+
+  /** `true` when an active session exists. */
+  get isConnected(): boolean {
+    return this.session !== null;
+  }
+
+  async getPublicKey(): Promise<string> {
+    this._requireSession();
+    const accounts: string[] = this.session.namespaces?.stellar?.accounts ?? [];
+    if (accounts.length === 0) {
+      throw new Error("WalletConnect: no Stellar accounts found in the active session.");
+    }
+    // Accounts are formatted as "stellar:<network>:<G...address>"
+    const parts = accounts[0].split(":");
+    const pubkey = parts[parts.length - 1];
+    if (!pubkey) {
+      throw new Error("WalletConnect: could not parse public key from session accounts.");
+    }
+    return pubkey;
+  }
+
+  async signTransaction(txXdr: string, networkPassphrase: string): Promise<string> {
+    this._requireSession();
+    const chainId = networkPassphrase.includes("Public")
+      ? "stellar:pubnet"
+      : "stellar:testnet";
+
+    const result = await this.signClient.request({
+      topic: this.session.topic,
+      chainId,
+      request: {
+        method: "stellar_signTransaction",
+        params: { xdr: txXdr },
+      },
+    });
+
+    if (typeof result === "string") return result;
+    if (result?.signedXDR) return result.signedXDR;
+    if (result?.xdr) return result.xdr;
+    throw new Error("WalletConnect: unexpected response format from wallet.");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private _restoreSession(): void {
+    try {
+      const sessions: any[] = this.signClient.session?.getAll?.() ?? [];
+      if (sessions.length > 0) {
+        this.session = sessions[sessions.length - 1];
+      }
+    } catch {
+      this.session = null;
+    }
+  }
+
+  private _requireSession(): void {
+    if (!this.session) {
+      throw new Error(
+        "WalletConnect: no active session. Call connect() and wait for approval before signing.",
+      );
+    }
+  }
+}

--- a/client/src/wallets/XBullAdapter.ts
+++ b/client/src/wallets/XBullAdapter.ts
@@ -1,0 +1,68 @@
+import { WalletAdapter } from "../types";
+
+/**
+ * Adapter for the xBull Wallet browser extension.
+ *
+ * xBull injects `window.xBull` when the extension is installed.
+ * If the extension is absent the adapter throws a descriptive error so the
+ * caller can prompt the user to install it.
+ *
+ * @example
+ * ```typescript
+ * const adapter = new XBullAdapter();
+ * const sdk = new StellarGrantsSDK({ ..., signer: adapter });
+ * ```
+ */
+export class XBullAdapter implements WalletAdapter {
+  async getPublicKey(): Promise<string> {
+    const xBull = this._getExtension();
+
+    const response = await xBull.connect();
+    if (!response) {
+      throw new Error("xBull: connect() returned no response.");
+    }
+
+    // xBull.connect() resolves to either a plain public-key string or an
+    // object with a publicKey / pubkey property depending on the extension version.
+    if (typeof response === "string") return response;
+    const pubkey = response.publicKey ?? response.pubkey;
+    if (!pubkey) {
+      throw new Error("xBull: could not retrieve public key from connect() response.");
+    }
+    return pubkey;
+  }
+
+  async signTransaction(txXdr: string, networkPassphrase: string): Promise<string> {
+    const xBull = this._getExtension();
+
+    const network = networkPassphrase.includes("Public") ? "public" : "testnet";
+    const response = await xBull.signXDR(txXdr, { network });
+
+    if (!response) {
+      throw new Error("xBull: signXDR() returned no response.");
+    }
+
+    // signXDR resolves to either a signed-XDR string or an object with xdr property.
+    if (typeof response === "string") return response;
+    const signedXdr = response.xdr ?? response.signedXDR;
+    if (!signedXdr) {
+      throw new Error("xBull: could not retrieve signed XDR from signXDR() response.");
+    }
+    return signedXdr;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private _getExtension(): any {
+    const xBull = (window as any)?.xBull;
+    if (!xBull) {
+      throw new Error(
+        "xBull Wallet extension is not installed or not accessible. " +
+          "Please install xBull from https://xbull.app and reload the page.",
+      );
+    }
+    return xBull;
+  }
+}

--- a/client/src/wallets/index.ts
+++ b/client/src/wallets/index.ts
@@ -1,2 +1,4 @@
 export * from "./FreighterAdapter";
 export * from "./AlbedoAdapter";
+export * from "./WalletConnectAdapter";
+export * from "./XBullAdapter";

--- a/client/tests/fee-estimation.test.ts
+++ b/client/tests/fee-estimation.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for simulation-based fee estimation (#255) and SDK versioning (#263).
+ */
+
+import { CONTRACT_INTERFACE_VERSION } from "../src/StellarGrantsSDK";
+import { makeSdk } from "./helpers/sdkFactory";
+
+// ---------------------------------------------------------------------------
+// Minimal stellar-sdk mock (mirrors existing sdk.test.ts pattern)
+// ---------------------------------------------------------------------------
+jest.mock("@stellar/stellar-sdk", () => {
+  return {
+    rpc: {
+      Server: class {
+        async getAccount() { return { accountId: "GMOCK", sequence: "0" }; }
+        async simulateTransaction() { return { result: { retval: null }, minResourceFee: "1000" }; }
+        async prepareTransaction(tx: any) { return tx; }
+        async sendTransaction() { return { status: "PENDING", hash: "mockhash" }; }
+        async getEvents() { return { events: [] }; }
+        async getTransaction() { return { status: "SUCCESS", hash: "x" }; }
+        async getNetwork() { return { passphrase: "Test SDF Network ; September 2015" }; }
+      },
+    },
+    Contract: class {
+      call(method: string, ...args: unknown[]) { return { method, args }; }
+    },
+    Account: class {
+      constructor(public accountId: string, public sequence: string) {}
+    },
+    TransactionBuilder: class {
+      static fromXDR(_xdr: string, _pass: string) {
+        return { toXDR: () => "SIGNED_TX_XDR" };
+      }
+      addOperation() { return this; }
+      setTimeout() { return this; }
+      setSorobanData() { return this; }
+      build() { return { toXDR: () => "TX_XDR" }; }
+    },
+    nativeToScVal: (v: any) => v,
+    scValToNative: (v: any) => v,
+    xdr: { ScVal: { fromXDR: () => null }, SorobanTransactionData: {} },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// estimateFees
+// ---------------------------------------------------------------------------
+describe("StellarGrantsSDK.estimateFees", () => {
+  it("returns fee tiers based on minResourceFee from simulation", async () => {
+    const { sdk, state } = makeSdk();
+    state.minResourceFee = "2000";
+
+    const fees = await sdk.estimateFees("grant_create", []);
+
+    expect(fees.base).toBe("2000");
+    expect(fees.low).toBe("2000");    // 1.0×
+    expect(fees.medium).toBe("3000"); // 1.5×
+    expect(fees.high).toBe("4000");   // 2.0×
+  });
+
+  it("ceilings fractional fees", async () => {
+    const { sdk, state } = makeSdk();
+    state.minResourceFee = "1001";
+
+    const fees = await sdk.estimateFees("grant_create", []);
+
+    // 1001 × 1.5 = 1501.5 → ceil → 1502
+    expect(fees.medium).toBe("1502");
+  });
+
+  it("handles zero minResourceFee", async () => {
+    const { sdk, state } = makeSdk();
+    state.minResourceFee = "0";
+
+    const fees = await sdk.estimateFees("grant_create", []);
+
+    expect(fees.base).toBe("0");
+    expect(fees.low).toBe("0");
+    expect(fees.medium).toBe("0");
+    expect(fees.high).toBe("0");
+  });
+
+  it("throws when simulation returns an error", async () => {
+    const { sdk, state } = makeSdk();
+    state.simulationError = "contract error";
+
+    await expect(sdk.estimateFees("grant_create", [])).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// feePriority WriteOption
+// ---------------------------------------------------------------------------
+describe("feePriority WriteOption", () => {
+  it("uses medium priority by default (1.5× fee)", async () => {
+    const { sdk, mockServer, state, mockSigner } = makeSdk();
+    state.minResourceFee = "1000";
+    mockSigner.signTransaction.mockResolvedValue("SIGNED_XDR");
+
+    await sdk.grantCreate(
+      {
+        owner: "GOWNER",
+        title: "T",
+        description: "D",
+        budget: BigInt(100),
+        deadline: BigInt(9999999),
+        milestoneCount: 3,
+      },
+      {},
+    );
+
+    // buildTx is called with fee "1500" (1000 × 1.5 = 1500)
+    const calls = mockServer.simulateTransaction.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it("respects high feePriority (2.0× fee)", async () => {
+    const { sdk, state, mockSigner } = makeSdk();
+    state.minResourceFee = "1000";
+    mockSigner.signTransaction.mockResolvedValue("SIGNED_XDR");
+
+    // Should not throw - high priority simply multiplies the fee
+    await expect(
+      sdk.grantCreate(
+        {
+          owner: "GOWNER",
+          title: "T",
+          description: "D",
+          budget: BigInt(100),
+          deadline: BigInt(9999999),
+          milestoneCount: 3,
+        },
+        { feePriority: "high" },
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it("simulatedFee takes precedence over feePriority", async () => {
+    const { sdk, state, mockSigner } = makeSdk();
+    state.minResourceFee = "1000";
+    mockSigner.signTransaction.mockResolvedValue("SIGNED_XDR");
+
+    await expect(
+      sdk.grantCreate(
+        {
+          owner: "GOWNER",
+          title: "T",
+          description: "D",
+          budget: BigInt(100),
+          deadline: BigInt(9999999),
+          milestoneCount: 3,
+        },
+        { simulatedFee: "500", feePriority: "high" },
+      ),
+    ).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkCompatibility
+// ---------------------------------------------------------------------------
+describe("StellarGrantsSDK.checkCompatibility", () => {
+  it("CONTRACT_INTERFACE_VERSION is a positive integer", () => {
+    expect(typeof CONTRACT_INTERFACE_VERSION).toBe("number");
+    expect(Number.isInteger(CONTRACT_INTERFACE_VERSION)).toBe(true);
+    expect(CONTRACT_INTERFACE_VERSION).toBeGreaterThan(0);
+  });
+
+  it("returns compatible:true with matching contract version", async () => {
+    const { sdk, state } = makeSdk();
+    // Make the simulation return the current SDK version as the contract version
+    state.simulationResult = CONTRACT_INTERFACE_VERSION;
+
+    const report = await sdk.checkCompatibility();
+
+    expect(report.compatible).toBe(true);
+    expect(report.sdkVersion).toBe(CONTRACT_INTERFACE_VERSION);
+    expect(report.contractVersion).toBe(CONTRACT_INTERFACE_VERSION);
+    expect(report.warning).toBeUndefined();
+  });
+
+  it("returns compatible:false with a newer contract version", async () => {
+    const { sdk, state } = makeSdk();
+    state.simulationResult = CONTRACT_INTERFACE_VERSION + 1;
+
+    const report = await sdk.checkCompatibility();
+
+    expect(report.compatible).toBe(false);
+    expect(report.warning).toContain("upgrade the SDK");
+  });
+
+  it("returns compatible:false with an older contract version", async () => {
+    const { sdk, state } = makeSdk();
+    state.simulationResult = CONTRACT_INTERFACE_VERSION - 1;
+
+    // Only run this test when CONTRACT_INTERFACE_VERSION > 1
+    if (CONTRACT_INTERFACE_VERSION <= 1) return;
+
+    const report = await sdk.checkCompatibility();
+
+    expect(report.compatible).toBe(false);
+    expect(report.warning).toBeDefined();
+  });
+
+  it("returns compatible:true with a warning when sdk_version method is missing", async () => {
+    const { sdk, state } = makeSdk();
+    // Simulate the sdk_version read failing (contract doesn't have the method)
+    state.simulationError = "method not found: sdk_version";
+
+    const report = await sdk.checkCompatibility();
+
+    expect(report.compatible).toBe(true);
+    expect(report.contractVersion).toBeNull();
+    expect(report.warning).toContain("Could not determine contract interface version");
+  });
+});

--- a/client/tests/wallets/walletconnect.test.ts
+++ b/client/tests/wallets/walletconnect.test.ts
@@ -1,0 +1,268 @@
+import { WalletConnectAdapter } from "../../src/wallets/WalletConnectAdapter";
+
+const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+const MAINNET_PASSPHRASE = "Public Global Stellar Network ; September 2015";
+
+const TESTNET_ACCOUNT = "stellar:testnet:GTEST_WC_PUBKEY";
+const MAINNET_ACCOUNT = "stellar:pubnet:GMAIN_WC_PUBKEY";
+
+function makeSignClient(overrides?: {
+  sessions?: any[];
+  connectResult?: { uri: string; approval: () => Promise<any> };
+  requestResult?: any;
+  disconnectMock?: jest.Mock;
+}) {
+  const sessions = overrides?.sessions ?? [];
+  return {
+    session: { getAll: jest.fn(() => sessions) },
+    connect: jest.fn(async () =>
+      overrides?.connectResult ?? {
+        uri: "wc:mock-uri",
+        approval: async () => ({
+          topic: "mock-topic",
+          namespaces: {
+            stellar: { accounts: [TESTNET_ACCOUNT] },
+          },
+        }),
+      },
+    ),
+    disconnect: overrides?.disconnectMock ?? jest.fn(async () => {}),
+    request: jest.fn(async () => overrides?.requestResult ?? "SIGNED_XDR"),
+  };
+}
+
+describe("WalletConnectAdapter constructor", () => {
+  it("throws when no signClient is provided", () => {
+    expect(() => new WalletConnectAdapter(null)).toThrow(
+      "WalletConnectAdapter: a SignClient instance is required.",
+    );
+  });
+
+  it("restores an existing session from the sign client", () => {
+    const existingSession = {
+      topic: "existing-topic",
+      namespaces: { stellar: { accounts: [TESTNET_ACCOUNT] } },
+    };
+    const client = makeSignClient({ sessions: [existingSession] });
+    const adapter = new WalletConnectAdapter(client);
+    expect(adapter.isConnected).toBe(true);
+  });
+
+  it("starts with no session when none exist", () => {
+    const client = makeSignClient({ sessions: [] });
+    const adapter = new WalletConnectAdapter(client);
+    expect(adapter.isConnected).toBe(false);
+  });
+});
+
+describe("WalletConnectAdapter.connect", () => {
+  it("connects on testnet and returns uri + approval", async () => {
+    const client = makeSignClient();
+    const adapter = new WalletConnectAdapter(client);
+
+    const { uri, approval } = await adapter.connect(TESTNET_PASSPHRASE);
+
+    expect(client.connect).toHaveBeenCalledWith({
+      requiredNamespaces: {
+        stellar: {
+          methods: ["stellar_signTransaction"],
+          chains: ["stellar:testnet"],
+          events: [],
+        },
+      },
+    });
+    expect(uri).toBe("wc:mock-uri");
+
+    await approval();
+    expect(adapter.isConnected).toBe(true);
+  });
+
+  it("selects stellar:pubnet chain for mainnet passphrase", async () => {
+    const client = makeSignClient({
+      connectResult: {
+        uri: "wc:main-uri",
+        approval: async () => ({
+          topic: "main-topic",
+          namespaces: { stellar: { accounts: [MAINNET_ACCOUNT] } },
+        }),
+      },
+    });
+    const adapter = new WalletConnectAdapter(client);
+
+    await adapter.connect(MAINNET_PASSPHRASE);
+
+    expect(client.connect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requiredNamespaces: expect.objectContaining({
+          stellar: expect.objectContaining({ chains: ["stellar:pubnet"] }),
+        }),
+      }),
+    );
+  });
+});
+
+describe("WalletConnectAdapter.getPublicKey", () => {
+  it("throws when no session is active", async () => {
+    const client = makeSignClient({ sessions: [] });
+    const adapter = new WalletConnectAdapter(client);
+
+    await expect(adapter.getPublicKey()).rejects.toThrow(
+      "WalletConnect: no active session.",
+    );
+  });
+
+  it("parses public key from testnet account string", async () => {
+    const client = makeSignClient();
+    const adapter = new WalletConnectAdapter(client);
+    const { approval } = await adapter.connect(TESTNET_PASSPHRASE);
+    await approval();
+
+    const key = await adapter.getPublicKey();
+
+    expect(key).toBe("GTEST_WC_PUBKEY");
+  });
+
+  it("parses public key from mainnet account string", async () => {
+    const client = makeSignClient({
+      connectResult: {
+        uri: "wc:x",
+        approval: async () => ({
+          topic: "t",
+          namespaces: { stellar: { accounts: [MAINNET_ACCOUNT] } },
+        }),
+      },
+    });
+    const adapter = new WalletConnectAdapter(client);
+    const { approval } = await adapter.connect(MAINNET_PASSPHRASE);
+    await approval();
+
+    expect(await adapter.getPublicKey()).toBe("GMAIN_WC_PUBKEY");
+  });
+
+  it("throws when session has no stellar accounts", async () => {
+    const client = makeSignClient({
+      connectResult: {
+        uri: "wc:x",
+        approval: async () => ({
+          topic: "t",
+          namespaces: { stellar: { accounts: [] } },
+        }),
+      },
+    });
+    const adapter = new WalletConnectAdapter(client);
+    const { approval } = await adapter.connect(TESTNET_PASSPHRASE);
+    await approval();
+
+    await expect(adapter.getPublicKey()).rejects.toThrow(
+      "WalletConnect: no Stellar accounts found",
+    );
+  });
+});
+
+describe("WalletConnectAdapter.signTransaction", () => {
+  it("throws when no session is active", async () => {
+    const client = makeSignClient();
+    const adapter = new WalletConnectAdapter(client);
+
+    await expect(adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE)).rejects.toThrow(
+      "WalletConnect: no active session.",
+    );
+  });
+
+  it("calls signClient.request with stellar_signTransaction on testnet", async () => {
+    const client = makeSignClient({ requestResult: "SIGNED_XDR" });
+    const adapter = new WalletConnectAdapter(client);
+    const { approval } = await adapter.connect(TESTNET_PASSPHRASE);
+    await approval();
+
+    const result = await adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE);
+
+    expect(client.request).toHaveBeenCalledWith({
+      topic: "mock-topic",
+      chainId: "stellar:testnet",
+      request: { method: "stellar_signTransaction", params: { xdr: "TX_XDR" } },
+    });
+    expect(result).toBe("SIGNED_XDR");
+  });
+
+  it("uses stellar:pubnet chain for mainnet passphrase", async () => {
+    const client = makeSignClient({
+      connectResult: {
+        uri: "wc:x",
+        approval: async () => ({
+          topic: "main-topic",
+          namespaces: { stellar: { accounts: [MAINNET_ACCOUNT] } },
+        }),
+      },
+      requestResult: "MAIN_SIGNED_XDR",
+    });
+    const adapter = new WalletConnectAdapter(client);
+    const { approval } = await adapter.connect(MAINNET_PASSPHRASE);
+    await approval();
+
+    await adapter.signTransaction("TX_XDR", MAINNET_PASSPHRASE);
+
+    expect(client.request).toHaveBeenCalledWith(
+      expect.objectContaining({ chainId: "stellar:pubnet" }),
+    );
+  });
+
+  it("extracts signedXDR from object response", async () => {
+    const client = makeSignClient({ requestResult: { signedXDR: "OBJ_SIGNED_XDR" } });
+    const adapter = new WalletConnectAdapter(client);
+    const { approval } = await adapter.connect(TESTNET_PASSPHRASE);
+    await approval();
+
+    const result = await adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE);
+    expect(result).toBe("OBJ_SIGNED_XDR");
+  });
+
+  it("extracts xdr from object response", async () => {
+    const client = makeSignClient({ requestResult: { xdr: "XDR_FIELD" } });
+    const adapter = new WalletConnectAdapter(client);
+    const { approval } = await adapter.connect(TESTNET_PASSPHRASE);
+    await approval();
+
+    const result = await adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE);
+    expect(result).toBe("XDR_FIELD");
+  });
+
+  it("throws on unexpected response format", async () => {
+    const client = makeSignClient({ requestResult: { unexpected: true } });
+    const adapter = new WalletConnectAdapter(client);
+    const { approval } = await adapter.connect(TESTNET_PASSPHRASE);
+    await approval();
+
+    await expect(adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE)).rejects.toThrow(
+      "WalletConnect: unexpected response format",
+    );
+  });
+});
+
+describe("WalletConnectAdapter.disconnect", () => {
+  it("disconnects and clears the session", async () => {
+    const disconnectMock = jest.fn(async () => {});
+    const client = makeSignClient({ disconnectMock });
+    const adapter = new WalletConnectAdapter(client);
+    const { approval } = await adapter.connect(TESTNET_PASSPHRASE);
+    await approval();
+    expect(adapter.isConnected).toBe(true);
+
+    await adapter.disconnect();
+
+    expect(disconnectMock).toHaveBeenCalledWith({
+      topic: "mock-topic",
+      reason: { code: 6000, message: "USER_DISCONNECTED" },
+    });
+    expect(adapter.isConnected).toBe(false);
+  });
+
+  it("is a no-op when no session exists", async () => {
+    const disconnectMock = jest.fn(async () => {});
+    const client = makeSignClient({ sessions: [], disconnectMock });
+    const adapter = new WalletConnectAdapter(client);
+
+    await expect(adapter.disconnect()).resolves.toBeUndefined();
+    expect(disconnectMock).not.toHaveBeenCalled();
+  });
+});

--- a/client/tests/wallets/xbull.test.ts
+++ b/client/tests/wallets/xbull.test.ts
@@ -1,0 +1,161 @@
+import { XBullAdapter } from "../../src/wallets/XBullAdapter";
+
+const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+const MAINNET_PASSPHRASE = "Public Global Stellar Network ; September 2015";
+
+function makeXBullWindow(overrides?: {
+  connect?: jest.Mock;
+  signXDR?: jest.Mock;
+}) {
+  return {
+    xBull: {
+      connect: overrides?.connect ?? jest.fn(async () => "GXBULL_TEST_KEY"),
+      signXDR: overrides?.signXDR ?? jest.fn(async () => "XBULL_SIGNED_XDR"),
+    },
+  };
+}
+
+afterEach(() => {
+  delete (global as any).window;
+});
+
+describe("XBullAdapter.getPublicKey", () => {
+  it("returns public key string directly from connect()", async () => {
+    (global as any).window = makeXBullWindow();
+    const adapter = new XBullAdapter();
+
+    const key = await adapter.getPublicKey();
+
+    expect(key).toBe("GXBULL_TEST_KEY");
+  });
+
+  it("extracts publicKey property when connect() returns an object", async () => {
+    (global as any).window = makeXBullWindow({
+      connect: jest.fn(async () => ({ publicKey: "GOBJ_KEY" })),
+    });
+    const adapter = new XBullAdapter();
+
+    expect(await adapter.getPublicKey()).toBe("GOBJ_KEY");
+  });
+
+  it("extracts pubkey property when connect() returns an object with pubkey", async () => {
+    (global as any).window = makeXBullWindow({
+      connect: jest.fn(async () => ({ pubkey: "GPUBKEY_FIELD" })),
+    });
+    const adapter = new XBullAdapter();
+
+    expect(await adapter.getPublicKey()).toBe("GPUBKEY_FIELD");
+  });
+
+  it("throws when xBull extension is not installed", async () => {
+    (global as any).window = {};
+    const adapter = new XBullAdapter();
+
+    await expect(adapter.getPublicKey()).rejects.toThrow(
+      "xBull Wallet extension is not installed",
+    );
+  });
+
+  it("throws when window is undefined", async () => {
+    delete (global as any).window;
+    const adapter = new XBullAdapter();
+
+    await expect(adapter.getPublicKey()).rejects.toThrow();
+  });
+
+  it("throws when connect() returns null", async () => {
+    (global as any).window = makeXBullWindow({
+      connect: jest.fn(async () => null),
+    });
+    const adapter = new XBullAdapter();
+
+    await expect(adapter.getPublicKey()).rejects.toThrow(
+      "xBull: connect() returned no response.",
+    );
+  });
+
+  it("throws when connect() returns object without publicKey/pubkey", async () => {
+    (global as any).window = makeXBullWindow({
+      connect: jest.fn(async () => ({ other: "value" })),
+    });
+    const adapter = new XBullAdapter();
+
+    await expect(adapter.getPublicKey()).rejects.toThrow(
+      "xBull: could not retrieve public key",
+    );
+  });
+});
+
+describe("XBullAdapter.signTransaction", () => {
+  it("calls signXDR with testnet network and returns signed XDR string", async () => {
+    (global as any).window = makeXBullWindow();
+    const adapter = new XBullAdapter();
+
+    const result = await adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE);
+
+    expect((global as any).window.xBull.signXDR).toHaveBeenCalledWith("TX_XDR", { network: "testnet" });
+    expect(result).toBe("XBULL_SIGNED_XDR");
+  });
+
+  it("calls signXDR with public network for mainnet passphrase", async () => {
+    (global as any).window = makeXBullWindow();
+    const adapter = new XBullAdapter();
+
+    await adapter.signTransaction("TX_XDR", MAINNET_PASSPHRASE);
+
+    expect((global as any).window.xBull.signXDR).toHaveBeenCalledWith("TX_XDR", { network: "public" });
+  });
+
+  it("extracts xdr property when signXDR returns an object", async () => {
+    (global as any).window = makeXBullWindow({
+      signXDR: jest.fn(async () => ({ xdr: "OBJ_SIGNED_XDR" })),
+    });
+    const adapter = new XBullAdapter();
+
+    const result = await adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE);
+
+    expect(result).toBe("OBJ_SIGNED_XDR");
+  });
+
+  it("extracts signedXDR property from response object", async () => {
+    (global as any).window = makeXBullWindow({
+      signXDR: jest.fn(async () => ({ signedXDR: "SIGNED_XDR_FIELD" })),
+    });
+    const adapter = new XBullAdapter();
+
+    const result = await adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE);
+
+    expect(result).toBe("SIGNED_XDR_FIELD");
+  });
+
+  it("throws when xBull extension is not installed", async () => {
+    (global as any).window = {};
+    const adapter = new XBullAdapter();
+
+    await expect(adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE)).rejects.toThrow(
+      "xBull Wallet extension is not installed",
+    );
+  });
+
+  it("throws when signXDR returns null", async () => {
+    (global as any).window = makeXBullWindow({
+      signXDR: jest.fn(async () => null),
+    });
+    const adapter = new XBullAdapter();
+
+    await expect(adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE)).rejects.toThrow(
+      "xBull: signXDR() returned no response.",
+    );
+  });
+
+  it("throws when signXDR returns object without xdr/signedXDR", async () => {
+    (global as any).window = makeXBullWindow({
+      signXDR: jest.fn(async () => ({ other: "value" })),
+    });
+    const adapter = new XBullAdapter();
+
+    await expect(adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE)).rejects.toThrow(
+      "xBull: could not retrieve signed XDR",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- **closes #251** — `WalletConnectAdapter`: implements `WalletAdapter` using a pre-initialised WalletConnect v2 `SignClient`. Supports the `stellar` namespace and `stellar_signTransaction` method, handles session connect/disconnect, and restores persisted sessions on construction.
- **closes #252** — `XBullAdapter`: implements `WalletAdapter` for the xBull browser extension (`window.xBull`). Exposes `getPublicKey` and `signTransaction` with graceful errors when the extension is not installed.
- **closes #255** — Simulation-based fee estimation: adds `estimateFees(method, args)` to the SDK returning `low` / `medium` / `high` / `base` fee tiers. Adds `feePriority` to `WriteOptions` so callers can select a tier per-transaction (default `medium` = 1.5× simulated resource fee). `simulatedFee` and `feeMultiplier` continue to take precedence for full backwards compatibility.
- **closes #263** — SDK versioning: exports `CONTRACT_INTERFACE_VERSION` constant and adds `checkCompatibility()` to the SDK, which queries the `sdk_version` read method on the contract, compares against the SDK version, and returns a structured report with a `warning` on mismatch.

## Test plan

- [ ] `npm test` in `client/` — all 110 tests pass (8 suites)
- [ ] New test suites: `tests/wallets/walletconnect.test.ts`, `tests/wallets/xbull.test.ts`, `tests/fee-estimation.test.ts`
- [ ] Existing suites (`sdk.test.ts`, `freighter.test.ts`, `albedo.test.ts`, `errors.test.ts`, `events.test.ts`) unchanged and passing