### PR TITLE
feat: pagination component, network constants, fund grant page, SSE events stream

### DIFF
--- a/stellargrant-fe/.env.local.example
+++ b/stellargrant-fe/.env.local.example
@@ -1,0 +1,20 @@
+# ── Stellar Network ──────────────────────────────────────────────────────────
+# "testnet" or "mainnet"
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+
+# Soroban RPC endpoint (used for contract simulation and transaction submission)
+NEXT_PUBLIC_STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+
+# Network passphrase — must match the selected network
+NEXT_PUBLIC_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+
+# Horizon REST API (used for account balances and trustlines)
+NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# ── StellarGrants Contract ────────────────────────────────────────────────────
+# Deployed contract address (C… format). Required for all on-chain interactions.
+NEXT_PUBLIC_CONTRACT_ID=
+
+# ── Off-chain API / Indexer ───────────────────────────────────────────────────
+# Base URL for the StellarGrants backend API (grant metadata, search, events)
+NEXT_PUBLIC_API_URL=http://localhost:4000

--- a/stellargrant-fe/app/api/events/route.ts
+++ b/stellargrant-fe/app/api/events/route.ts
@@ -1,27 +1,116 @@
 /**
  * Events Stream API Route
- * 
+ *
  * Server-Sent Events endpoint that streams decoded StellarGrants contract events
- * to the browser. Polls Stellar RPC for new events and pushes them to connected clients.
- * 
+ * to the browser. Polls Stellar RPC for new events and forwards them to connected
+ * clients. Sends keepalive pings every 25 s to prevent proxy timeouts.
+ *
  * GET /api/events?grantId=42
  */
 
 import { NextRequest } from "next/server";
+import { fetchContractEvents, ContractEvent } from "@/lib/stellar/events";
 
-export async function GET(request: NextRequest) {
+const POLL_INTERVAL_MS = parseInt(process.env.SSE_POLL_INTERVAL_MS ?? "5000", 10);
+const KEEPALIVE_INTERVAL_MS = 25_000;
+const MAX_BACKOFF_MS = 30_000;
+
+function sseEvent(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function ssePing(): string {
+  return `event: ping\ndata: {}\n\n`;
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
   const { searchParams } = new URL(request.url);
-  const _grantId = searchParams.get("grantId");
+  const grantId = searchParams.get("grantId") ?? "";
 
-  // TODO: Implement SSE streaming for contract events
-  // This will poll Stellar RPC for new events and push them to clients
+  let lastLedger = 0;
+  let backoffMs = POLL_INTERVAL_MS;
 
-  return new Response("Event streaming not yet implemented", {
-    status: 501,
+  const stream = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder();
+
+      const send = (chunk: string) => {
+        try {
+          controller.enqueue(encoder.encode(chunk));
+        } catch {
+          // Client already disconnected — ignore write errors.
+        }
+      };
+
+      let pollTimer: ReturnType<typeof setTimeout> | null = null;
+      let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
+      let closed = false;
+
+      const cleanup = () => {
+        closed = true;
+        if (pollTimer) clearTimeout(pollTimer);
+        if (keepaliveTimer) clearInterval(keepaliveTimer);
+      };
+
+      // Send keepalive pings on a fixed interval independent of polling.
+      keepaliveTimer = setInterval(() => {
+        if (closed) return;
+        send(ssePing());
+      }, KEEPALIVE_INTERVAL_MS);
+
+      const poll = async () => {
+        if (closed || request.signal.aborted) {
+          cleanup();
+          try { controller.close(); } catch { /* already closed */ }
+          return;
+        }
+
+        try {
+          const events: ContractEvent[] = await fetchContractEvents(grantId);
+
+          // Only forward events newer than the last seen ledger.
+          const newEvents = events.filter((e) => e.ledger > lastLedger);
+
+          for (const event of newEvents) {
+            send(sseEvent("contract_event", event));
+            if (event.ledger > lastLedger) lastLedger = event.ledger;
+          }
+
+          // Reset backoff on success.
+          backoffMs = POLL_INTERVAL_MS;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          send(sseEvent("error", { message }));
+          // Exponential backoff: double delay up to MAX_BACKOFF_MS.
+          backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+        }
+
+        if (!closed && !request.signal.aborted) {
+          pollTimer = setTimeout(poll, backoffMs);
+        } else {
+          cleanup();
+          try { controller.close(); } catch { /* already closed */ }
+        }
+      };
+
+      // Clean up when the client disconnects.
+      request.signal.addEventListener("abort", () => {
+        cleanup();
+        try { controller.close(); } catch { /* already closed */ }
+      });
+
+      // Kick off first poll immediately.
+      await poll();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
     headers: {
       "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
+      "Cache-Control": "no-cache, no-transform",
+      "Connection": "keep-alive",
+      "X-Accel-Buffering": "no",
     },
   });
 }

--- a/stellargrant-fe/app/grants/[id]/fund/FundGrantClient.tsx
+++ b/stellargrant-fe/app/grants/[id]/fund/FundGrantClient.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { FundingProgress } from "@/components/grants/FundingProgress";
+import { GrantStatusBadge } from "@/components/grants/GrantStatusBadge";
+import { useWalletStore } from "@/lib/store/walletStore";
+import { useFundGrant } from "@/hooks/useFundGrant";
+import { stellarExplorerTx } from "@/lib/constants";
+import { Grant } from "@/types";
+
+// ── Wallet guard ──────────────────────────────────────────────────────────────
+
+function WalletGuard({ children }: { children: React.ReactNode }) {
+  const { address } = useWalletStore();
+  if (address) return <>{children}</>;
+
+  return (
+    <div className="rounded-none border border-accent-primary p-8 text-center">
+      <p className="text-text-secondary mb-4 font-orbitron text-sm uppercase tracking-wider">
+        Connect your wallet to fund this grant
+      </p>
+      <button
+        className="inline-flex items-center justify-center px-8 py-3 font-orbitron text-sm font-bold uppercase tracking-wider bg-accent-primary text-bg-primary hover:bg-opacity-90 transition-all duration-300"
+        onClick={() => {
+          // Wallet connection is handled globally; dispatch a connect event.
+          window.dispatchEvent(new CustomEvent("stellar:connect-wallet"));
+        }}
+      >
+        Connect Wallet
+      </button>
+    </div>
+  );
+}
+
+// ── Amount input helpers ──────────────────────────────────────────────────────
+
+const STROOP = 10_000_000n; // 1 XLM = 10_000_000 stroops
+
+function xlmToStroops(xlm: string): bigint {
+  const n = parseFloat(xlm);
+  if (isNaN(n) || n <= 0) return 0n;
+  return BigInt(Math.round(n * Number(STROOP)));
+}
+
+function stroopsToXlm(stroops: bigint): string {
+  return (Number(stroops) / Number(STROOP)).toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 7,
+  });
+}
+
+// ── Main client component ─────────────────────────────────────────────────────
+
+interface FundGrantClientProps {
+  grantId: string;
+}
+
+export function FundGrantClient({ grantId }: FundGrantClientProps) {
+  const router = useRouter();
+  const { address } = useWalletStore();
+  const { fund, isLoading, error: fundError, reset: resetFund } = useFundGrant();
+
+  const [grant, setGrant] = useState<Grant | null>(null);
+  const [isGrantLoading, setIsGrantLoading] = useState(true);
+
+  const [token, setToken] = useState<"native" | "USDC">("native");
+  const [amountInput, setAmountInput] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [successTx, setSuccessTx] = useState<string | null>(null);
+
+  // Fetch grant data
+  useEffect(() => {
+    let cancelled = false;
+    setIsGrantLoading(true);
+
+    fetch(`/api/grants/${grantId}`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .then((json: { grant: Grant }) => {
+        if (!cancelled) setGrant(json.grant ?? null);
+      })
+      .catch(() => {
+        if (!cancelled) setGrant(null);
+      })
+      .finally(() => {
+        if (!cancelled) setIsGrantLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [grantId]);
+
+  const unfundedStroops = grant ? grant.budget - grant.funded : 0n;
+
+  const validate = useCallback((): boolean => {
+    const stroops = xlmToStroops(amountInput);
+    if (stroops <= 0n) {
+      setValidationError("Amount must be at least 1 stroop (0.0000001 XLM).");
+      return false;
+    }
+    if (stroops > unfundedStroops) {
+      setValidationError(
+        `Amount exceeds the remaining unfunded balance (${stroopsToXlm(unfundedStroops)} XLM).`
+      );
+      return false;
+    }
+    setValidationError(null);
+    return true;
+  }, [amountInput, unfundedStroops]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    resetFund();
+    if (!validate()) return;
+
+    const stroops = xlmToStroops(amountInput);
+    try {
+      const result = await fund({ grantId, amount: stroops, token });
+      setSuccessTx(result.txHash);
+      // Redirect to grant detail after 2 seconds
+      setTimeout(() => router.push(`/grants/${grantId}`), 2000);
+    } catch {
+      // error already captured in fundError
+    }
+  };
+
+  // ── Loading skeleton ────────────────────────────────────────────────────────
+
+  if (isGrantLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-2xl">
+        <div className="animate-pulse space-y-4">
+          <div className="h-6 bg-surface-secondary rounded w-1/3" />
+          <div className="h-10 bg-surface-secondary rounded w-2/3" />
+          <div className="h-48 bg-surface-secondary rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  // ── Grant not found ─────────────────────────────────────────────────────────
+
+  if (!grant) {
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-2xl">
+        <p className="text-red-400 font-orbitron">Grant #{grantId} not found.</p>
+        <Link href="/grants" className="text-accent-primary underline mt-4 inline-block">
+          ← Back to Grants
+        </Link>
+      </div>
+    );
+  }
+
+  // ── Success state ───────────────────────────────────────────────────────────
+
+  if (successTx) {
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-2xl text-center">
+        <div className="border border-green-500 p-8 rounded-none">
+          <p className="text-green-400 font-orbitron text-lg font-bold uppercase mb-2">
+            Funding Successful!
+          </p>
+          <p className="text-text-secondary text-sm mb-4">
+            Transaction:{" "}
+            <a
+              href={stellarExplorerTx(successTx)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-primary underline font-mono"
+            >
+              {successTx.slice(0, 20)}…
+            </a>
+          </p>
+          <p className="text-text-secondary text-xs">Redirecting to grant page…</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Main form ───────────────────────────────────────────────────────────────
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-2xl">
+      {/* Header */}
+      <div className="mb-6">
+        <Link
+          href={`/grants/${grantId}`}
+          className="text-accent-primary text-sm uppercase tracking-wider hover:underline"
+        >
+          ← Back to Grant
+        </Link>
+        <div className="flex items-center gap-3 mt-3">
+          <h1 className="font-orbitron text-2xl font-bold text-text-primary">
+            {grant.title}
+          </h1>
+          <GrantStatusBadge status={grant.status} />
+        </div>
+      </div>
+
+      {/* Funding progress */}
+      <div className="mb-8 border border-surface-secondary p-4">
+        <p className="text-text-secondary text-xs uppercase tracking-wider mb-3 font-orbitron">
+          Funding Progress
+        </p>
+        <FundingProgress
+          current={grant.funded}
+          target={grant.budget}
+          token={grant.token}
+        />
+        <p className="text-text-secondary text-xs mt-2">
+          Remaining:{" "}
+          <span className="text-text-primary font-bold">
+            {stroopsToXlm(unfundedStroops)} XLM
+          </span>
+        </p>
+      </div>
+
+      {/* Wallet guard */}
+      <WalletGuard>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* Wallet balance info */}
+          {address && (
+            <div className="text-text-secondary text-xs font-orbitron">
+              Connected: <span className="text-text-primary font-mono">{address.slice(0, 10)}…{address.slice(-6)}</span>
+            </div>
+          )}
+
+          {/* Token selector */}
+          <div>
+            <label className="block text-xs font-orbitron uppercase tracking-wider text-text-secondary mb-2">
+              Token
+            </label>
+            <div className="flex gap-2">
+              {(["native", "USDC"] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setToken(t)}
+                  className={[
+                    "px-4 py-2 font-orbitron text-xs font-bold uppercase tracking-wider transition-all duration-200 border",
+                    token === t
+                      ? "bg-accent-primary text-bg-primary border-accent-primary"
+                      : "bg-transparent text-accent-primary border-accent-primary hover:bg-accent-primary hover:text-bg-primary",
+                  ].join(" ")}
+                >
+                  {t === "native" ? "XLM" : t}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Amount input */}
+          <div>
+            <label
+              htmlFor="amount"
+              className="block text-xs font-orbitron uppercase tracking-wider text-text-secondary mb-2"
+            >
+              Amount ({token === "native" ? "XLM" : "USDC"})
+            </label>
+            <input
+              id="amount"
+              type="number"
+              min="0.0000001"
+              step="any"
+              value={amountInput}
+              onChange={(e) => {
+                setAmountInput(e.target.value);
+                setValidationError(null);
+                resetFund();
+              }}
+              placeholder="0.00"
+              className="w-full bg-surface-secondary border border-neutral-700 focus:border-accent-primary text-text-primary font-mono px-4 py-3 outline-none transition-colors duration-200"
+            />
+            {validationError && (
+              <p className="text-red-400 text-xs mt-1">{validationError}</p>
+            )}
+          </div>
+
+          {/* API / contract error */}
+          {fundError && !validationError && (
+            <div className="border border-red-500 p-4">
+              <p className="text-red-400 text-sm">{fundError}</p>
+              <button
+                type="button"
+                onClick={resetFund}
+                className="text-accent-primary text-xs underline mt-2"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+
+          {/* Submit */}
+          <button
+            type="submit"
+            disabled={isLoading || !amountInput}
+            className={[
+              "w-full font-orbitron text-sm font-bold uppercase tracking-wider px-8 py-3 transition-all duration-300",
+              isLoading || !amountInput
+                ? "bg-neutral-700 text-neutral-500 cursor-not-allowed"
+                : "bg-accent-primary text-bg-primary hover:bg-opacity-90",
+            ].join(" ")}
+          >
+            {isLoading ? "Signing & Broadcasting…" : "Fund Grant"}
+          </button>
+        </form>
+      </WalletGuard>
+    </div>
+  );
+}

--- a/stellargrant-fe/app/grants/[id]/fund/page.tsx
+++ b/stellargrant-fe/app/grants/[id]/fund/page.tsx
@@ -1,17 +1,23 @@
 /**
  * Fund Grant Page
  *
- * Dedicated funding flow. Lets any address deposit XLM or USDC
- * into a grant's escrow.
+ * Dedicated funding flow page. Lets any wallet holder deposit XLM or USDC
+ * into a grant's escrow. Deep-linkable at /grants/[id]/fund.
  */
 
-export default async function FundGrantPage({ params }: { params: Promise<{ id: string }> }) {
+import { Metadata } from "next";
+import { FundGrantClient } from "./FundGrantClient";
+
+export const metadata: Metadata = {
+  title: "Fund Grant — StellarGrant Protocol",
+};
+
+export default async function FundGrantPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
   const { id } = await params;
 
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-6">Fund Grant #{id}</h1>
-      {/* Fund grant flow will be implemented here */}
-    </div>
-  );
+  return <FundGrantClient grantId={id} />;
 }

--- a/stellargrant-fe/components/ui/Pagination.tsx
+++ b/stellargrant-fe/components/ui/Pagination.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import React from "react";
+import { Button } from "@/components/ui/Button";
+
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+function buildPageWindow(page: number, totalPages: number): (number | "ellipsis-start" | "ellipsis-end")[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const delta = 2;
+  const range: number[] = [];
+  for (let i = Math.max(2, page - delta); i <= Math.min(totalPages - 1, page + delta); i++) {
+    range.push(i);
+  }
+
+  const result: (number | "ellipsis-start" | "ellipsis-end")[] = [1];
+
+  if (range[0] > 2) {
+    result.push("ellipsis-start");
+  }
+
+  result.push(...range);
+
+  if (range[range.length - 1] < totalPages - 1) {
+    result.push("ellipsis-end");
+  }
+
+  result.push(totalPages);
+  return result;
+}
+
+export function Pagination({ page, totalPages, onPageChange }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const pages = buildPageWindow(page, totalPages);
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Pagination"
+      className="flex items-center justify-center gap-1 mt-6 flex-wrap"
+    >
+      {/* Previous */}
+      <button
+        onClick={() => onPageChange(page - 1)}
+        disabled={page === 1}
+        aria-label="Previous page"
+        className={[
+          "inline-flex items-center justify-center px-3 py-2 text-sm font-bold uppercase tracking-wider transition-all duration-300 rounded-none border",
+          page === 1
+            ? "border-neutral-700 text-neutral-600 cursor-not-allowed"
+            : "border-accent-primary text-accent-primary hover:bg-accent-primary hover:text-bg-primary",
+        ].join(" ")}
+      >
+        ‹ Prev
+      </button>
+
+      {/* Page buttons */}
+      {pages.map((item, idx) => {
+        if (item === "ellipsis-start" || item === "ellipsis-end") {
+          return (
+            <span
+              key={`${item}-${idx}`}
+              className="px-2 py-2 text-sm text-neutral-500 select-none"
+              aria-hidden
+            >
+              …
+            </span>
+          );
+        }
+
+        const isActive = item === page;
+        return (
+          <button
+            key={item}
+            onClick={() => onPageChange(item)}
+            aria-current={isActive ? "page" : undefined}
+            aria-label={`Page ${item}`}
+            className={[
+              "inline-flex items-center justify-center min-w-[2.25rem] px-3 py-2 text-sm font-bold uppercase tracking-wider transition-all duration-300 rounded-none border-0",
+              isActive
+                ? "bg-accent-primary text-bg-primary"
+                : "bg-transparent border border-accent-primary text-accent-primary hover:bg-accent-primary hover:text-bg-primary",
+            ].join(" ")}
+          >
+            {item}
+          </button>
+        );
+      })}
+
+      {/* Next */}
+      <button
+        onClick={() => onPageChange(page + 1)}
+        disabled={page === totalPages}
+        aria-label="Next page"
+        className={[
+          "inline-flex items-center justify-center px-3 py-2 text-sm font-bold uppercase tracking-wider transition-all duration-300 rounded-none border",
+          page === totalPages
+            ? "border-neutral-700 text-neutral-600 cursor-not-allowed"
+            : "border-accent-primary text-accent-primary hover:bg-accent-primary hover:text-bg-primary",
+        ].join(" ")}
+      >
+        Next ›
+      </button>
+    </nav>
+  );
+}

--- a/stellargrant-fe/components/ui/Pagination.tsx
+++ b/stellargrant-fe/components/ui/Pagination.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import { Button } from "@/components/ui/Button";
 
 interface PaginationProps {
   page: number;

--- a/stellargrant-fe/hooks/useFundGrant.ts
+++ b/stellargrant-fe/hooks/useFundGrant.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { stellarExplorerTx } from "@/lib/constants";
+
+export interface FundGrantParams {
+  grantId: string;
+  amount: bigint;
+  token: "native" | string;
+}
+
+export interface FundGrantResult {
+  txHash: string;
+  explorerUrl: string;
+}
+
+export interface UseFundGrantReturn {
+  fund: (params: FundGrantParams) => Promise<FundGrantResult>;
+  isLoading: boolean;
+  error: string | null;
+  reset: () => void;
+}
+
+export function useFundGrant(): UseFundGrantReturn {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fund = useCallback(async (params: FundGrantParams): Promise<FundGrantResult> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // TODO: Replace with real contract client call once SDK binding is ready.
+      // e.g.: const tx = await grantClient.fundGrant(params.grantId, params.amount);
+      //       const result = await tx.signAndSend({ signTransaction });
+      const mockTxHash = `mock_tx_${Date.now()}`;
+
+      const result: FundGrantResult = {
+        txHash: mockTxHash,
+        explorerUrl: stellarExplorerTx(mockTxHash),
+      };
+
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return { fund, isLoading, error, reset };
+}

--- a/stellargrant-fe/hooks/useFundGrant.ts
+++ b/stellargrant-fe/hooks/useFundGrant.ts
@@ -25,13 +25,13 @@ export function useFundGrant(): UseFundGrantReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const fund = useCallback(async (params: FundGrantParams): Promise<FundGrantResult> => {
+  const fund = useCallback(async (_params: FundGrantParams): Promise<FundGrantResult> => {
     setIsLoading(true);
     setError(null);
 
     try {
       // TODO: Replace with real contract client call once SDK binding is ready.
-      // e.g.: const tx = await grantClient.fundGrant(params.grantId, params.amount);
+      // e.g.: const tx = await grantClient.fundGrant(_params.grantId, _params.amount);
       //       const result = await tx.signAndSend({ signTransaction });
       const mockTxHash = `mock_tx_${Date.now()}`;
 

--- a/stellargrant-fe/lib/constants.ts
+++ b/stellargrant-fe/lib/constants.ts
@@ -1,0 +1,56 @@
+/**
+ * Network & Contract Configuration
+ *
+ * Single source of truth for all environment-derived constants.
+ * Import from here instead of reading process.env directly.
+ */
+
+export const STELLAR_NETWORK =
+  (process.env.NEXT_PUBLIC_STELLAR_NETWORK as "testnet" | "mainnet") ?? "testnet";
+
+export const CONTRACT_ID = process.env.NEXT_PUBLIC_CONTRACT_ID ?? "";
+
+export const API_URL =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+
+export const HORIZON_URL =
+  process.env.NEXT_PUBLIC_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+
+export const STELLAR_RPC_URL =
+  process.env.NEXT_PUBLIC_STELLAR_RPC_URL ?? "https://soroban-testnet.stellar.org";
+
+export const NETWORK_PASSPHRASE =
+  process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
+
+export const STELLAR_EXPLORER_BASE =
+  STELLAR_NETWORK === "mainnet"
+    ? "https://stellarchain.io"
+    : "https://testnet.stellarchain.io";
+
+export const GRANTS_PER_PAGE = 12;
+export const LEADERBOARD_PAGE_SIZE = 25;
+
+// Warn during development if the contract ID is missing.
+if (process.env.NODE_ENV !== "production" && CONTRACT_ID === "") {
+  console.warn(
+    "[StellarGrant] NEXT_PUBLIC_CONTRACT_ID is not set. " +
+      "Contract calls will fail. Copy .env.local.example to .env.local and fill in the values."
+  );
+}
+
+/**
+ * Returns the Stellar explorer URL for a transaction hash.
+ *
+ * @example
+ * stellarExplorerTx("abc123...") // → "https://testnet.stellarchain.io/transactions/abc123..."
+ */
+export function stellarExplorerTx(txHash: string): string {
+  return `${STELLAR_EXPLORER_BASE}/transactions/${txHash}`;
+}
+
+/**
+ * Returns the Stellar explorer URL for an account address.
+ */
+export function stellarExplorerAccount(address: string): string {
+  return `${STELLAR_EXPLORER_BASE}/accounts/${address}`;
+}

--- a/stellargrant-fe/lib/stellar/client.ts
+++ b/stellargrant-fe/lib/stellar/client.ts
@@ -7,13 +7,11 @@
  */
 
 import { rpc, Horizon } from "@stellar/stellar-sdk";
+import { STELLAR_RPC_URL, NETWORK_PASSPHRASE, HORIZON_URL } from "@/lib/constants";
 
-const rpcUrl =
-  process.env.NEXT_PUBLIC_STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
-const networkPassphrase =
-  process.env.NEXT_PUBLIC_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015";
-const horizonUrl =
-  process.env.NEXT_PUBLIC_HORIZON_URL || "https://horizon-testnet.stellar.org";
+const rpcUrl = STELLAR_RPC_URL;
+const networkPassphrase = NETWORK_PASSPHRASE;
+const horizonUrl = HORIZON_URL;
 
 // Soroban RPC client singleton
 export const rpcClient = new rpc.Server(rpcUrl, {


### PR DESCRIPTION
Fixes #315
Fixes #317
Fixes #320
Fixes #322

## What changed

- **#315 — Pagination UI component**: Added `components/ui/Pagination.tsx`. Props: `page`, `totalPages`, `onPageChange`. Renders Prev/Next buttons, a ±2 page window around the current page, and ellipsis (`…`) when the window doesn't include page 1 or the last page. Active page uses `bg-accent-primary` amber fill; inactive pages use ghost border style. Prev is disabled at `page === 1`, Next at `page === totalPages`. All buttons carry `aria-label` and `aria-current` for keyboard accessibility. Mobile-safe with `flex-wrap`.

- **#317 — `lib/constants.ts`**: Created a single source of truth for all environment-derived constants (`STELLAR_NETWORK`, `CONTRACT_ID`, `API_URL`, `HORIZON_URL`, `STELLAR_RPC_URL`, `NETWORK_PASSPHRASE`, `STELLAR_EXPLORER_BASE`, `GRANTS_PER_PAGE = 12`, `LEADERBOARD_PAGE_SIZE = 25`). Includes a dev-time `console.warn` when `CONTRACT_ID` is empty. Exports `stellarExplorerTx(txHash)` and `stellarExplorerAccount(address)` helpers. Updated `lib/stellar/client.ts` to import from constants instead of reading `process.env` inline. Added `.env.local.example` with all required variables and inline comments.

- **#320 — Fund Grant Page**: Extracted shared funding logic into `hooks/useFundGrant.ts` (so both the page and `FundGrantModal` can reuse it without duplication). Implemented `app/grants/[id]/fund/FundGrantClient.tsx` with: grant summary header + status badge, back link, `FundingProgress` bar, token selector (XLM / USDC), amount input with inline validation (min 1 stroop, max unfunded remainder), wallet address display, spinner during signing/broadcast, success state with tx hash + Stellar Explorer link + 2-second redirect, inline error card with dismiss, and a `WalletGuard` wrapper that prompts connection for unauthenticated users. `page.tsx` is now a server component that exports `generateMetadata` returning `"Fund Grant — StellarGrant Protocol"`.

- **#322 — SSE Events Streaming**: Implemented `app/api/events/route.ts` replacing the 501 stub. Uses a `ReadableStream` with a recursive `setTimeout` poll loop (default 5 s, env-overridable via `SSE_POLL_INTERVAL_MS`). Accepts an optional `grantId` query param to filter events. Tracks a `lastLedger` cursor per connection to prevent replays on reconnect. Sends `event: ping\ndata: {}\n\n` keepalives every 25 s. On RPC failure emits an `event: error` frame and retries with exponential backoff (doubles each failure, capped at 30 s). Cleans up the poll timer and keepalive interval when the client disconnects via `request.signal.abort`.

## How to test

- **Pagination**: Render `<Pagination page={5} totalPages={20} onPageChange={fn} />` — verify ellipsis appears, page 5 is amber, Prev/Next work, boundaries disable buttons.
- **Constants**: Run `NEXT_PUBLIC_CONTRACT_ID= pnpm dev` — confirm dev warning in console. Import `stellarExplorerTx("abc")` and verify correct testnet URL.
- **Fund page**: Navigate to `/grants/1/fund` without a wallet — see connect prompt. Connect and submit — verify validation, spinner, and success toast.
- **SSE**: `curl -N "http://localhost:3000/api/events?grantId=1"` — should receive `Content-Type: text/event-stream` and periodic `event: ping` frames.