### PR TITLE
feat(client-sdk): metadata schema validation, Albedo fallback, dynamic fees, and developer CLI

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -47,6 +47,32 @@ const sdk = new StellarGrantsSDK({
 - **`getPublicKey()`**: returns the active Stellar address used as the transaction source.
 - **`signTransaction(txXdr, networkPassphrase)`**: must return a signed transaction XDR string.
 
+### Wallet Adapters
+
+Built-in adapters:
+
+- `FreighterAdapter`
+- `AlbedoAdapter`
+- `WalletConnectAdapter`
+- `XBullAdapter`
+- `createPreferredWalletAdapter(networkPassphrase)` for automatic Freighter -> Albedo fallback.
+
+Example:
+
+```ts
+import { createPreferredWalletAdapter, StellarGrantsSDK } from "@stellargrants/client-sdk";
+
+const networkPassphrase = "Test SDF Network ; September 2015";
+const signer = createPreferredWalletAdapter(networkPassphrase);
+
+const sdk = new StellarGrantsSDK({
+  contractId: process.env.CONTRACT_ID!,
+  rpcUrl: process.env.RPC_URL!,
+  networkPassphrase,
+  signer,
+});
+```
+
 ## Public API
 
 ### `StellarGrantsSDK`
@@ -57,6 +83,69 @@ const sdk = new StellarGrantsSDK({
 - **`milestoneVote(input)`**: vote approve/reject on a milestone.
 - **`grantGet(grantId)`**: read grant details.
 - **`milestoneGet(grantId, milestoneIdx)`**: read milestone details.
+
+### Dynamic Fee Estimation
+
+`estimateFees()` now uses dynamic network load data from Horizon when
+`horizonUrl` (or `feeStatsEndpoint`) is configured:
+
+```ts
+const sdk = new StellarGrantsSDK({
+  contractId,
+  rpcUrl,
+  networkPassphrase,
+  signer,
+  horizonUrl: "https://horizon-testnet.stellar.org",
+});
+
+const fees = await sdk.estimateFees("grant_create", []);
+console.log(fees.source, fees.networkLoad, fees.modifiers);
+```
+
+When fee stats are unavailable, the SDK safely falls back to static defaults.
+
+### IPFS Metadata Schema Validation
+
+`uploadMetadataToIPFS()` validates metadata locally before upload to prevent
+storing malformed payloads and to avoid unnecessary on-chain calls.
+
+Built-in schemas:
+
+- `grant`
+- `milestone`
+
+```ts
+import { uploadMetadataToIPFS } from "@stellargrants/client-sdk";
+
+await uploadMetadataToIPFS(
+  {
+    title: "Open-source educational grant",
+    description: "Funding curriculum and mentorship",
+  },
+  {
+    pinataJwt: process.env.PINATA_JWT,
+    metadataSchema: "grant",
+  },
+);
+```
+
+Invalid payloads throw `MetadataValidationError` with field-level details.
+
+## CLI
+
+The SDK package ships with a developer CLI available through `npx`:
+
+```bash
+npx @stellargrants/client-sdk init
+npx @stellargrants/client-sdk grant-status 1 --format json
+npx @stellargrants/client-sdk fund-grant 1 --token CTOKEN... --amount 1000000
+```
+
+Supported commands:
+
+- `init` - write a starter `.env`
+- `grant-status` - query grant state
+- `fund-grant` - fund a grant with local secret-key signing
 
 ## Errors
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "@stellar/stellar-base": "^13.1.0",
-        "@stellar/stellar-sdk": "^13.3.0"
+        "@stellar/stellar-sdk": "^13.3.0",
+        "commander": "^13.1.0",
+        "dotenv": "^17.2.2"
+      },
+      "bin": {
+        "sg": "dist/cli.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -1715,6 +1720,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1853,6 +1867,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/client/package.json
+++ b/client/package.json
@@ -4,13 +4,17 @@
   "description": "TypeScript SDK for StellarGrants Soroban contract interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "sg": "dist/cli.js"
+  },
   "files": [
     "dist"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "jest --runInBand",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "cli": "node dist/cli.js"
   },
   "keywords": [
     "stellar",
@@ -21,7 +25,9 @@
   "license": "MIT",
   "dependencies": {
     "@stellar/stellar-base": "^13.1.0",
-    "@stellar/stellar-sdk": "^13.3.0"
+    "@stellar/stellar-sdk": "^13.3.0",
+    "commander": "^13.1.0",
+    "dotenv": "^17.2.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/client/src/StellarGrantsSDK.ts
+++ b/client/src/StellarGrantsSDK.ts
@@ -13,6 +13,8 @@ import {
   AllowanceCheckResult,
   AllowanceResult,
   FeeEstimate,
+  FeeLevelModifiers,
+  FeeNetworkLoad,
   FeePriority,
   GrantCreateInput,
   GrantFundInput,
@@ -36,12 +38,23 @@ const READ_ONLY_SIMULATION_ACCOUNT =
  */
 export const CONTRACT_INTERFACE_VERSION = 1;
 
-/** Multipliers applied to `minResourceFee` for each priority tier. */
-const FEE_PRIORITY_MULTIPLIERS: Record<FeePriority, number> = {
+/** Default multipliers applied to `minResourceFee` for each priority tier. */
+const DEFAULT_FEE_LEVEL_MODIFIERS: FeeLevelModifiers = {
   low: 1.0,
   medium: 1.5,
   high: 2.0,
 };
+
+const DYNAMIC_FEE_LEVELS: Array<{
+  maxUsage: number;
+  load: FeeNetworkLoad;
+  modifiers: FeeLevelModifiers;
+}> = [
+  { maxUsage: 0.5, load: "low", modifiers: { low: 0.9, medium: 1.2, high: 1.6 } },
+  { maxUsage: 0.8, load: "moderate", modifiers: { low: 1.0, medium: 1.5, high: 2.0 } },
+  { maxUsage: 0.95, load: "high", modifiers: { low: 1.2, medium: 1.8, high: 2.6 } },
+  { maxUsage: Infinity, load: "surge", modifiers: { low: 1.6, medium: 2.5, high: 3.5 } },
+];
 
 /**
  * Encapsulated client for StellarGrants Soroban contract interactions.
@@ -195,16 +208,26 @@ export class StellarGrantsSDK {
     const simulation = await this.server.simulateTransaction(tx) as any;
     this.ensureSimulationSuccess(simulation);
 
-    const base = Number(simulation.minResourceFee ?? 0);
+    const simulationBase = Number(simulation.minResourceFee ?? 0);
+    const dynamicFees = await this.resolveDynamicFeeModifiers();
+    const recommendedBase = dynamicFees?.recommendedBaseFee ?? simulationBase;
+    const effectiveBase = Math.max(simulationBase, recommendedBase);
+    const modifiers = dynamicFees?.modifiers ?? DEFAULT_FEE_LEVEL_MODIFIERS;
 
     const calc = (multiplier: number) =>
-      String(Math.ceil(base * multiplier));
+      String(Math.ceil(effectiveBase * multiplier));
 
     return {
-      base: String(base),
-      low: calc(FEE_PRIORITY_MULTIPLIERS.low),
-      medium: calc(FEE_PRIORITY_MULTIPLIERS.medium),
-      high: calc(FEE_PRIORITY_MULTIPLIERS.high),
+      base: String(simulationBase),
+      ...(dynamicFees?.recommendedBaseFee !== undefined
+        ? { recommendedBase: String(dynamicFees.recommendedBaseFee) }
+        : {}),
+      low: calc(modifiers.low),
+      medium: calc(modifiers.medium),
+      high: calc(modifiers.high),
+      modifiers,
+      networkLoad: dynamicFees?.networkLoad ?? "moderate",
+      source: dynamicFees ? "horizon" : "simulation-fallback",
     };
   }
 
@@ -537,12 +560,16 @@ export class StellarGrantsSDK {
         this.ensureSimulationSuccess(simulation);
 
         const base = Number(simulation.minResourceFee ?? 0);
+        const dynamicFees = await this.resolveDynamicFeeModifiers();
+        const recommendedBase = dynamicFees?.recommendedBaseFee ?? base;
+        const effectiveBase = Math.max(base, recommendedBase);
 
         if (options?.feeMultiplier) {
-          finalFee = String(Math.ceil(base * options.feeMultiplier));
+          finalFee = String(Math.ceil(effectiveBase * options.feeMultiplier));
         } else {
           const priority: FeePriority = options?.feePriority ?? "medium";
-          finalFee = String(Math.ceil(base * FEE_PRIORITY_MULTIPLIERS[priority]));
+          const modifiers = dynamicFees?.modifiers ?? DEFAULT_FEE_LEVEL_MODIFIERS;
+          finalFee = String(Math.ceil(effectiveBase * modifiers[priority]));
         }
       }
 
@@ -656,5 +683,61 @@ export class StellarGrantsSDK {
     const retval = simulation?.result?.retval;
     if (!retval) return null;
     return scValToNative(retval);
+  }
+
+  private async resolveDynamicFeeModifiers(): Promise<{
+    modifiers: FeeLevelModifiers;
+    networkLoad: FeeNetworkLoad;
+    recommendedBaseFee?: number;
+  } | null> {
+    const endpoint = this.config.feeStatsEndpoint
+      ?? (this.config.horizonUrl
+        ? `${this.config.horizonUrl.replace(/\/$/, "")}/fee_stats`
+        : undefined);
+
+    if (!endpoint) {
+      return null;
+    }
+
+    try {
+      const stats = await this.fetchJsonWithTimeout(endpoint, 5000);
+      const usage = Number(stats?.ledger_capacity_usage);
+      if (!Number.isFinite(usage)) {
+        return null;
+      }
+
+      const feeBuckets = stats?.max_fee ?? {};
+      const recommendedBaseFee = Number(
+        feeBuckets.p70 ?? feeBuckets.p60 ?? feeBuckets.p50 ?? 0,
+      );
+
+      const level = DYNAMIC_FEE_LEVELS.find((entry) => usage <= entry.maxUsage);
+      if (!level) return null;
+
+      return {
+        modifiers: level.modifiers,
+        networkLoad: level.load,
+        ...(Number.isFinite(recommendedBaseFee) && recommendedBaseFee > 0
+          ? { recommendedBaseFee }
+          : {}),
+      };
+    } catch (error) {
+      console.warn("Failed to fetch dynamic fee stats; falling back to static multipliers", error);
+      return null;
+    }
+  }
+
+  private async fetchJsonWithTimeout(url: string, timeoutMs: number): Promise<any> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response.json();
+    } finally {
+      clearTimeout(timer);
+    }
   }
 }

--- a/client/src/cli.ts
+++ b/client/src/cli.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { Command } from "commander";
+import dotenv from "dotenv";
+import { Keypair, TransactionBuilder } from "@stellar/stellar-sdk";
+import { StellarGrantsSDK } from "./StellarGrantsSDK";
+import { WalletAdapter } from "./types";
+
+type OutputFormat = "json" | "table";
+
+type CliConfig = {
+  contractId: string;
+  rpcUrl: string;
+  networkPassphrase: string;
+};
+
+class SecretKeySigner implements WalletAdapter {
+  private readonly keypair: Keypair;
+
+  constructor(secret: string) {
+    this.keypair = Keypair.fromSecret(secret);
+  }
+
+  async getPublicKey(): Promise<string> {
+    return this.keypair.publicKey();
+  }
+
+  async signTransaction(txXdr: string, networkPassphrase: string): Promise<string> {
+    const tx = TransactionBuilder.fromXDR(txXdr, networkPassphrase);
+    tx.sign(this.keypair);
+    return tx.toXDR();
+  }
+}
+
+export function resolveCliConfig(overrides: Partial<CliConfig> = {}): CliConfig {
+  const contractId = overrides.contractId ?? process.env.CONTRACT_ID;
+  const rpcUrl = overrides.rpcUrl ?? process.env.RPC_URL;
+  const networkPassphrase = overrides.networkPassphrase ?? process.env.NETWORK_PASSPHRASE;
+
+  const missing: string[] = [];
+  if (!contractId) missing.push("CONTRACT_ID");
+  if (!rpcUrl) missing.push("RPC_URL");
+  if (!networkPassphrase) missing.push("NETWORK_PASSPHRASE");
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required connection credentials: ${missing.join(", ")}`);
+  }
+
+  return {
+    contractId: contractId as string,
+    rpcUrl: rpcUrl as string,
+    networkPassphrase: networkPassphrase as string,
+  };
+}
+
+function printOutput(data: Record<string, unknown>, format: OutputFormat): void {
+  if (format === "json") {
+    process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+    return;
+  }
+  console.table(data);
+}
+
+function writeEnvTemplate(targetPath: string, force = false): string {
+  const resolved = path.resolve(targetPath);
+  if (fs.existsSync(resolved) && !force) {
+    throw new Error(`Refusing to overwrite existing file: ${resolved}. Use --force to overwrite.`);
+  }
+
+  const template = [
+    "# StellarGrants SDK CLI config",
+    "CONTRACT_ID=",
+    "RPC_URL=https://soroban-testnet.stellar.org",
+    "NETWORK_PASSPHRASE=Test SDF Network ; September 2015",
+    "CLI_SIGNER_SECRET=",
+    "",
+  ].join("\n");
+
+  fs.writeFileSync(resolved, template, "utf8");
+  return resolved;
+}
+
+async function runGrantStatus(
+  grantId: string,
+  options: { format: OutputFormat; contractId?: string; rpcUrl?: string; networkPassphrase?: string },
+): Promise<void> {
+  const cfg = resolveCliConfig(options);
+  const sdk = new StellarGrantsSDK(cfg);
+  const grant = await sdk.grantGet(Number(grantId));
+
+  printOutput(
+    {
+      command: "grant-status",
+      grantId: Number(grantId),
+      status: "ok",
+      grant,
+    },
+    options.format,
+  );
+}
+
+async function runFundGrant(
+  grantId: string,
+  options: {
+    token: string;
+    amount: string;
+    format: OutputFormat;
+    contractId?: string;
+    rpcUrl?: string;
+    networkPassphrase?: string;
+    secret?: string;
+  },
+): Promise<void> {
+  const cfg = resolveCliConfig(options);
+  const secret = options.secret ?? process.env.CLI_SIGNER_SECRET;
+  if (!secret) {
+    throw new Error("Missing signing credential: CLI_SIGNER_SECRET (or --secret)");
+  }
+
+  const signer = new SecretKeySigner(secret);
+  const sdk = new StellarGrantsSDK({ ...cfg, signer });
+
+  const tx = await sdk.grantFund({
+    grantId: Number(grantId),
+    token: options.token,
+    amount: BigInt(options.amount),
+  });
+
+  printOutput(
+    {
+      command: "fund-grant",
+      grantId: Number(grantId),
+      token: options.token,
+      amount: options.amount,
+      status: tx.status,
+      hash: (tx as any).hash,
+    },
+    options.format,
+  );
+}
+
+export async function runCli(argv = process.argv): Promise<void> {
+  const program = new Command();
+  program
+    .name("sg")
+    .description("StellarGrants developer CLI")
+    .option("--env <path>", "Path to .env file", ".env");
+
+  program
+    .command("init")
+    .description("Create a starter .env configuration")
+    .option("--path <path>", "Output path for env file", ".env")
+    .option("--force", "Overwrite existing file", false)
+    .action((options: { path: string; force: boolean }) => {
+      const resolved = writeEnvTemplate(options.path, options.force);
+      process.stdout.write(`Created ${resolved}\n`);
+    });
+
+  program
+    .command("grant-status")
+    .description("Fetch on-chain grant status")
+    .argument("<grantId>", "Grant numeric ID")
+    .option("--contract-id <id>")
+    .option("--rpc-url <url>")
+    .option("--network-passphrase <passphrase>")
+    .option("--format <format>", "json|table", "table")
+    .action(async (grantId: string, options: any) => {
+      await runGrantStatus(grantId, options);
+    });
+
+  program
+    .command("fund-grant")
+    .description("Fund an existing grant")
+    .argument("<grantId>", "Grant numeric ID")
+    .requiredOption("--token <address>", "Token contract address")
+    .requiredOption("--amount <amount>", "Amount in base units")
+    .option("--contract-id <id>")
+    .option("--rpc-url <url>")
+    .option("--network-passphrase <passphrase>")
+    .option("--secret <secret>", "Stellar secret key used for signing")
+    .option("--format <format>", "json|table", "table")
+    .action(async (grantId: string, options: any) => {
+      await runFundGrant(grantId, options);
+    });
+
+  const envPath = (() => {
+    const idx = argv.findIndex((arg) => arg === "--env");
+    if (idx >= 0 && argv[idx + 1]) return argv[idx + 1];
+    return ".env";
+  })();
+  dotenv.config({ path: envPath });
+
+  await program.parseAsync(argv);
+}
+
+if (require.main === module) {
+  runCli().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/client/src/errors/MetadataValidationError.ts
+++ b/client/src/errors/MetadataValidationError.ts
@@ -1,0 +1,25 @@
+import { StellarGrantsError } from "./StellarGrantsError";
+
+export type MetadataValidationIssue = {
+  field: string;
+  message: string;
+};
+
+export class MetadataValidationError extends StellarGrantsError {
+  readonly issues: MetadataValidationIssue[];
+  readonly schema: string;
+
+  constructor(schema: string, issues: MetadataValidationIssue[]) {
+    const details = issues
+      .map((issue) => `${issue.field}: ${issue.message}`)
+      .join(", ");
+    super(
+      `IPFS metadata validation failed for schema \"${schema}\": ${details}`,
+      "METADATA_SCHEMA_VALIDATION_FAILED",
+      { schema, issues },
+    );
+    this.name = "MetadataValidationError";
+    this.schema = schema;
+    this.issues = issues;
+  }
+}

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -25,6 +25,14 @@ export type {
   MilestoneVotedData,
 } from "./events";
 export { uploadMetadataToIPFS, fetchMetadataFromIPFS } from "./ipfs";
+export {
+  GRANT_METADATA_SCHEMA,
+  MILESTONE_METADATA_SCHEMA,
+  IPFS_METADATA_SCHEMAS,
+  inferMetadataSchemaName,
+  validateMetadataAgainstSchema,
+} from "./metadataSchemas";
+export { MetadataValidationError } from "./errors/MetadataValidationError";
 export type {
   AllowanceResult,
   AllowanceCheckResult,

--- a/client/src/ipfs.ts
+++ b/client/src/ipfs.ts
@@ -23,6 +23,10 @@
  */
 
 import { IpfsUploadConfig, IpfsUploadResult } from "./types";
+import {
+  inferMetadataSchemaName,
+  validateMetadataAgainstSchema,
+} from "./metadataSchemas";
 
 const PINATA_PIN_URL = "https://api.pinata.cloud/pinning/pinJSONToIPFS";
 
@@ -49,6 +53,11 @@ export async function uploadMetadataToIPFS(
   metadata: Record<string, unknown>,
   config: IpfsUploadConfig,
 ): Promise<IpfsUploadResult> {
+  if (!config.skipSchemaValidation) {
+    const schemaName = config.metadataSchema ?? inferMetadataSchemaName(metadata);
+    validateMetadataAgainstSchema(schemaName, metadata);
+  }
+
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };

--- a/client/src/metadataSchemas.ts
+++ b/client/src/metadataSchemas.ts
@@ -1,0 +1,88 @@
+import { MetadataValidationError, MetadataValidationIssue } from "./errors/MetadataValidationError";
+import { IpfsMetadataSchemaName } from "./types";
+
+type JsonSchema = {
+  $id: IpfsMetadataSchemaName;
+  type: "object";
+  required: string[];
+  properties: Record<string, unknown>;
+  additionalProperties: boolean;
+};
+
+export const GRANT_METADATA_SCHEMA: JsonSchema = {
+  $id: "grant",
+  type: "object",
+  required: ["title", "description"],
+  properties: {
+    title: { type: "string", minLength: 1 },
+    description: { type: "string", minLength: 1 },
+    summary: { type: "string" },
+    category: { type: "string" },
+    links: { type: "array", items: { type: "string" } },
+    milestones: { type: "array" },
+  },
+  additionalProperties: true,
+};
+
+export const MILESTONE_METADATA_SCHEMA: JsonSchema = {
+  $id: "milestone",
+  type: "object",
+  required: ["title", "description", "acceptanceCriteria"],
+  properties: {
+    title: { type: "string", minLength: 1 },
+    description: { type: "string", minLength: 1 },
+    acceptanceCriteria: { type: "string", minLength: 1 },
+    proofCid: { type: "string" },
+    links: { type: "array", items: { type: "string" } },
+    milestoneIdx: { type: "number" },
+  },
+  additionalProperties: true,
+};
+
+export const IPFS_METADATA_SCHEMAS: Record<IpfsMetadataSchemaName, JsonSchema> = {
+  grant: GRANT_METADATA_SCHEMA,
+  milestone: MILESTONE_METADATA_SCHEMA,
+};
+
+export function inferMetadataSchemaName(metadata: Record<string, unknown>): IpfsMetadataSchemaName {
+  if (
+    "acceptanceCriteria" in metadata ||
+    "milestoneIdx" in metadata ||
+    "proofCid" in metadata
+  ) {
+    return "milestone";
+  }
+  return "grant";
+}
+
+export function validateMetadataAgainstSchema(
+  schemaName: IpfsMetadataSchemaName,
+  metadata: Record<string, unknown>,
+): void {
+  const schema = IPFS_METADATA_SCHEMAS[schemaName];
+  const issues: MetadataValidationIssue[] = [];
+
+  for (const field of schema.required) {
+    const value = metadata[field];
+    if (value === undefined || value === null || value === "") {
+      issues.push({
+        field,
+        message: "is required",
+      });
+    }
+  }
+
+  for (const [field, value] of Object.entries(metadata)) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === "string" && value.trim() === "") {
+      issues.push({
+        field,
+        message: "must not be an empty string",
+      });
+    }
+  }
+
+  if (issues.length > 0) {
+    throw new MetadataValidationError(schemaName, issues);
+  }
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -49,6 +49,16 @@ export type StellarGrantsSDKConfig = {
    * @example "https://my-proxy.example.com/stellar-rpc"
    */
   proxyUrl?: string;
+  /**
+   * Optional Horizon base URL used for dynamic fee recommendations via
+   * `/fee_stats`. If omitted, static multipliers are used.
+   */
+  horizonUrl?: string;
+  /**
+   * Optional explicit endpoint for fee stats. Takes precedence over
+   * `${horizonUrl}/fee_stats` when provided.
+   */
+  feeStatsEndpoint?: string;
 };
 
 /** Result of an allowance check. */
@@ -79,7 +89,14 @@ export type IpfsUploadConfig = {
   pinataSecretKey?: string;
   /** Optional display name for the pinned object. */
   name?: string;
+  /** Explicit schema name for metadata validation before upload. */
+  metadataSchema?: IpfsMetadataSchemaName;
+  /** Disable local schema validation in exceptional flows. */
+  skipSchemaValidation?: boolean;
 };
+
+/** Supported built-in metadata schemas for IPFS artifacts. */
+export type IpfsMetadataSchemaName = "grant" | "milestone";
 
 /** Result of a successful IPFS upload. */
 export type IpfsUploadResult = {
@@ -161,13 +178,31 @@ export type FeePriority = "low" | "medium" | "high";
 export type FeeEstimate = {
   /** Raw simulated resource fee (in stroops) before any multiplier. */
   base: string;
-  /** Fee at low priority (1.0× base). */
+  /** Optional dynamic recommended base fee derived from recent network stats. */
+  recommendedBase?: string;
+  /** Fee at low priority using the effective low-tier modifier. */
   low: string;
-  /** Fee at medium priority (1.5× base). */
+  /** Fee at medium priority using the effective medium-tier modifier. */
   medium: string;
-  /** Fee at high priority (2.0× base). */
+  /** Fee at high priority using the effective high-tier modifier. */
   high: string;
+  /** Effective per-tier multipliers used for this estimate. */
+  modifiers: FeeLevelModifiers;
+  /** Network load bucket used to derive modifiers. */
+  networkLoad: FeeNetworkLoad;
+  /** Source used to derive fee modifiers. */
+  source: "horizon" | "simulation-fallback";
 };
+
+/** Frontend-safe per-tier multipliers returned with fee estimates. */
+export type FeeLevelModifiers = {
+  low: number;
+  medium: number;
+  high: number;
+};
+
+/** Coarse network load buckets for dynamic fee guidance. */
+export type FeeNetworkLoad = "low" | "moderate" | "high" | "surge";
 
 /**
  * Options for state-changing transaction invocations.

--- a/client/src/wallets/AlbedoAdapter.ts
+++ b/client/src/wallets/AlbedoAdapter.ts
@@ -1,13 +1,13 @@
 import { WalletAdapter } from "../types";
 
+type AlbedoNetwork = "testnet" | "public";
+
 export class AlbedoAdapter implements WalletAdapter {
   private publicKeyCache: string | null = null;
-  private network: "testnet" | "public" = "testnet";
+  private network: AlbedoNetwork = "testnet";
 
   constructor(networkPassphrase?: string) {
-    if (networkPassphrase?.includes("Public")) {
-      this.network = "public";
-    }
+    this.network = this.resolveNetwork(networkPassphrase ?? "");
   }
 
   async getPublicKey(): Promise<string> {
@@ -15,7 +15,11 @@ export class AlbedoAdapter implements WalletAdapter {
     const albedo = (window as any).albedo;
     if (!albedo) throw new Error("Albedo is not installed or available");
 
-    const response = await albedo.publicKey({});
+    const response = await this.executeWithPopupGuard<{ pubkey?: string }>(() => albedo.publicKey({}));
+    if (!response?.pubkey) {
+      throw new Error("Albedo did not return a public key.");
+    }
+
     this.publicKeyCache = response.pubkey;
     return response.pubkey;
   }
@@ -24,16 +28,40 @@ export class AlbedoAdapter implements WalletAdapter {
     const albedo = (window as any).albedo;
     if (!albedo) throw new Error("Albedo is not installed or available");
 
-    let network = "testnet";
-    if (networkPassphrase.includes("Public")) {
-      network = "public";
-    }
+    const network = this.resolveNetwork(networkPassphrase || this.network);
 
-    const response = await albedo.tx({
+    const response = await this.executeWithPopupGuard<{ signed_envelope_xdr?: string }>(() => albedo.tx({
       xdr: txXdr,
       network,
-    });
+    }));
+
+    if (!response?.signed_envelope_xdr) {
+      throw new Error("Albedo did not return a signed transaction envelope.");
+    }
 
     return response.signed_envelope_xdr;
+  }
+
+  private resolveNetwork(networkPassphrase: string): AlbedoNetwork {
+    if (networkPassphrase.includes("Public")) {
+      return "public";
+    }
+    // Albedo prompts currently support testnet/public. Futurenet and custom
+    // passphrases are mapped to testnet for compatibility.
+    return "testnet";
+  }
+
+  private async executeWithPopupGuard<T>(cb: () => Promise<T>): Promise<T> {
+    try {
+      return await cb();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/popup|blocked|denied|closed|cancel/i.test(message)) {
+        throw new Error(
+          "Albedo popup was blocked or closed. Enable popups for this site and try again.",
+        );
+      }
+      throw error;
+    }
   }
 }

--- a/client/src/wallets/createPreferredWalletAdapter.ts
+++ b/client/src/wallets/createPreferredWalletAdapter.ts
@@ -1,0 +1,26 @@
+import { WalletAdapter } from "../types";
+import { AlbedoAdapter } from "./AlbedoAdapter";
+import { FreighterAdapter } from "./FreighterAdapter";
+
+function hasFreighter(): boolean {
+  return typeof window !== "undefined" && Boolean((window as any).freighterApi);
+}
+
+function hasAlbedo(): boolean {
+  return typeof window !== "undefined" && Boolean((window as any).albedo);
+}
+
+/**
+ * Creates a signer with seamless Freighter -> Albedo fallback.
+ */
+export function createPreferredWalletAdapter(networkPassphrase?: string): WalletAdapter {
+  if (hasFreighter()) {
+    return new FreighterAdapter();
+  }
+  if (hasAlbedo()) {
+    return new AlbedoAdapter(networkPassphrase);
+  }
+  throw new Error(
+    "No supported wallet detected. Install Freighter or Albedo and refresh.",
+  );
+}

--- a/client/src/wallets/index.ts
+++ b/client/src/wallets/index.ts
@@ -2,3 +2,4 @@ export * from "./FreighterAdapter";
 export * from "./AlbedoAdapter";
 export * from "./WalletConnectAdapter";
 export * from "./XBullAdapter";
+export * from "./createPreferredWalletAdapter";

--- a/client/tests/cli.test.ts
+++ b/client/tests/cli.test.ts
@@ -1,0 +1,44 @@
+import { resolveCliConfig } from "../src/cli";
+
+describe("CLI config resolution", () => {
+  const envBackup = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...envBackup };
+  });
+
+  it("throws when required connection credentials are missing", () => {
+    delete process.env.CONTRACT_ID;
+    delete process.env.RPC_URL;
+    delete process.env.NETWORK_PASSPHRASE;
+
+    expect(() => resolveCliConfig()).toThrow("Missing required connection credentials");
+  });
+
+  it("uses environment values", () => {
+    process.env.CONTRACT_ID = "C123";
+    process.env.RPC_URL = "https://rpc.example";
+    process.env.NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+
+    const cfg = resolveCliConfig();
+
+    expect(cfg.contractId).toBe("C123");
+    expect(cfg.rpcUrl).toBe("https://rpc.example");
+  });
+
+  it("prefers explicit overrides", () => {
+    process.env.CONTRACT_ID = "C123";
+    process.env.RPC_URL = "https://rpc.example";
+    process.env.NETWORK_PASSPHRASE = "Test SDF Network ; September 2015";
+
+    const cfg = resolveCliConfig({
+      contractId: "C999",
+      rpcUrl: "https://rpc.override",
+      networkPassphrase: "Public Global Stellar Network ; September 2015",
+    });
+
+    expect(cfg.contractId).toBe("C999");
+    expect(cfg.rpcUrl).toBe("https://rpc.override");
+    expect(cfg.networkPassphrase).toContain("Public");
+  });
+});

--- a/client/tests/fee-estimation.test.ts
+++ b/client/tests/fee-estimation.test.ts
@@ -46,6 +46,10 @@ jest.mock("@stellar/stellar-sdk", () => {
 // estimateFees
 // ---------------------------------------------------------------------------
 describe("StellarGrantsSDK.estimateFees", () => {
+  afterEach(() => {
+    delete (global as any).fetch;
+  });
+
   it("returns fee tiers based on minResourceFee from simulation", async () => {
     const { sdk, state } = makeSdk();
     state.minResourceFee = "2000";
@@ -56,6 +60,8 @@ describe("StellarGrantsSDK.estimateFees", () => {
     expect(fees.low).toBe("2000");    // 1.0×
     expect(fees.medium).toBe("3000"); // 1.5×
     expect(fees.high).toBe("4000");   // 2.0×
+    expect(fees.modifiers).toEqual({ low: 1, medium: 1.5, high: 2 });
+    expect(fees.source).toBe("simulation-fallback");
   });
 
   it("ceilings fractional fees", async () => {
@@ -85,6 +91,45 @@ describe("StellarGrantsSDK.estimateFees", () => {
     state.simulationError = "contract error";
 
     await expect(sdk.estimateFees("grant_create", [])).rejects.toThrow();
+  });
+
+  it("uses dynamic Horizon stats when available", async () => {
+    (global as any).fetch = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        ledger_capacity_usage: "0.97",
+        max_fee: { p70: "2400" },
+      }),
+    }));
+
+    const { sdk, state } = makeSdk({ horizonUrl: "https://horizon-testnet.stellar.org" });
+    state.minResourceFee = "1000";
+
+    const fees = await sdk.estimateFees("grant_create", []);
+
+    expect(fees.base).toBe("1000");
+    expect(fees.recommendedBase).toBe("2400");
+    expect(fees.networkLoad).toBe("surge");
+    expect(fees.source).toBe("horizon");
+    expect(fees.low).toBe("3840");
+    expect(fees.medium).toBe("6000");
+    expect(fees.high).toBe("8400");
+  });
+
+  it("falls back to static tiers when fee stats fetch fails", async () => {
+    (global as any).fetch = jest.fn(async () => {
+      throw new Error("timeout");
+    });
+
+    const { sdk, state } = makeSdk({ horizonUrl: "https://horizon-testnet.stellar.org" });
+    state.minResourceFee = "1000";
+
+    const fees = await sdk.estimateFees("grant_create", []);
+
+    expect(fees.source).toBe("simulation-fallback");
+    expect(fees.low).toBe("1000");
+    expect(fees.medium).toBe("1500");
+    expect(fees.high).toBe("2000");
   });
 });
 

--- a/client/tests/integration.test.ts
+++ b/client/tests/integration.test.ts
@@ -395,6 +395,8 @@ describe("Token allowance management (#272)", () => {
 describe("IPFS metadata helpers (#261)", () => {
   const { uploadMetadataToIPFS, fetchMetadataFromIPFS } =
     require("../src/ipfs") as typeof import("../src/ipfs");
+  const { MetadataValidationError } =
+    require("../src/errors/MetadataValidationError") as typeof import("../src/errors/MetadataValidationError");
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -422,8 +424,30 @@ describe("IPFS metadata helpers (#261)", () => {
 
   it("uploadMetadataToIPFS throws when no credentials provided", async () => {
     await expect(
-      uploadMetadataToIPFS({ title: "No auth" }, {}),
+      uploadMetadataToIPFS({ title: "No auth", description: "No credentials" }, {}),
     ).rejects.toThrow(/pinata/i);
+  });
+
+  it("uploadMetadataToIPFS validates grant schema before upload", async () => {
+    await expect(
+      uploadMetadataToIPFS(
+        { title: "", description: "" },
+        { pinataJwt: "my-jwt-token", metadataSchema: "grant" },
+      ),
+    ).rejects.toBeInstanceOf(MetadataValidationError);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("uploadMetadataToIPFS validates milestone schema before upload", async () => {
+    await expect(
+      uploadMetadataToIPFS(
+        { title: "M1", description: "First milestone" },
+        { pinataJwt: "my-jwt-token", metadataSchema: "milestone" },
+      ),
+    ).rejects.toBeInstanceOf(MetadataValidationError);
+
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it("fetchMetadataFromIPFS returns parsed JSON from first responding gateway", async () => {

--- a/client/tests/wallets/albedo.test.ts
+++ b/client/tests/wallets/albedo.test.ts
@@ -101,4 +101,17 @@ describe("AlbedoAdapter.signTransaction", () => {
             "Albedo is not installed or available",
         );
     });
+
+    it("throws descriptive error when popup is blocked", async () => {
+        (global as any).window = makeAlbedoWindow({
+            tx: jest.fn(async () => {
+                throw new Error("Popup blocked");
+            }),
+        });
+        const adapter = new AlbedoAdapter();
+
+        await expect(adapter.signTransaction("TX_XDR", TESTNET_PASSPHRASE)).rejects.toThrow(
+            "Albedo popup was blocked or closed",
+        );
+    });
 });

--- a/client/tests/wallets/preferred-wallet.test.ts
+++ b/client/tests/wallets/preferred-wallet.test.ts
@@ -1,0 +1,33 @@
+import { AlbedoAdapter } from "../../src/wallets/AlbedoAdapter";
+import { FreighterAdapter } from "../../src/wallets/FreighterAdapter";
+import { createPreferredWalletAdapter } from "../../src/wallets/createPreferredWalletAdapter";
+
+afterEach(() => {
+  delete (global as any).window;
+});
+
+describe("createPreferredWalletAdapter", () => {
+  it("returns FreighterAdapter when Freighter is available", () => {
+    (global as any).window = { freighterApi: {} };
+
+    const adapter = createPreferredWalletAdapter();
+
+    expect(adapter).toBeInstanceOf(FreighterAdapter);
+  });
+
+  it("falls back to AlbedoAdapter when Freighter is unavailable", () => {
+    (global as any).window = { albedo: {} };
+
+    const adapter = createPreferredWalletAdapter();
+
+    expect(adapter).toBeInstanceOf(AlbedoAdapter);
+  });
+
+  it("throws when no supported wallet exists", () => {
+    (global as any).window = {};
+
+    expect(() => createPreferredWalletAdapter()).toThrow(
+      "No supported wallet detected",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
This PR bundles four assigned tasks for the Client SDK:
- #294 IPFS metadata schema validation before costly operations
- #295 Albedo wallet support hardening and Freighter fallback
- #296 Dynamic fee estimation using live network saturation stats
- #298 Developer CLI for faster local workflows

## What Changed

### #294 - PFS/IPFS Metadata Validation Before Contract Call
- Added built-in schema definitions for metadata artifacts:
  - grant
  - milestone
- Added local validation in uploadMetadataToIPFS before Pinata upload.
- Added descriptive local exception:
  - MetadataValidationError (includes field-level issues)
- Added integration tests to ensure malformed metadata is rejected before upload.

### #295 - Add Support for Albedo Wallet
- Hardened AlbedoAdapter with:
  - explicit passphrase -> Albedo network mapping
  - popup-blocked/closed detection with descriptive errors
  - stricter response validation for pubkey and signed XDR
- Added createPreferredWalletAdapter(networkPassphrase) helper for seamless
  Freighter -> Albedo fallback.
- Added wallet tests for fallback behavior and blocked popup handling.

### #296 - Dynamic Gas/Fee Estimation Improvements
- estimateFees now supports dynamic recommendations from Horizon /fee_stats when configured via:
  - horizonUrl
  - feeStatsEndpoint
- Added load-aware fee modifiers based on ledger saturation buckets.
- Added recommendedBase in response where available.
- Preserved safe static fallback when stats are unavailable.
- Exposed frontend-safe fee metadata:
  - modifiers
  - networkLoad
  - source
- Added tests for dynamic and fallback paths.

### #298 - CLI for Developer Tasks
- Added CLI binary entrypoint (`sg`) and command parser using commander.
- Added dotenv credential loading.
- Implemented commands:
  - init
  - grant-status
  - fund-grant
- Added JSON/table stdout support via --format.
- Added robust required-credential validation.
- Added CLI tests and README quick-start usage.

## Files of Interest
- client/src/ipfs.ts
- client/src/metadataSchemas.ts
- client/src/errors/MetadataValidationError.ts
- client/src/wallets/AlbedoAdapter.ts
- client/src/wallets/createPreferredWalletAdapter.ts
- client/src/StellarGrantsSDK.ts
- client/src/cli.ts
- client/src/types/index.ts
- client/tests/integration.test.ts
- client/tests/fee-estimation.test.ts
- client/tests/wallets/albedo.test.ts
- client/tests/wallets/preferred-wallet.test.ts
- client/tests/cli.test.ts
- client/README.md

## Validation Performed
From client/:
- npm test
- npm run build

Both passed.

## Commits
1) feat(client-sdk): add metadata validation, Albedo fallback, and dynamic fee strategy
2) feat(cli): add npx developer CLI for init, grant-status, and fund-grant

## Linked Issues
Closes #294 
Closes #295 
Closes #296 
Closes #298 
