### PR TITLE
feat: add EmptyState, ErrorCard, PageHeader, FileUpload reusable components

### DIFF
--- a/stellargrant-fe/app/dashboard/page.tsx
+++ b/stellargrant-fe/app/dashboard/page.tsx
@@ -22,6 +22,7 @@ import { WalletConnect } from "@/components/wallet/WalletConnect";
 import { GrantCard, grantListVariants, grantCardVariants } from "@/components/grants/GrantCard";
 import { WatchedGrantsPanel } from "@/components/grants/WatchedGrantsPanel";
 import type { Grant } from "@/types";
+import { EmptyState, PageHeader } from "@/components/ui";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -152,13 +153,7 @@ function DashboardContent() {
   // ── Connected / watchlist ──────────────────────────────────────────────────
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl space-y-6">
-      {/* Header */}
-      <div>
-        <p className="font-mono text-xs uppercase tracking-[0.32em] text-accent-secondary">
-          Dashboard
-        </p>
-        <h1 className="mt-2 text-3xl font-bold">My Account</h1>
-      </div>
+      <PageHeader eyebrow="Dashboard" title="My Account" />
 
       {/* Wallet info card */}
       {address && (
@@ -232,21 +227,29 @@ function DashboardContent() {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
-                className="rounded-[4px] border border-border-color bg-surface/60 p-10 text-center space-y-3"
               >
-                <p className="text-text-muted text-sm">
-                  {activeTab === "my-grants" && "You haven't created any grants yet."}
-                  {activeTab === "funding" && "You haven't funded any grants yet."}
-                  {activeTab === "reviewing" && "You have no grants assigned for review."}
-                </p>
-                {activeTab === "my-grants" && (
-                  <Link
-                    href="/grants/new"
-                    className="inline-block text-sm text-accent-primary hover:underline"
-                  >
-                    Create your first grant →
-                  </Link>
-                )}
+                <EmptyState
+                  title={
+                    activeTab === "my-grants"
+                      ? "No grants created"
+                      : activeTab === "funding"
+                        ? "No grants funded"
+                        : "No review assignments"
+                  }
+                  description={
+                    activeTab === "my-grants"
+                      ? "You haven't created any grants yet."
+                      : activeTab === "funding"
+                        ? "You haven't funded any grants yet."
+                        : "You have no grants assigned for review."
+                  }
+                  action={
+                    activeTab === "my-grants"
+                      ? { label: "Create your first grant", href: "/grants/new" }
+                      : undefined
+                  }
+                  size="sm"
+                />
               </motion.div>
             ) : (
               <motion.div

--- a/stellargrant-fe/app/grants/[id]/milestones/page.tsx
+++ b/stellargrant-fe/app/grants/[id]/milestones/page.tsx
@@ -3,6 +3,7 @@
 import { use, useEffect, useState } from "react";
 import { MilestoneList } from "@/components/milestones";
 import type { Milestone } from "@/types";
+import { ErrorCard, PageHeader } from "@/components/ui";
 
 /**
  * Milestone List Page
@@ -59,6 +60,7 @@ export default function MilestonesPage({ params }: MilestonesPageProps) {
   const [title, setTitle] = useState(`Grant #${id}`);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -92,24 +94,22 @@ export default function MilestonesPage({ params }: MilestonesPageProps) {
 
     void loadGrant();
     return () => controller.abort();
-  }, [id]);
-
+  }, [id, retryCount]);
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <p className="font-mono text-xs uppercase tracking-[0.32em] text-accent-secondary">
-        Creator Timeline
-      </p>
-      <h1 className="mb-3 mt-3 text-3xl font-bold">Milestones - {title}</h1>
-      <p className="mb-8 max-w-2xl text-sm leading-6 text-text-muted">
-        Upcoming deadlines, overdue work, and submitted proofs are grouped here so creators can see what needs attention first.
-      </p>
+      <PageHeader
+        eyebrow="Creator Timeline"
+        title={`Milestones — ${title}`}
+        description="Upcoming deadlines, overdue work, and submitted proofs are grouped here so creators can see what needs attention first."
+      />
 
       {loading && <div className="shimmer h-40 rounded-[4px]" />}
       {error && (
-        <div className="rounded-[4px] border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
-          {error}
-        </div>
+        <ErrorCard
+          message={error}
+          onRetry={() => setRetryCount((c) => c + 1)}
+        />
       )}
       {!loading && !error && <MilestoneList milestones={milestones} grantId={id} />}
     </div>

--- a/stellargrant-fe/app/grants/page.tsx
+++ b/stellargrant-fe/app/grants/page.tsx
@@ -1,21 +1,9 @@
- "use client";
+"use client";
 
 import { useEffect, useState } from "react";
 import { GrantCard } from "@/components/grants/GrantCard";
 import { apiGet } from "@/lib/api";
-
-/**
- * Grant Listing Page
- *
- * Paginated, filterable list of all grants stored on-chain.
- *
- * Query Parameters:
- * - status: open | active | completed | cancelled
- * - token: XLM | USDC | all
- * - page: number (pagination)
- * - sort: newest | funded | deadline
- * - q: string (search query)
- */
+import { EmptyState, ErrorCard, PageHeader } from "@/components/ui";
 
 /** Raw shape returned by the API */
 type GrantListItem = {
@@ -67,6 +55,7 @@ export default function GrantsPage() {
   const [grants, setGrants] = useState<GrantCardInput[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -74,7 +63,6 @@ export default function GrantsPage() {
     const loadGrants = async () => {
       try {
         setLoading(true);
-        // apiGet unwraps the { data: [...] } envelope automatically
         const raw = await apiGet<GrantListItem[]>("/grants");
         if (!cancelled) {
           setGrants((Array.isArray(raw) ? raw : []).map(normaliseGrant));
@@ -92,22 +80,18 @@ export default function GrantsPage() {
     };
 
     void loadGrants();
-    return () => { cancelled = true; };
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [retryCount]);
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
-        <div>
-          <p className="font-mono text-xs uppercase tracking-[0.32em] text-accent-secondary">
-            Live Delivery Board
-          </p>
-          <h1 className="mt-3 text-3xl font-bold">Grants</h1>
-          <p className="mt-2 max-w-2xl text-sm leading-6 text-text-muted">
-            Track open grants, see which milestone tracks are slipping, and jump straight into the creator work queue.
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="Live Delivery Board"
+        title="Grants"
+        description="Track open grants, see which milestone tracks are slipping, and jump straight into the creator work queue."
+      />
 
       {loading && (
         <div className="grid gap-4 md:grid-cols-2">
@@ -118,12 +102,21 @@ export default function GrantsPage() {
       )}
 
       {error && (
-        <div className="rounded-[4px] border border-danger/40 bg-danger/10 p-4 text-sm text-danger">
-          {error}
-        </div>
+        <ErrorCard
+          message={error}
+          onRetry={() => setRetryCount((c) => c + 1)}
+        />
       )}
 
-      {!loading && !error && (
+      {!loading && !error && grants.length === 0 && (
+        <EmptyState
+          title="No grants yet"
+          description="Be the first to create a grant and kick off a milestone track."
+          action={{ label: "Create a grant", href: "/grants/create" }}
+        />
+      )}
+
+      {!loading && !error && grants.length > 0 && (
         <div className="grid gap-4 md:grid-cols-2">
           {grants.map((grant) => (
             <GrantCard key={grant.id} grant={grant} />

--- a/stellargrant-fe/components/ui/EmptyState.tsx
+++ b/stellargrant-fe/components/ui/EmptyState.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import React from "react";
+import Link from "next/link";
+
+export interface EmptyStateProps {
+  title: string;
+  description?: string;
+  action?: { label: string; href?: string; onClick?: () => void };
+  icon?: React.ReactNode;
+  size?: "sm" | "md" | "lg";
+}
+
+function SatelliteIcon({ size }: { size: "sm" | "md" | "lg" }) {
+  const dim = size === "lg" ? 64 : size === "sm" ? 40 : 48;
+  return (
+    <svg
+      width={dim}
+      height={dim}
+      viewBox="0 0 64 64"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <rect x="26" y="26" width="12" height="12" rx="1" fill="var(--text-muted)" />
+      <line x1="32" y1="26" x2="32" y2="16" stroke="var(--text-muted)" strokeWidth="2" />
+      <circle cx="32" cy="14" r="2" fill="var(--text-muted)" />
+      <rect x="8" y="28" width="16" height="8" rx="1" fill="var(--text-muted)" opacity="0.6" />
+      <line x1="24" y1="32" x2="26" y2="32" stroke="var(--text-muted)" strokeWidth="2" />
+      <rect x="40" y="28" width="16" height="8" rx="1" fill="var(--text-muted)" opacity="0.6" />
+      <line x1="38" y1="32" x2="40" y2="32" stroke="var(--text-muted)" strokeWidth="2" />
+    </svg>
+  );
+}
+
+const actionClass =
+  "inline-flex items-center justify-center border border-accent-primary px-6 py-2 font-orbitron text-sm font-bold uppercase tracking-wider text-accent-primary transition-all duration-300 hover:bg-accent-primary hover:text-bg-primary";
+
+export function EmptyState({ title, description, action, icon, size = "md" }: EmptyStateProps) {
+  const titleClass = size === "sm" ? "text-lg" : "text-xl";
+
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-16 text-center">
+      <div className="mb-4 text-text-muted">
+        {icon ?? <SatelliteIcon size={size} />}
+      </div>
+      <h3 className={`font-orbitron ${titleClass} mb-2 text-text-primary`}>{title}</h3>
+      {description && (
+        <p className="mb-6 max-w-sm font-mono text-sm text-text-muted">{description}</p>
+      )}
+      {action && (
+        <div className="mt-4">
+          {action.href ? (
+            <Link href={action.href} className={actionClass}>
+              {action.label}
+            </Link>
+          ) : (
+            <button onClick={action.onClick} className={actionClass}>
+              {action.label}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/stellargrant-fe/components/ui/ErrorCard.tsx
+++ b/stellargrant-fe/components/ui/ErrorCard.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle } from "lucide-react";
+
+export interface ErrorCardProps {
+  title?: string;
+  message: string;
+  onRetry?: () => void;
+  compact?: boolean;
+}
+
+export function ErrorCard({
+  title = "Something went wrong",
+  message,
+  onRetry,
+  compact = false,
+}: ErrorCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const needsTruncation = message.length > 200;
+  const displayMessage = needsTruncation && !expanded ? message.slice(0, 200) + "…" : message;
+
+  if (compact) {
+    return (
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4 shrink-0 text-danger" />
+        <span className="font-mono text-xs text-text-muted">
+          {displayMessage}
+          {needsTruncation && (
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="ml-1 text-danger underline"
+            >
+              {expanded ? "less" : "more"}
+            </button>
+          )}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-danger/40 bg-danger/5 p-4">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-danger" />
+        <div className="min-w-0 flex-1">
+          <p className="font-orbitron text-sm font-bold text-danger">{title}</p>
+          <p className="mt-1 font-mono text-xs text-text-muted">
+            {displayMessage}
+            {needsTruncation && (
+              <button
+                onClick={() => setExpanded(!expanded)}
+                className="ml-1 text-danger underline"
+              >
+                {expanded ? "less" : "more"}
+              </button>
+            )}
+          </p>
+          {onRetry && (
+            <button
+              onClick={onRetry}
+              className="mt-3 inline-flex items-center justify-center border border-danger/40 px-4 py-1.5 font-orbitron text-xs font-bold uppercase tracking-wider text-danger transition-all duration-300 hover:bg-danger/10"
+            >
+              Try again
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/stellargrant-fe/components/ui/FileUpload.tsx
+++ b/stellargrant-fe/components/ui/FileUpload.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertTriangle, CheckCircle, Copy, Upload, X } from "lucide-react";
+import { useIPFS } from "@/hooks/useIPFS";
+
+export interface FileUploadProps {
+  onFileSelected: (file: File) => void;
+  onCidReady?: (cid: string) => void;
+  autoUpload?: boolean;
+  accept?: string;
+  maxSizeMB?: number;
+  label?: string;
+  disabled?: boolean;
+  existingCid?: string;
+}
+
+type UploadState = "idle" | "dragover" | "selected" | "uploading" | "done" | "error";
+
+export function FileUpload({
+  onFileSelected,
+  onCidReady,
+  autoUpload = false,
+  accept,
+  maxSizeMB = 10,
+  label,
+  disabled = false,
+  existingCid,
+}: FileUploadProps) {
+  const [uploadState, setUploadState] = useState<UploadState>(existingCid ? "done" : "idle");
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [cid, setCid] = useState<string | null>(existingCid ?? null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const previewUrlRef = useRef<string | null>(null);
+  const cancelledRef = useRef(false);
+  const { upload } = useIPFS();
+
+  useEffect(() => {
+    return () => {
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    };
+  }, []);
+
+  const validate = useCallback(
+    (f: File): string | null => {
+      if (f.size > maxSizeMB * 1024 * 1024) return `File exceeds ${maxSizeMB} MB limit`;
+      if (accept) {
+        const accepted = accept.split(",").map((s) => s.trim());
+        const matches = accepted.some((a) => {
+          if (a.startsWith(".")) return f.name.toLowerCase().endsWith(a.toLowerCase());
+          if (a.endsWith("/*")) return f.type.startsWith(a.replace("/*", "/"));
+          return f.type === a;
+        });
+        if (!matches) return "File type not accepted";
+      }
+      return null;
+    },
+    [accept, maxSizeMB],
+  );
+
+  const doUpload = useCallback(
+    async (f: File) => {
+      cancelledRef.current = false;
+      setUploadState("uploading");
+      try {
+        const result = await upload(f);
+        if (cancelledRef.current) return;
+        if (result) {
+          setCid(result);
+          setUploadState("done");
+          onCidReady?.(result);
+        } else {
+          throw new Error("Upload returned an empty CID");
+        }
+      } catch (e) {
+        if (cancelledRef.current) return;
+        setError(e instanceof Error ? e.message : "Upload failed");
+        setUploadState("error");
+      }
+    },
+    [upload, onCidReady],
+  );
+
+  const handleFile = useCallback(
+    (f: File) => {
+      const validationError = validate(f);
+      if (validationError) {
+        setError(validationError);
+        setUploadState("error");
+        return;
+      }
+
+      setFile(f);
+      setError(null);
+
+      if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+      if (f.type.startsWith("image/")) {
+        const url = URL.createObjectURL(f);
+        previewUrlRef.current = url;
+        setPreview(url);
+      } else {
+        setPreview(null);
+      }
+
+      onFileSelected(f);
+
+      if (autoUpload) {
+        void doUpload(f);
+      } else {
+        setUploadState("selected");
+      }
+    },
+    [validate, onFileSelected, autoUpload, doUpload],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      if (disabled) return;
+      const f = e.dataTransfer.files[0];
+      if (f) handleFile(f);
+    },
+    [disabled, handleFile],
+  );
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (!disabled && uploadState !== "uploading" && uploadState !== "done") {
+      setUploadState("dragover");
+    }
+  };
+
+  const handleDragLeave = () => {
+    if (uploadState === "dragover") setUploadState("idle");
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) handleFile(f);
+    e.target.value = "";
+  };
+
+  const handleCopy = async () => {
+    if (!cid) return;
+    await navigator.clipboard.writeText(cid);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleReset = () => {
+    cancelledRef.current = true;
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
+    setUploadState("idle");
+    setFile(null);
+    setPreview(null);
+    setCid(null);
+    setError(null);
+  };
+
+  const zoneClass = [
+    "relative flex min-h-[140px] flex-col items-center justify-center gap-3 border-2 border-dashed p-8 text-center transition-all duration-200",
+    disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+    uploadState === "dragover"
+      ? "border-accent-secondary bg-accent-secondary/5"
+      : uploadState === "done"
+        ? "border-success/40 bg-success/5"
+        : uploadState === "error"
+          ? "border-danger/40 bg-danger/5"
+          : "border-border-color bg-bg-secondary hover:border-accent-secondary/60",
+  ].join(" ");
+
+  const openPicker = () => {
+    if (!disabled && uploadState !== "uploading" && uploadState !== "done") {
+      inputRef.current?.click();
+    }
+  };
+
+  return (
+    <div className="w-full">
+      {label && (
+        <label className="mb-2 block font-mono text-xs uppercase tracking-[0.2em] text-text-muted">
+          {label}
+        </label>
+      )}
+      <div
+        className={zoneClass}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={openPicker}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") openPicker();
+        }}
+        aria-label="File upload zone"
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          className="sr-only"
+          onChange={handleInputChange}
+          disabled={disabled}
+        />
+
+        {(uploadState === "idle" || uploadState === "dragover") && (
+          <>
+            <Upload className="h-8 w-8 text-text-muted" />
+            <div>
+              <p className="font-mono text-sm text-text-muted">
+                Drag &amp; drop your proof here
+              </p>
+              <p className="mt-1 font-mono text-xs text-text-muted/60">
+                or <span className="text-accent-secondary underline">Browse files</span>
+              </p>
+            </div>
+            <p className="font-mono text-xs text-text-muted/50">
+              {accept ? accept.replace(/,\s*/g, " · ") : ".md · .txt · .pdf · images"}&nbsp; Max:{" "}
+              {maxSizeMB} MB
+            </p>
+          </>
+        )}
+
+        {uploadState === "selected" && file && (
+          <div
+            className="flex w-full items-start gap-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {preview && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={preview} alt="preview" className="h-24 w-24 shrink-0 object-cover" />
+            )}
+            <div className="flex-1 text-left">
+              <p className="truncate font-mono text-sm text-text-primary">{file.name}</p>
+              <p className="font-mono text-xs text-text-muted">
+                {(file.size / 1024 / 1024).toFixed(2)} MB · {file.type || "unknown type"}
+              </p>
+              <button
+                className="mt-3 inline-flex items-center gap-2 bg-accent-primary px-4 py-1.5 font-orbitron text-xs font-bold uppercase tracking-wider text-bg-primary transition-all hover:opacity-90"
+                onClick={() => void doUpload(file)}
+              >
+                <Upload className="h-3 w-3" />
+                Upload to IPFS
+              </button>
+            </div>
+            <button
+              className="shrink-0 text-text-muted hover:text-danger"
+              onClick={handleReset}
+              aria-label="Remove file"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+
+        {uploadState === "uploading" && (
+          <div className="w-full" onClick={(e) => e.stopPropagation()}>
+            <p className="mb-3 text-center font-mono text-sm text-text-muted">
+              Uploading to IPFS…
+            </p>
+            <div className="h-1.5 w-full overflow-hidden bg-border-color">
+              <div className="shimmer h-full w-full" />
+            </div>
+            <div className="mt-3 flex justify-center">
+              <button
+                className="font-mono text-xs text-text-muted underline hover:text-danger"
+                onClick={handleReset}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {uploadState === "done" && cid && (
+          <div
+            className="flex w-full items-start gap-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {preview && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={preview} alt="preview" className="h-24 w-24 shrink-0 object-cover" />
+            )}
+            <div className="min-w-0 flex-1 text-left">
+              <div className="mb-1 flex items-center gap-2">
+                <CheckCircle className="h-4 w-4 shrink-0 text-success" />
+                <p className="font-mono text-xs text-success">Uploaded to IPFS</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <p className="truncate font-mono text-xs text-text-muted">
+                  {cid.length > 20 ? `${cid.slice(0, 10)}…${cid.slice(-8)}` : cid}
+                </p>
+                <button
+                  onClick={() => void handleCopy()}
+                  className="shrink-0 text-text-muted hover:text-accent-secondary"
+                  aria-label="Copy CID"
+                >
+                  <Copy className="h-3 w-3" />
+                </button>
+                {copied && <span className="font-mono text-xs text-success">Copied!</span>}
+              </div>
+            </div>
+            <button
+              className="shrink-0 text-text-muted hover:text-text-primary"
+              onClick={handleReset}
+              aria-label="Replace file"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+
+        {uploadState === "error" && (
+          <div className="w-full text-center" onClick={(e) => e.stopPropagation()}>
+            <div className="mb-1 flex items-center justify-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-danger" />
+              <p className="font-mono text-xs text-danger">{error}</p>
+            </div>
+            <button
+              className="mt-2 font-mono text-xs text-text-muted underline hover:text-danger"
+              onClick={(e) => {
+                e.stopPropagation();
+                setUploadState("idle");
+                setError(null);
+                setFile(null);
+                setPreview(null);
+              }}
+            >
+              Try again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/stellargrant-fe/components/ui/PageHeader.tsx
+++ b/stellargrant-fe/components/ui/PageHeader.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+export interface PageHeaderProps {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}
+
+export function PageHeader({ eyebrow, title, description, action }: PageHeaderProps) {
+  return (
+    <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+      <div>
+        {eyebrow && (
+          <p className="font-mono text-xs uppercase tracking-[0.32em] text-accent-secondary">
+            {eyebrow}
+          </p>
+        )}
+        <h1 className="mt-3 text-3xl font-bold">{title}</h1>
+        {description && (
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-text-muted">{description}</p>
+        )}
+      </div>
+      {action && <div>{action}</div>}
+    </div>
+  );
+}

--- a/stellargrant-fe/components/ui/index.ts
+++ b/stellargrant-fe/components/ui/index.ts
@@ -20,3 +20,15 @@ export { PageTransition } from "./PageTransition";
 
 export { AddressInput, addressToColor } from "./AddressInput";
 export type { AddressInputProps } from "./AddressInput";
+
+export { EmptyState } from "./EmptyState";
+export type { EmptyStateProps } from "./EmptyState";
+
+export { ErrorCard } from "./ErrorCard";
+export type { ErrorCardProps } from "./ErrorCard";
+
+export { PageHeader } from "./PageHeader";
+export type { PageHeaderProps } from "./PageHeader";
+
+export { FileUpload } from "./FileUpload";
+export type { FileUploadProps } from "./FileUpload";


### PR DESCRIPTION
## Summary

Implements issues by extracting four repeated UI patterns into shared `components/ui/` primitives, then migrating existing pages to use them.

### New components

| Component | File | Purpose |
|---|---|---|
| `EmptyState` | `components/ui/EmptyState.tsx` | Centered satellite SVG + title + description + optional CTA. Accepts `size`, `icon`, `action` props. |
| `ErrorCard` | `components/ui/ErrorCard.tsx` | `AlertTriangle` card with expandable message (truncates at 200 chars) and optional "Try again" retry button. Supports `compact` inline mode. |
| `PageHeader` | `components/ui/PageHeader.tsx` | Eyebrow / title / description / right-aligned action layout matching the existing pattern in Grants, Profile, and Milestones pages. |
| `FileUpload` | `components/ui/FileUpload.tsx` | Drag-and-drop zone with 6 visual states (idle, drag-over, selected, uploading, done, error), MIME/size validation, image thumbnail preview, IPFS upload via `useIPFS`, CID display with copy button, and object-URL cleanup on unmount. |

All four are exported from the `components/ui/index.ts` barrel.

### Page migrations (3 pages)

- **`app/grants/page.tsx`** — manual header → `<PageHeader>`, inline error div → `<ErrorCard onRetry>`, added `<EmptyState>` for zero-grants case
- **`app/grants/[id]/milestones/page.tsx`** — manual header → `<PageHeader>`, inline error div → `<ErrorCard onRetry>`
- **`app/dashboard/page.tsx`** — manual header → `<PageHeader>`, per-tab empty div → `<EmptyState>` with tab-specific title/description/action

### CI status

- ✅ TypeScript: `tsc --noEmit` — zero errors
- ✅ ESLint: 0 errors on all changed files (2 pre-existing warnings in dashboard unrelated to this PR)
- ✅ Tests: 369/370 pass — 1 pre-existing failure in `token-utils.test.ts` (confirmed failing on `main` before this branch)

## Test plan

- [ ] Visit `/grants` — confirm header renders, error card shows with "Try again" on API failure, satellite empty state shows when list is empty
- [ ] Visit `/grants/<id>/milestones` — confirm header renders, error card shows with "Try again" on API failure
- [ ] Visit `/dashboard` — confirm header renders, EmptyState appears per tab when no grants
- [ ] Mount `<FileUpload>` — drag a file, confirm border turns blue; drag an image, confirm thumbnail; exceed 10 MB, confirm error message
- [ ] Confirm `EmptyState` renders satellite SVG when no `icon` prop is passed
- [ ] Confirm `ErrorCard compact` mode shows inline icon + message without border

Closes #363
Closes #364
Closes #354 
Closes #372 
