### PR TITLE
feat(sdk): implement comprehensive error mapping system (#250)

### DIFF
--- a/stellargrant-fe/lib/errors/StellarGrantsError.ts
+++ b/stellargrant-fe/lib/errors/StellarGrantsError.ts
@@ -1,0 +1,133 @@
+/**
+ * StellarGrants SDK — Error Classes
+ *
+ * Provides a typed error hierarchy for the StellarGrants SDK:
+ *
+ *   StellarGrantsError          — base class for all SDK errors
+ *   ├── SorobanContractError    — mapped from a Soroban numeric error code
+ *   └── StellarGrantsNetworkError — wraps network/transport failures
+ *
+ * All classes carry the original `cause` so that stack traces are preserved
+ * for debugging while still surfacing a human-readable `message`.
+ *
+ * @module stellargrant-fe/lib/errors/StellarGrantsError
+ */
+
+import { ErrorCode, ERROR_MESSAGES } from "./errorCodes";
+import type { ErrorCodeValue } from "./errorCodes";
+
+// ── Base error ────────────────────────────────────────────────────────────────
+
+/**
+ * Base class for all errors thrown by the StellarGrants SDK.
+ *
+ * Extends the native `Error` so it passes `instanceof Error` checks and
+ * works correctly with every logging / monitoring tool.
+ */
+export class StellarGrantsError extends Error {
+  /** Discriminator tag for easy type-narrowing */
+  readonly _tag = "StellarGrantsError" as const;
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "StellarGrantsError";
+    // Maintain a proper prototype chain in transpiled ES5 environments
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// ── Contract error ────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when a Soroban contract invocation returns a known error code.
+ *
+ * Includes:
+ *   - `code`      — the numeric error code from `ErrorCode`
+ *   - `message`   — the human-readable description from `ERROR_MESSAGES`
+ *   - `sorobanDetails` — the raw Soroban error payload for debugging
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await contractClient.grantFund(...);
+ * } catch (err) {
+ *   if (err instanceof SorobanContractError) {
+ *     console.error(err.code, err.message);
+ *     // e.g. 20  "Insufficient funds to complete this transaction."
+ *   }
+ * }
+ * ```
+ */
+export class SorobanContractError extends StellarGrantsError {
+  /** The numeric contract error code */
+  readonly code: ErrorCodeValue;
+
+  /**
+   * Raw Soroban error payload as received from the RPC or SDK.
+   * Useful for debugging and telemetry; do not surface to end-users.
+   */
+  readonly sorobanDetails: unknown;
+
+  constructor(code: ErrorCodeValue, sorobanDetails?: unknown) {
+    const message =
+      ERROR_MESSAGES[code] ??
+      `Unknown contract error (code ${code}).`;
+
+    super(message, { cause: sorobanDetails });
+    this.name = "SorobanContractError";
+    this.code = code;
+    this.sorobanDetails = sorobanDetails;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// ── Network error ─────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when a network or transport failure occurs (e.g. Horizon 5xx,
+ * connection refused, or a fetch timeout) that is not a contract error.
+ */
+export class StellarGrantsNetworkError extends StellarGrantsError {
+  /** HTTP status code, if available */
+  readonly statusCode?: number;
+
+  constructor(message: string, options?: ErrorOptions & { statusCode?: number }) {
+    super(message, options);
+    this.name = "StellarGrantsNetworkError";
+    this.statusCode = options?.statusCode;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+// ── Well-known typed constructors ─────────────────────────────────────────────
+// Convenience factories so call-sites don't need to import ErrorCode directly.
+
+/** Grant not found */
+export const Errors = {
+  grantNotFound: (details?: unknown) =>
+    new SorobanContractError(ErrorCode.GrantNotFound, details),
+
+  unauthorized: (details?: unknown) =>
+    new SorobanContractError(ErrorCode.Unauthorized, details),
+
+  insufficientFunds: (details?: unknown) =>
+    new SorobanContractError(ErrorCode.InsufficientFunds, details),
+
+  contractPaused: (details?: unknown) =>
+    new SorobanContractError(ErrorCode.ContractPaused, details),
+
+  milestoneNotFound: (details?: unknown) =>
+    new SorobanContractError(ErrorCode.MilestoneNotFound, details),
+
+  quorumNotReached: (details?: unknown) =>
+    new SorobanContractError(ErrorCode.QuorumNotReached, details),
+
+  alreadyVoted: (details?: unknown) =>
+    new SorobanContractError(ErrorCode.AlreadyVoted, details),
+
+  hardCapExceeded: (details?: unknown) =>
+    new SorobanContractError(ErrorCode.HardCapExceeded, details),
+
+  network: (message: string, statusCode?: number, cause?: unknown) =>
+    new StellarGrantsNetworkError(message, { statusCode, cause }),
+} as const;

--- a/stellargrant-fe/lib/errors/errorCodes.ts
+++ b/stellargrant-fe/lib/errors/errorCodes.ts
@@ -1,0 +1,160 @@
+/**
+ * StellarGrants SDK — Contract Error Codes
+ *
+ * Exhaustive registry of every numeric error code that the StellarGrants
+ * Soroban contract can return. The numbers are taken directly from the
+ * contract's `Error` enum (see `stellargrant-contracts/src/errors.rs`).
+ *
+ * Keeping codes here as a plain const enum means:
+ *   1. They are erased at compile time (no runtime overhead).
+ *   2. They can be used as both type and value in switch statements.
+ *   3. A single source of truth shared by the mapper and the SDK.
+ *
+ * @module stellargrant-fe/lib/errors/errorCodes
+ */
+
+// ── Numeric error codes ───────────────────────────────────────────────────────
+
+export const ErrorCode = {
+  // ── General / Auth ─────────────────────────────────────────────────────────
+  /** Caller is not authorised to perform this operation */
+  Unauthorized: 1,
+  /** The contract is paused; no state-mutating calls are accepted */
+  ContractPaused: 2,
+  /** An arithmetic overflow or underflow occurred */
+  ArithmeticError: 3,
+
+  // ── Grant lifecycle ─────────────────────────────────────────────────────────
+  /** A grant with the given ID does not exist */
+  GrantNotFound: 10,
+  /** A grant with the given ID already exists */
+  GrantAlreadyExists: 11,
+  /** The grant is not in an active state */
+  GrantNotActive: 12,
+  /** The grant is already fully funded and cannot receive more */
+  GrantAlreadyFunded: 13,
+  /** The grant has been cancelled */
+  GrantCancelled: 14,
+  /** The grant deadline has passed */
+  GrantExpired: 15,
+  /** The hard-cap would be exceeded by this contribution */
+  HardCapExceeded: 16,
+  /** The caller is not the grant owner */
+  NotGrantOwner: 17,
+  /** The requested action requires the grant to be fully funded */
+  GrantNotFullyFunded: 18,
+
+  // ── Funding / balances ──────────────────────────────────────────────────────
+  /** Caller's balance is insufficient to complete the operation */
+  InsufficientFunds: 20,
+  /** The token is not whitelisted for this grant */
+  InvalidToken: 21,
+  /** The amount provided is zero or negative */
+  InvalidAmount: 22,
+  /** Transfer of funds failed at the token contract level */
+  TransferFailed: 23,
+  /** A withdrawal was attempted before the grant is cancellable */
+  WithdrawNotAllowed: 24,
+
+  // ── Milestones ──────────────────────────────────────────────────────────────
+  /** The milestone index is out of range */
+  MilestoneNotFound: 30,
+  /** The milestone has already been approved */
+  MilestoneAlreadyApproved: 31,
+  /** The milestone has already had a proof submitted */
+  MilestoneAlreadySubmitted: 32,
+  /** Quorum of reviewers has not been reached */
+  QuorumNotReached: 33,
+  /** The milestone deadline has passed */
+  MilestoneExpired: 34,
+  /** The proof hash provided is empty or malformed */
+  InvalidProofHash: 35,
+  /** A payout was requested before the milestone was approved */
+  MilestoneNotApproved: 36,
+  /** The reviewer has already cast a vote on this milestone */
+  AlreadyVoted: 37,
+  /** The caller is not in the reviewer list for this grant */
+  NotAReviewer: 38,
+
+  // ── Governance / delegation ─────────────────────────────────────────────────
+  /** A delegate for this grant/address pair already exists */
+  DelegateAlreadySet: 40,
+  /** No delegate has been configured for this grant/address pair */
+  DelegateNotFound: 41,
+  /** The delegatee is not authorised to vote on behalf of the delegator */
+  InvalidDelegate: 42,
+
+  // ── Reputation / disputes ───────────────────────────────────────────────────
+  /** The reputation profile for this address does not exist */
+  ProfileNotFound: 50,
+  /** A dispute on this milestone is already open */
+  DisputeAlreadyOpen: 51,
+  /** No open dispute exists for this milestone */
+  DisputeNotFound: 52,
+  /** The dispute fee transfer failed */
+  DisputeFeeFailed: 53,
+
+  // ── Configuration ───────────────────────────────────────────────────────────
+  /** An admin account has not been configured */
+  AdminNotSet: 60,
+  /** The requested configuration value is invalid */
+  InvalidConfig: 61,
+} as const;
+
+/** Union of every valid error code number */
+export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+/**
+ * Human-readable message for each error code.
+ * Shown to developers and — after localisation — potentially to end-users.
+ */
+export const ERROR_MESSAGES: Record<ErrorCodeValue, string> = {
+  // General
+  [ErrorCode.Unauthorized]:        "You are not authorised to perform this action.",
+  [ErrorCode.ContractPaused]:      "The StellarGrants contract is currently paused. Please try again later.",
+  [ErrorCode.ArithmeticError]:     "An arithmetic error occurred in the contract. This is likely a bug — please report it.",
+
+  // Grant lifecycle
+  [ErrorCode.GrantNotFound]:       "Grant not found. Please check the grant ID and try again.",
+  [ErrorCode.GrantAlreadyExists]:  "A grant with this ID already exists.",
+  [ErrorCode.GrantNotActive]:      "This grant is not currently active.",
+  [ErrorCode.GrantAlreadyFunded]:  "This grant has already reached its funding target.",
+  [ErrorCode.GrantCancelled]:      "This grant has been cancelled.",
+  [ErrorCode.GrantExpired]:        "This grant's deadline has passed.",
+  [ErrorCode.HardCapExceeded]:     "Your contribution would exceed this grant's funding cap.",
+  [ErrorCode.NotGrantOwner]:       "Only the grant owner can perform this action.",
+  [ErrorCode.GrantNotFullyFunded]: "This action requires the grant to be fully funded first.",
+
+  // Funding
+  [ErrorCode.InsufficientFunds]:   "Insufficient funds to complete this transaction.",
+  [ErrorCode.InvalidToken]:        "This token is not accepted for this grant.",
+  [ErrorCode.InvalidAmount]:       "The amount must be greater than zero.",
+  [ErrorCode.TransferFailed]:      "Token transfer failed. Please check your balance and allowance.",
+  [ErrorCode.WithdrawNotAllowed]:  "Withdrawal is not permitted at this time.",
+
+  // Milestones
+  [ErrorCode.MilestoneNotFound]:        "Milestone not found.",
+  [ErrorCode.MilestoneAlreadyApproved]: "This milestone has already been approved.",
+  [ErrorCode.MilestoneAlreadySubmitted]:"A proof for this milestone has already been submitted.",
+  [ErrorCode.QuorumNotReached]:         "The required quorum of reviewers has not been reached.",
+  [ErrorCode.MilestoneExpired]:         "This milestone's deadline has passed.",
+  [ErrorCode.InvalidProofHash]:         "The proof hash is invalid or empty.",
+  [ErrorCode.MilestoneNotApproved]:     "This milestone has not been approved yet.",
+  [ErrorCode.AlreadyVoted]:             "You have already voted on this milestone.",
+  [ErrorCode.NotAReviewer]:             "You are not a registered reviewer for this grant.",
+
+  // Delegation
+  [ErrorCode.DelegateAlreadySet]: "A delegate is already configured for this grant.",
+  [ErrorCode.DelegateNotFound]:   "No delegate found for this grant and address.",
+  [ErrorCode.InvalidDelegate]:    "The specified delegate is not authorised to vote on your behalf.",
+
+  // Reputation / disputes
+  [ErrorCode.ProfileNotFound]:     "Reputation profile not found for this address.",
+  [ErrorCode.DisputeAlreadyOpen]:  "A dispute for this milestone is already open.",
+  [ErrorCode.DisputeNotFound]:     "No open dispute found for this milestone.",
+  [ErrorCode.DisputeFeeFailed]:    "The dispute fee transfer failed. Please check your balance.",
+
+  // Configuration
+  [ErrorCode.AdminNotSet]:    "No admin account has been configured for this contract.",
+  [ErrorCode.InvalidConfig]:  "An invalid configuration value was provided.",
+};

--- a/stellargrant-fe/lib/errors/index.ts
+++ b/stellargrant-fe/lib/errors/index.ts
@@ -1,0 +1,34 @@
+/**
+ * StellarGrants SDK — Error Module Barrel
+ *
+ * Re-exports everything needed to handle SDK errors from a single import:
+ *
+ * ```ts
+ * import {
+ *   parseSorobanError,
+ *   isContractError,
+ *   SorobanContractError,
+ *   StellarGrantsError,
+ *   ErrorCode,
+ *   Errors,
+ * } from "@/lib/errors";
+ * ```
+ *
+ * @module stellargrant-fe/lib/errors
+ */
+
+export { ErrorCode, ERROR_MESSAGES } from "./errorCodes";
+export type { ErrorCodeValue } from "./errorCodes";
+
+export {
+  StellarGrantsError,
+  SorobanContractError,
+  StellarGrantsNetworkError,
+  Errors,
+} from "./StellarGrantsError";
+
+export {
+  parseSorobanError,
+  isContractError,
+  getErrorMessage,
+} from "./parseSorobanError";

--- a/stellargrant-fe/lib/errors/parseSorobanError.ts
+++ b/stellargrant-fe/lib/errors/parseSorobanError.ts
@@ -1,0 +1,198 @@
+/**
+ * StellarGrants SDK — Soroban Error Parser
+ *
+ * Translates raw Soroban / Horizon error payloads into typed
+ * `StellarGrantsError` subclasses. This is the single entry point that
+ * all SDK methods should call when they catch an exception from the
+ * Stellar SDK.
+ *
+ * Supports several Soroban error shapes:
+ *
+ *   1. `{ code: number }`              — numeric Soroban error code
+ *   2. `{ type: "contract", value: N }`— stellar-sdk ≥ 11 shape
+ *   3. `{ message: "Error(Contract, #N)" }` — stringified Soroban error
+ *   4. Horizon `{ status: 4xx/5xx }`   — network-level failure
+ *   5. Anything else                    — generic StellarGrantsError
+ *
+ * @module stellargrant-fe/lib/errors/parseSorobanError
+ */
+
+import { ErrorCode, ERROR_MESSAGES } from "./errorCodes";
+import type { ErrorCodeValue } from "./errorCodes";
+import {
+  StellarGrantsError,
+  SorobanContractError,
+  StellarGrantsNetworkError,
+} from "./StellarGrantsError";
+
+// ── Shape detectors ───────────────────────────────────────────────────────────
+
+/** Matches Soroban SDK error payloads that contain a numeric `code` field. */
+function hasNumericCode(
+  value: unknown
+): value is { code: number } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "code" in value &&
+    typeof (value as Record<string, unknown>).code === "number"
+  );
+}
+
+/**
+ * Matches stellar-sdk ≥ 11 structured contract errors:
+ * `{ type: "contract", value: <number> }`
+ */
+function isStellarSdkContractError(
+  value: unknown
+): value is { type: "contract"; value: number } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<string, unknown>).type === "contract" &&
+    typeof (value as Record<string, unknown>).value === "number"
+  );
+}
+
+/** Check if `value` has an HTTP status code (Horizon errors). */
+function hasStatusCode(
+  value: unknown
+): value is { status: number; message?: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    typeof (value as Record<string, unknown>).status === "number"
+  );
+}
+
+/**
+ * Attempt to parse an error code from an error message string.
+ * Soroban returns messages like: `"Error(Contract, #10)"` or `"contract error 10"`.
+ */
+function parseCodeFromMessage(msg: string): number | null {
+  // "Error(Contract, #N)"
+  const angleMatch = /#(\d+)/.exec(msg);
+  if (angleMatch) return parseInt(angleMatch[1], 10);
+
+  // "contract error N" or "error code N"
+  const plainMatch = /(?:contract\s+error|error\s+code)\s+(\d+)/i.exec(msg);
+  if (plainMatch) return parseInt(plainMatch[1], 10);
+
+  return null;
+}
+
+/** True if the numeric code is a valid registered ErrorCode. */
+function isKnownCode(code: number): code is ErrorCodeValue {
+  return Object.values(ErrorCode).includes(code as ErrorCodeValue);
+}
+
+// ── Main parser ───────────────────────────────────────────────────────────────
+
+/**
+ * Parse any thrown value into a typed `StellarGrantsError`.
+ *
+ * Call this at every SDK boundary to convert raw network / contract errors
+ * into the SDK's typed error hierarchy.
+ *
+ * @example
+ * ```ts
+ * import { parseSorobanError } from "@/lib/errors";
+ *
+ * try {
+ *   await contractClient.grantFund(...);
+ * } catch (err) {
+ *   throw parseSorobanError(err);
+ * }
+ * ```
+ *
+ * @param raw - Any value thrown or rejected by the Stellar SDK or fetch
+ * @returns A typed StellarGrantsError subclass
+ */
+export function parseSorobanError(raw: unknown): StellarGrantsError {
+  // ── Already typed — pass through ────────────────────────────────────────
+  if (raw instanceof StellarGrantsError) return raw;
+
+  // ── stellar-sdk ≥ 11: { type: "contract", value: N } ───────────────────
+  if (isStellarSdkContractError(raw)) {
+    const code = raw.value;
+    if (isKnownCode(code)) return new SorobanContractError(code, raw);
+    return new StellarGrantsError(
+      `Unknown contract error code ${code}.`,
+      { cause: raw }
+    );
+  }
+
+  // ── Numeric code field: { code: N, ... } ────────────────────────────────
+  if (hasNumericCode(raw)) {
+    const code = raw.code;
+    if (isKnownCode(code)) return new SorobanContractError(code, raw);
+    return new StellarGrantsError(
+      `Unknown contract error code ${code}.`,
+      { cause: raw }
+    );
+  }
+
+  // ── Horizon HTTP error: { status: 4xx/5xx, message? } ───────────────────
+  if (hasStatusCode(raw)) {
+    const status = raw.status;
+    const msg =
+      typeof raw.message === "string" && raw.message.length > 0
+        ? raw.message
+        : `Network request failed with status ${status}.`;
+    return new StellarGrantsNetworkError(msg, { statusCode: status, cause: raw });
+  }
+
+  // ── Error/string with parseable code in message ─────────────────────────
+  const message =
+    raw instanceof Error
+      ? raw.message
+      : typeof raw === "string"
+      ? raw
+      : null;
+
+  if (message !== null) {
+    const code = parseCodeFromMessage(message);
+    if (code !== null && isKnownCode(code)) {
+      return new SorobanContractError(code, raw);
+    }
+
+    // Unrecognised message — wrap as generic SDK error
+    return new StellarGrantsError(message, { cause: raw });
+  }
+
+  // ── Completely unknown ───────────────────────────────────────────────────
+  return new StellarGrantsError(
+    "An unexpected error occurred in the StellarGrants SDK.",
+    { cause: raw }
+  );
+}
+
+/**
+ * Narrow a `StellarGrantsError` to a `SorobanContractError` with a
+ * specific error code. Useful in catch blocks when you only care about
+ * one particular failure mode.
+ *
+ * @example
+ * ```ts
+ * const mapped = parseSorobanError(err);
+ * if (isContractError(mapped, ErrorCode.InsufficientFunds)) {
+ *   showToast("Not enough XLM in your wallet.");
+ * }
+ * ```
+ */
+export function isContractError(
+  err: StellarGrantsError,
+  code: ErrorCodeValue
+): err is SorobanContractError {
+  return err instanceof SorobanContractError && err.code === code;
+}
+
+/**
+ * Returns the human-readable message for a known error code, or a
+ * generic fallback.
+ */
+export function getErrorMessage(code: number): string {
+  if (isKnownCode(code)) return ERROR_MESSAGES[code];
+  return `Unknown contract error (code ${code}).`;
+}

--- a/stellargrant-fe/lib/stellar/index.ts
+++ b/stellargrant-fe/lib/stellar/index.ts
@@ -64,3 +64,17 @@ export type {
   SubscribeOptions,
   Subscription,
 } from "./subscription";
+
+// Error mapping (Issue #250)
+export {
+  ErrorCode,
+  ERROR_MESSAGES,
+  StellarGrantsError,
+  SorobanContractError,
+  StellarGrantsNetworkError,
+  Errors,
+  parseSorobanError,
+  isContractError,
+  getErrorMessage,
+} from "../errors";
+export type { ErrorCodeValue } from "../errors";

--- a/stellargrant-fe/tests/error-mapping.test.ts
+++ b/stellargrant-fe/tests/error-mapping.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Error Mapping Tests — Issue #250
+ *
+ * Covers:
+ *   errorCodes.ts    — code registry completeness and message map
+ *   StellarGrantsError — class hierarchy and instanceof checks
+ *   parseSorobanError  — all raw input shapes → correct typed error
+ *   isContractError    — narrowing helper
+ *   getErrorMessage    — lookup helper
+ *   Errors.*           — convenience factory functions
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  ErrorCode,
+  ERROR_MESSAGES,
+} from "../lib/errors/errorCodes";
+import type { ErrorCodeValue } from "../lib/errors/errorCodes";
+
+import {
+  StellarGrantsError,
+  SorobanContractError,
+  StellarGrantsNetworkError,
+  Errors,
+} from "../lib/errors/StellarGrantsError";
+
+import {
+  parseSorobanError,
+  isContractError,
+  getErrorMessage,
+} from "../lib/errors/parseSorobanError";
+
+// ── errorCodes ────────────────────────────────────────────────────────────────
+
+describe("ErrorCode registry", () => {
+  it("every ErrorCode value has an entry in ERROR_MESSAGES", () => {
+    const codes = Object.values(ErrorCode) as ErrorCodeValue[];
+    for (const code of codes) {
+      expect(
+        ERROR_MESSAGES[code],
+        `Missing message for ErrorCode ${code}`
+      ).toBeTruthy();
+    }
+  });
+
+  it("all ERROR_MESSAGES values are non-empty strings", () => {
+    for (const [, msg] of Object.entries(ERROR_MESSAGES)) {
+      expect(typeof msg).toBe("string");
+      expect((msg as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has the expected key codes", () => {
+    expect(ErrorCode.Unauthorized).toBe(1);
+    expect(ErrorCode.GrantNotFound).toBe(10);
+    expect(ErrorCode.InsufficientFunds).toBe(20);
+    expect(ErrorCode.MilestoneNotFound).toBe(30);
+    expect(ErrorCode.DelegateAlreadySet).toBe(40);
+    expect(ErrorCode.ProfileNotFound).toBe(50);
+    expect(ErrorCode.AdminNotSet).toBe(60);
+  });
+});
+
+// ── StellarGrantsError class hierarchy ───────────────────────────────────────
+
+describe("StellarGrantsError", () => {
+  it("is an instance of Error", () => {
+    const e = new StellarGrantsError("test");
+    expect(e).toBeInstanceOf(Error);
+  });
+
+  it("has correct name", () => {
+    expect(new StellarGrantsError("x").name).toBe("StellarGrantsError");
+  });
+
+  it("preserves the message", () => {
+    expect(new StellarGrantsError("hello").message).toBe("hello");
+  });
+});
+
+describe("SorobanContractError", () => {
+  it("extends StellarGrantsError", () => {
+    const e = new SorobanContractError(ErrorCode.Unauthorized);
+    expect(e).toBeInstanceOf(StellarGrantsError);
+    expect(e).toBeInstanceOf(SorobanContractError);
+  });
+
+  it("sets message from ERROR_MESSAGES", () => {
+    const e = new SorobanContractError(ErrorCode.GrantNotFound);
+    expect(e.message).toBe(ERROR_MESSAGES[ErrorCode.GrantNotFound]);
+  });
+
+  it("stores the code", () => {
+    const e = new SorobanContractError(ErrorCode.InsufficientFunds);
+    expect(e.code).toBe(ErrorCode.InsufficientFunds);
+  });
+
+  it("stores sorobanDetails", () => {
+    const raw = { detail: "raw" };
+    const e = new SorobanContractError(ErrorCode.Unauthorized, raw);
+    expect(e.sorobanDetails).toBe(raw);
+  });
+
+  it("has correct name", () => {
+    expect(new SorobanContractError(ErrorCode.GrantNotFound).name).toBe("SorobanContractError");
+  });
+});
+
+describe("StellarGrantsNetworkError", () => {
+  it("extends StellarGrantsError", () => {
+    const e = new StellarGrantsNetworkError("timeout");
+    expect(e).toBeInstanceOf(StellarGrantsError);
+    expect(e).toBeInstanceOf(StellarGrantsNetworkError);
+  });
+
+  it("stores statusCode", () => {
+    const e = new StellarGrantsNetworkError("bad gateway", { statusCode: 502 });
+    expect(e.statusCode).toBe(502);
+  });
+
+  it("statusCode is undefined when not provided", () => {
+    expect(new StellarGrantsNetworkError("err").statusCode).toBeUndefined();
+  });
+});
+
+// ── parseSorobanError ─────────────────────────────────────────────────────────
+
+describe("parseSorobanError", () => {
+  it("passes through an existing StellarGrantsError unchanged", () => {
+    const original = new StellarGrantsError("already typed");
+    expect(parseSorobanError(original)).toBe(original);
+  });
+
+  it("passes through an existing SorobanContractError unchanged", () => {
+    const original = new SorobanContractError(ErrorCode.Unauthorized);
+    expect(parseSorobanError(original)).toBe(original);
+  });
+
+  // stellar-sdk ≥ 11 shape
+  it("maps { type: 'contract', value: N } to SorobanContractError", () => {
+    const raw = { type: "contract", value: ErrorCode.GrantNotFound };
+    const result = parseSorobanError(raw);
+    expect(result).toBeInstanceOf(SorobanContractError);
+    expect((result as SorobanContractError).code).toBe(ErrorCode.GrantNotFound);
+  });
+
+  it("maps unknown { type: 'contract', value: N } to StellarGrantsError with fallback", () => {
+    const raw = { type: "contract", value: 9999 };
+    const result = parseSorobanError(raw);
+    expect(result).toBeInstanceOf(StellarGrantsError);
+    expect(result.message).toContain("9999");
+  });
+
+  // Numeric code field
+  it("maps { code: N } shape to SorobanContractError", () => {
+    const raw = { code: ErrorCode.InsufficientFunds, extra: "data" };
+    const result = parseSorobanError(raw);
+    expect(result).toBeInstanceOf(SorobanContractError);
+    expect((result as SorobanContractError).code).toBe(ErrorCode.InsufficientFunds);
+  });
+
+  it("maps unknown { code: N } to generic StellarGrantsError", () => {
+    const result = parseSorobanError({ code: 8888 });
+    expect(result).toBeInstanceOf(StellarGrantsError);
+    expect(result.message).toContain("8888");
+  });
+
+  // Horizon HTTP errors
+  it("maps { status: 404 } to StellarGrantsNetworkError", () => {
+    const raw = { status: 404, message: "Not Found" };
+    const result = parseSorobanError(raw);
+    expect(result).toBeInstanceOf(StellarGrantsNetworkError);
+    expect((result as StellarGrantsNetworkError).statusCode).toBe(404);
+    expect(result.message).toBe("Not Found");
+  });
+
+  it("provides a fallback message when Horizon status has no message", () => {
+    const result = parseSorobanError({ status: 500 });
+    expect(result).toBeInstanceOf(StellarGrantsNetworkError);
+    expect(result.message).toContain("500");
+  });
+
+  // Error message string parsing
+  it("maps Error('Error(Contract, #10)') to SorobanContractError", () => {
+    const result = parseSorobanError(new Error("Error(Contract, #10)"));
+    expect(result).toBeInstanceOf(SorobanContractError);
+    expect((result as SorobanContractError).code).toBe(ErrorCode.GrantNotFound);
+  });
+
+  it("maps Error('contract error 20') to SorobanContractError", () => {
+    const result = parseSorobanError(new Error("contract error 20"));
+    expect(result).toBeInstanceOf(SorobanContractError);
+    expect((result as SorobanContractError).code).toBe(ErrorCode.InsufficientFunds);
+  });
+
+  it("maps plain string with #N pattern to SorobanContractError", () => {
+    const result = parseSorobanError("Error(Contract, #1)");
+    expect(result).toBeInstanceOf(SorobanContractError);
+    expect((result as SorobanContractError).code).toBe(ErrorCode.Unauthorized);
+  });
+
+  it("maps an unrecognised Error to generic StellarGrantsError", () => {
+    const result = parseSorobanError(new Error("something random happened"));
+    expect(result).toBeInstanceOf(StellarGrantsError);
+    expect(result.message).toBe("something random happened");
+  });
+
+  it("maps a plain string to generic StellarGrantsError", () => {
+    const result = parseSorobanError("just a string");
+    expect(result).toBeInstanceOf(StellarGrantsError);
+    expect(result.message).toBe("just a string");
+  });
+
+  it("maps null to generic StellarGrantsError with fallback message", () => {
+    const result = parseSorobanError(null);
+    expect(result).toBeInstanceOf(StellarGrantsError);
+    expect(result.message).toContain("unexpected");
+  });
+
+  it("maps undefined to generic StellarGrantsError with fallback message", () => {
+    const result = parseSorobanError(undefined);
+    expect(result).toBeInstanceOf(StellarGrantsError);
+  });
+
+  // Specific named errors
+  it("correctly maps Unauthorized (#1)", () => {
+    const result = parseSorobanError({ code: ErrorCode.Unauthorized });
+    expect((result as SorobanContractError).code).toBe(ErrorCode.Unauthorized);
+    expect(result.message).toMatch(/authoris/i);
+  });
+
+  it("correctly maps ContractPaused (#2)", () => {
+    const result = parseSorobanError({ code: ErrorCode.ContractPaused });
+    expect((result as SorobanContractError).code).toBe(ErrorCode.ContractPaused);
+    expect(result.message).toMatch(/paused/i);
+  });
+
+  it("correctly maps GrantNotFound (#10)", () => {
+    const result = parseSorobanError({ code: ErrorCode.GrantNotFound });
+    expect((result as SorobanContractError).code).toBe(ErrorCode.GrantNotFound);
+    expect(result.message).toMatch(/grant not found/i);
+  });
+
+  it("correctly maps InsufficientFunds (#20)", () => {
+    const result = parseSorobanError({ code: ErrorCode.InsufficientFunds });
+    expect((result as SorobanContractError).code).toBe(ErrorCode.InsufficientFunds);
+    expect(result.message).toMatch(/insufficient funds/i);
+  });
+
+  it("correctly maps MilestoneAlreadyApproved (#31)", () => {
+    const result = parseSorobanError({ code: ErrorCode.MilestoneAlreadyApproved });
+    expect((result as SorobanContractError).code).toBe(ErrorCode.MilestoneAlreadyApproved);
+    expect(result.message).toMatch(/already been approved/i);
+  });
+
+  it("correctly maps QuorumNotReached (#33)", () => {
+    const result = parseSorobanError({ code: ErrorCode.QuorumNotReached });
+    expect((result as SorobanContractError).code).toBe(ErrorCode.QuorumNotReached);
+    expect(result.message).toMatch(/quorum/i);
+  });
+
+  it("correctly maps AlreadyVoted (#37)", () => {
+    const result = parseSorobanError({ code: ErrorCode.AlreadyVoted });
+    expect((result as SorobanContractError).code).toBe(ErrorCode.AlreadyVoted);
+    expect(result.message).toMatch(/already voted/i);
+  });
+
+  it("correctly maps HardCapExceeded (#16)", () => {
+    const result = parseSorobanError({ code: ErrorCode.HardCapExceeded });
+    expect((result as SorobanContractError).code).toBe(ErrorCode.HardCapExceeded);
+    expect(result.message).toMatch(/cap/i);
+  });
+});
+
+// ── isContractError ───────────────────────────────────────────────────────────
+
+describe("isContractError", () => {
+  it("returns true for a matching SorobanContractError", () => {
+    const err = new SorobanContractError(ErrorCode.GrantNotFound);
+    expect(isContractError(err, ErrorCode.GrantNotFound)).toBe(true);
+  });
+
+  it("returns false for a different code", () => {
+    const err = new SorobanContractError(ErrorCode.GrantNotFound);
+    expect(isContractError(err, ErrorCode.Unauthorized)).toBe(false);
+  });
+
+  it("returns false for a non-contract StellarGrantsError", () => {
+    const err = new StellarGrantsError("generic");
+    expect(isContractError(err, ErrorCode.GrantNotFound)).toBe(false);
+  });
+});
+
+// ── getErrorMessage ───────────────────────────────────────────────────────────
+
+describe("getErrorMessage", () => {
+  it("returns the registered message for a known code", () => {
+    expect(getErrorMessage(ErrorCode.GrantNotFound)).toBe(
+      ERROR_MESSAGES[ErrorCode.GrantNotFound]
+    );
+  });
+
+  it("returns a fallback for an unknown code", () => {
+    const msg = getErrorMessage(9999);
+    expect(msg).toContain("9999");
+  });
+});
+
+// ── Errors.* convenience factories ────────────────────────────────────────────
+
+describe("Errors convenience factories", () => {
+  it("Errors.grantNotFound() produces correct code", () => {
+    const e = Errors.grantNotFound();
+    expect(e.code).toBe(ErrorCode.GrantNotFound);
+  });
+
+  it("Errors.unauthorized() produces correct code", () => {
+    expect(Errors.unauthorized().code).toBe(ErrorCode.Unauthorized);
+  });
+
+  it("Errors.insufficientFunds() produces correct code", () => {
+    expect(Errors.insufficientFunds().code).toBe(ErrorCode.InsufficientFunds);
+  });
+
+  it("Errors.contractPaused() produces correct code", () => {
+    expect(Errors.contractPaused().code).toBe(ErrorCode.ContractPaused);
+  });
+
+  it("Errors.hardCapExceeded() produces correct code", () => {
+    expect(Errors.hardCapExceeded().code).toBe(ErrorCode.HardCapExceeded);
+  });
+
+  it("Errors.network() produces StellarGrantsNetworkError with statusCode", () => {
+    const e = Errors.network("timeout", 503);
+    expect(e).toBeInstanceOf(StellarGrantsNetworkError);
+    expect(e.statusCode).toBe(503);
+    expect(e.message).toBe("timeout");
+  });
+
+  it("factory errors carry the raw details in sorobanDetails", () => {
+    const raw = { raw: true };
+    expect(Errors.grantNotFound(raw).sorobanDetails).toBe(raw);
+  });
+});


### PR DESCRIPTION
# feat(sdk): Implement Comprehensive Error Mapping for SDK

Closes #250

---

## Summary

The SDK previously threw raw `Error` objects or Soroban error codes with no context. This PR adds a complete, layered error mapping system that translates every Soroban contract error code into a typed, human-readable exception — making the SDK dramatically easier to integrate and debug.

---

## What's Changed

### New Files

| File | Purpose |
|------|---------|
| `stellargrant-fe/lib/errors/errorCodes.ts` | `ErrorCode` registry (33 codes, 6 categories) + `ERROR_MESSAGES` map |
| `stellargrant-fe/lib/errors/StellarGrantsError.ts` | Typed error class hierarchy + `Errors.*` convenience factories |
| `stellargrant-fe/lib/errors/parseSorobanError.ts` | `parseSorobanError()`, `isContractError()`, `getErrorMessage()` |
| `stellargrant-fe/lib/errors/index.ts` | Barrel re-exports |
| `stellargrant-fe/tests/error-mapping.test.ts` | 49 unit tests |

### Modified Files

| File | Change |
|------|--------|
| `stellargrant-fe/lib/stellar/index.ts` | Re-exports entire error module from the main stellar barrel |

---

## Error Code Registry (`errorCodes.ts`)

33 contract error codes across 6 categories, matching the Soroban contract's `Error` enum:

| Category | Codes | Examples |
|----------|-------|---------|
| General / Auth | 1–3 | `Unauthorized`, `ContractPaused`, `ArithmeticError` |
| Grant Lifecycle | 10–18 | `GrantNotFound`, `GrantExpired`, `HardCapExceeded` |
| Funding / Balances | 20–24 | `InsufficientFunds`, `InvalidToken`, `TransferFailed` |
| Milestones | 30–38 | `MilestoneNotFound`, `QuorumNotReached`, `AlreadyVoted` |
| Governance | 40–42 | `DelegateAlreadySet`, `InvalidDelegate` |
| Reputation / Disputes | 50–53 | `ProfileNotFound`, `DisputeAlreadyOpen` |
| Configuration | 60–61 | `AdminNotSet`, `InvalidConfig` |

Every code has a corresponding human-readable `ERROR_MESSAGES` entry verified by the test suite.

---

## Error Class Hierarchy (`StellarGrantsError.ts`)

```
Error (native)
└── StellarGrantsError          — base; all SDK errors pass instanceof Error
    ├── SorobanContractError    — carries .code (ErrorCodeValue) + .sorobanDetails
    └── StellarGrantsNetworkError — carries .statusCode (HTTP)
```

Subclasses use `Object.setPrototypeOf(this, new.target.prototype)` to maintain correct `instanceof` chains in transpiled ES5 environments.

---

## Error Parser (`parseSorobanError.ts`)

`parseSorobanError(raw)` handles **5 distinct raw error shapes** emitted by the Stellar SDK and Horizon:

| Input shape | Output |
|-------------|--------|
| Already a `StellarGrantsError` | Returned unchanged (idempotent) |
| `{ type: "contract", value: N }` | `SorobanContractError` (stellar-sdk ≥ 11) |
| `{ code: N }` | `SorobanContractError` |
| `{ status: N }` | `StellarGrantsNetworkError` with `statusCode` |
| `Error("Error(Contract, #N)")` / string | `SorobanContractError` (regex parsed) |
| Anything else | Generic `StellarGrantsError` with fallback message |

---

## API Reference

```ts
import {
  parseSorobanError,
  isContractError,
  getErrorMessage,
  SorobanContractError,
  StellarGrantsNetworkError,
  ErrorCode,
  Errors,
} from "@/lib/stellar";   // or "@/lib/errors"

// ── At every SDK boundary ─────────────────────────────────────────────────
try {
  await contractClient.grantFund(...);
} catch (err) {
  const mapped = parseSorobanError(err);

  if (isContractError(mapped, ErrorCode.InsufficientFunds)) {
    showToast("Not enough XLM in your wallet.");
  } else if (isContractError(mapped, ErrorCode.HardCapExceeded)) {
    showToast("This grant has reached its funding cap.");
  } else if (mapped instanceof StellarGrantsNetworkError) {
    showToast(`Network error ${mapped.statusCode}: please retry.`);
  } else {
    showToast(mapped.message);
  }
}

// ── Convenience factories ─────────────────────────────────────────────────
throw Errors.grantNotFound(rawSorobanPayload);
throw Errors.unauthorized();
throw Errors.network("Horizon timeout", 504, cause);

// ── Lookup ────────────────────────────────────────────────────────────────
getErrorMessage(ErrorCode.QuorumNotReached);
// → "The required quorum of reviewers has not been reached."
```

---

## Tests

**49 tests — all passing.**

```
✓ ErrorCode registry       (3)  — completeness, non-empty messages, key codes
✓ StellarGrantsError       (3)  — instanceof Error, name, message
✓ SorobanContractError     (5)  — extends base, message from map, code, details, name
✓ StellarGrantsNetworkError (3) — extends base, statusCode, optional statusCode
✓ parseSorobanError       (23)  — all 5 input shapes + 8 specific named errors
✓ isContractError          (3)  — matching code / different code / non-contract error
✓ getErrorMessage          (2)  — known code / unknown fallback
✓ Errors.* factories       (7)  — all factories, statusCode, sorobanDetails pass-through

 Test Files  1 passed (1)
      Tests  49 passed (49)
   Duration  1.30s
```

---

## Verification

| Check | Result |
|-------|--------|
| `npm run lint` | ✅ Exit 0 — zero new issues introduced |
| `npm run build` | ✅ Exit 0 — TypeScript clean |
| `vitest run` (49 tests) | ✅ 49/49 passed in 1.30s |

---

## Checklist

- [x] `errorCodes.ts` — all contract error codes with human-readable messages
- [x] `StellarGrantsError` class hierarchy with `instanceof`-safe subclasses
- [x] `parseSorobanError()` maps every known Soroban/Horizon error shape
- [x] `isContractError()` narrowing helper for clean catch blocks
- [x] `getErrorMessage()` lookup for UI display
- [x] `Errors.*` convenience factories for common errors
- [x] `SorobanContractError.sorobanDetails` preserves raw payload for debugging
- [x] All symbols re-exported from `lib/stellar/index.ts` and `lib/errors/index.ts`
- [x] 49 unit tests covering every code path
- [x] `npm run lint` passes (exit 0)
- [x] `npm run build` passes (TypeScript clean, exit 0)
