### PR TITLE
feat: Next.js API proxy routes and user settings page

### DIFF
--- a/stellargrant-fe/app/api/contributors/[address]/route.ts
+++ b/stellargrant-fe/app/api/contributors/[address]/route.ts
@@ -1,0 +1,11 @@
+import { proxyGet } from "@/lib/apiProxy";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ address: string }> },
+) {
+  const { address } = await context.params;
+  return proxyGet(request, `/contributors/${encodeURIComponent(address)}`, {
+    revalidate: 120,
+  });
+}

--- a/stellargrant-fe/app/api/dashboard/[address]/route.ts
+++ b/stellargrant-fe/app/api/dashboard/[address]/route.ts
@@ -1,0 +1,11 @@
+import { proxyGet } from "@/lib/apiProxy";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ address: string }> },
+) {
+  const { address } = await context.params;
+  return proxyGet(request, `/dashboard/${encodeURIComponent(address)}`, {
+    revalidate: 10,
+  });
+}

--- a/stellargrant-fe/app/api/grants/[id]/milestones/[idx]/route.ts
+++ b/stellargrant-fe/app/api/grants/[id]/milestones/[idx]/route.ts
@@ -1,0 +1,13 @@
+import { proxyGet } from "@/lib/apiProxy";
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ id: string; idx: string }> },
+) {
+  const { id, idx } = await context.params;
+  return proxyGet(
+    request,
+    `/grants/${encodeURIComponent(id)}/milestones/${encodeURIComponent(idx)}`,
+    { revalidate: 30 },
+  );
+}

--- a/stellargrant-fe/app/api/grants/route.ts
+++ b/stellargrant-fe/app/api/grants/route.ts
@@ -1,0 +1,5 @@
+import { proxyGet } from "@/lib/apiProxy";
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/grants", { revalidate: 30 });
+}

--- a/stellargrant-fe/app/api/leaderboard/route.ts
+++ b/stellargrant-fe/app/api/leaderboard/route.ts
@@ -1,0 +1,5 @@
+import { proxyGet } from "@/lib/apiProxy";
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/leaderboard", { revalidate: 300 });
+}

--- a/stellargrant-fe/app/api/stats/route.ts
+++ b/stellargrant-fe/app/api/stats/route.ts
@@ -1,0 +1,5 @@
+import { proxyGet } from "@/lib/apiProxy";
+
+export async function GET(request: Request) {
+  return proxyGet(request, "/stats", { revalidate: 60 });
+}

--- a/stellargrant-fe/app/settings/page.tsx
+++ b/stellargrant-fe/app/settings/page.tsx
@@ -1,0 +1,19 @@
+/**
+ * /settings — Issue #386.
+ *
+ * Personal preferences (notifications, display, developer) plus a wallet
+ * panel. All state lives in `useUserPreferences`, which persists to
+ * localStorage. "Reset to defaults" wipes the stored preferences after a
+ * confirmation dialog.
+ */
+
+import type { Metadata } from "next";
+import { SettingsPageClient } from "@/components/settings/SettingsPageClient";
+
+export const metadata: Metadata = {
+  title: "Settings — StellarGrant Protocol",
+};
+
+export default function SettingsPage() {
+  return <SettingsPageClient />;
+}

--- a/stellargrant-fe/components/settings/RadioGroup.tsx
+++ b/stellargrant-fe/components/settings/RadioGroup.tsx
@@ -1,0 +1,68 @@
+/**
+ * RadioGroup — Issue #386.
+ *
+ * A horizontal group of pill-style radio buttons. Backed by hidden native
+ * `<input type="radio">` elements so the group is fully accessible (keyboard
+ * navigation, screen reader announcements).
+ */
+
+"use client";
+
+import { useId } from "react";
+
+export interface RadioOption<T extends string | number> {
+  value: T;
+  label: string;
+}
+
+export interface RadioGroupProps<T extends string | number> {
+  label: string;
+  value: T;
+  onChange: (value: T) => void;
+  options: ReadonlyArray<RadioOption<T>>;
+  name?: string;
+}
+
+export function RadioGroup<T extends string | number>({
+  label,
+  value,
+  onChange,
+  options,
+  name,
+}: RadioGroupProps<T>) {
+  const fallbackName = useId();
+  const groupName = name ?? fallbackName;
+  return (
+    <div className="flex items-center justify-between gap-4 py-3">
+      <span className="font-mono text-sm text-text-primary">{label}</span>
+      <div role="radiogroup" aria-label={label} className="flex gap-2">
+        {options.map((opt) => {
+          const id = `${groupName}-${opt.value}`;
+          const selected = opt.value === value;
+          return (
+            <label
+              key={String(opt.value)}
+              htmlFor={id}
+              className={`cursor-pointer rounded-none border px-3 py-1.5 font-mono text-xs uppercase tracking-wider transition-colors ${
+                selected
+                  ? "border-accent-primary bg-accent-primary text-bg-primary"
+                  : "border-border-color bg-surface text-text-muted hover:text-text-primary"
+              }`}
+            >
+              <input
+                id={id}
+                type="radio"
+                name={groupName}
+                value={String(opt.value)}
+                checked={selected}
+                onChange={() => onChange(opt.value)}
+                className="sr-only"
+              />
+              {opt.label}
+            </label>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/stellargrant-fe/components/settings/SettingsPageClient.tsx
+++ b/stellargrant-fe/components/settings/SettingsPageClient.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { useUserPreferences } from "@/hooks/useUserPreferences";
+import { useAddressFormat } from "@/hooks/useAddressFormat";
+import { useWallet } from "@/hooks/useWallet";
+import { ToggleSwitch } from "@/components/settings/ToggleSwitch";
+import { RadioGroup } from "@/components/settings/RadioGroup";
+
+const ADDRESS_FORMAT_OPTIONS = [
+  { value: "short" as const, label: "Short" },
+  { value: "medium" as const, label: "Medium" },
+  { value: "full" as const, label: "Full" },
+];
+
+const XLM_DECIMAL_OPTIONS = [
+  { value: 2 as const, label: "2" },
+  { value: 4 as const, label: "4" },
+  { value: 7 as const, label: "7" },
+];
+
+const DATE_FORMAT_OPTIONS = [
+  { value: "relative" as const, label: "Relative" },
+  { value: "absolute" as const, label: "Absolute" },
+];
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="border border-border-color bg-surface">
+      <header className="border-b border-border-color px-6 py-3">
+        <h2 className="font-orbitron text-sm font-bold uppercase tracking-wider text-text-primary">
+          {title}
+        </h2>
+      </header>
+      <div className="divide-y divide-border-color px-6">{children}</div>
+    </section>
+  );
+}
+
+export function SettingsPageClient() {
+  const { preferences, setPreferences, reset } = useUserPreferences();
+  const formatAddress = useAddressFormat();
+  const { address, isConnected, network, disconnect } = useWallet();
+
+  const [confirmingReset, setConfirmingReset] = useState(false);
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-12 space-y-6">
+      <header>
+        <h1 className="font-orbitron text-2xl font-bold uppercase tracking-wider text-text-primary">
+          Settings
+        </h1>
+      </header>
+
+      <Section title="Notifications">
+        <ToggleSwitch
+          label="Notify when a watched grant receives funding"
+          checked={preferences.notifyOnFunding}
+          onChange={(v) => setPreferences({ notifyOnFunding: v })}
+        />
+        <ToggleSwitch
+          label="Notify when a milestone I review is submitted"
+          checked={preferences.notifyOnMilestoneSubmit}
+          onChange={(v) => setPreferences({ notifyOnMilestoneSubmit: v })}
+        />
+        <ToggleSwitch
+          label="Notify when my grant receives a vote"
+          checked={preferences.notifyOnVote}
+          onChange={(v) => setPreferences({ notifyOnVote: v })}
+        />
+        <ToggleSwitch
+          label="Notify when a payout is released on my grant"
+          checked={preferences.notifyOnPayout}
+          onChange={(v) => setPreferences({ notifyOnPayout: v })}
+        />
+      </Section>
+
+      <Section title="Display">
+        <RadioGroup
+          label="Address format"
+          value={preferences.addressFormat}
+          onChange={(v) => setPreferences({ addressFormat: v })}
+          options={ADDRESS_FORMAT_OPTIONS}
+        />
+        <RadioGroup
+          label="XLM decimals"
+          value={preferences.xlmDecimals}
+          onChange={(v) => setPreferences({ xlmDecimals: v })}
+          options={XLM_DECIMAL_OPTIONS}
+        />
+        <RadioGroup
+          label="Dates"
+          value={preferences.dateFormat}
+          onChange={(v) => setPreferences({ dateFormat: v })}
+          options={DATE_FORMAT_OPTIONS}
+        />
+      </Section>
+
+      <Section title="Developer">
+        <ToggleSwitch
+          label="Show transaction hashes inline"
+          checked={preferences.showTxHashes}
+          onChange={(v) => setPreferences({ showTxHashes: v })}
+        />
+        <ToggleSwitch
+          label="Debug mode (verbose errors)"
+          checked={preferences.debugMode}
+          onChange={(v) => setPreferences({ debugMode: v })}
+        />
+      </Section>
+
+      <Section title="Wallet">
+        <div className="flex items-center justify-between py-3">
+          <span className="font-mono text-sm text-text-primary">Connected as</span>
+          <span className="font-mono text-sm text-text-muted">
+            {isConnected && address ? formatAddress(address) : "Not connected"}
+          </span>
+        </div>
+        <div className="flex items-center justify-between py-3">
+          <span className="font-mono text-sm text-text-primary">Network</span>
+          <span className="font-mono text-sm text-text-muted capitalize">{network}</span>
+        </div>
+        {isConnected && (
+          <div className="flex justify-end py-3">
+            <button
+              type="button"
+              onClick={disconnect}
+              className="border border-accent-primary bg-transparent px-4 py-2 font-orbitron text-xs font-bold uppercase tracking-wider text-accent-primary transition-colors hover:bg-accent-primary hover:text-bg-primary"
+            >
+              Disconnect
+            </button>
+          </div>
+        )}
+      </Section>
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={() => setConfirmingReset(true)}
+          className="border border-danger bg-transparent px-4 py-2 font-orbitron text-xs font-bold uppercase tracking-wider text-danger transition-colors hover:bg-danger hover:text-bg-primary"
+        >
+          Reset all settings to defaults
+        </button>
+      </div>
+
+      {confirmingReset && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Reset settings"
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        >
+          <div
+            aria-hidden="true"
+            onClick={() => setConfirmingReset(false)}
+            className="absolute inset-0 bg-black/60"
+          />
+          <div className="relative w-full max-w-md border border-border-color bg-surface p-6">
+            <h3 className="font-orbitron text-lg font-medium text-text-primary">
+              Reset all settings to defaults?
+            </h3>
+            <p className="mt-2 font-mono text-sm text-text-muted">
+              Your stored preferences will be cleared and the defaults will be restored.
+            </p>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setConfirmingReset(false)}
+                className="border border-accent-primary bg-transparent px-4 py-2 font-orbitron text-xs font-bold uppercase tracking-wider text-accent-primary transition-colors hover:bg-accent-primary hover:text-bg-primary"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  reset();
+                  setConfirmingReset(false);
+                }}
+                className="bg-danger px-4 py-2 font-orbitron text-xs font-bold uppercase tracking-wider text-bg-primary transition-colors hover:bg-opacity-90"
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/stellargrant-fe/components/settings/ToggleSwitch.tsx
+++ b/stellargrant-fe/components/settings/ToggleSwitch.tsx
@@ -1,0 +1,66 @@
+/**
+ * ToggleSwitch — Issue #386.
+ *
+ * A sliding pill toggle styled with design system tokens. Renders an accessible
+ * checkbox `<input>` underneath the styled track so keyboard / screen reader
+ * use just works.
+ */
+
+"use client";
+
+import { useId } from "react";
+
+export interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+}
+
+export function ToggleSwitch({
+  checked,
+  onChange,
+  label,
+  description,
+  disabled,
+}: ToggleSwitchProps) {
+  const id = useId();
+  return (
+    <label
+      htmlFor={id}
+      className={`flex items-start justify-between gap-4 py-3 cursor-pointer ${
+        disabled ? "opacity-50 cursor-not-allowed" : ""
+      }`}
+    >
+      <div className="min-w-0">
+        <span className="block font-mono text-sm text-text-primary">{label}</span>
+        {description && (
+          <span className="block font-mono text-xs text-text-muted mt-1">{description}</span>
+        )}
+      </div>
+      <span className="relative inline-flex shrink-0 items-center">
+        <input
+          id={id}
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.checked)}
+          className="peer sr-only"
+        />
+        <span
+          aria-hidden="true"
+          className={`block h-6 w-11 rounded-none border border-border-color transition-colors ${
+            checked ? "bg-accent-primary" : "bg-surface"
+          } peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-accent-secondary`}
+        />
+        <span
+          aria-hidden="true"
+          className={`absolute left-0.5 top-0.5 h-5 w-5 rounded-none bg-bg-primary transition-transform ${
+            checked ? "translate-x-5" : "translate-x-0"
+          }`}
+        />
+      </span>
+    </label>
+  );
+}

--- a/stellargrant-fe/components/wallet/WalletAddress.tsx
+++ b/stellargrant-fe/components/wallet/WalletAddress.tsx
@@ -17,6 +17,7 @@
 
 import { useState, useCallback } from "react";
 import { toast } from "@/lib/toast";
+import { useAddressFormat } from "@/hooks/useAddressFormat";
 
 // ── Inline SVG icons (no icon-library dependency) ─────────────────────────────
 
@@ -90,12 +91,6 @@ interface WalletAddressProps {
 
 const CHECKMARK_DURATION_MS = 2000;
 
-/** Truncate to first-6 … last-4 per spec: GABC12…XYZ9 */
-function truncateAddress(address: string): string {
-  if (address.length <= 10) return address;
-  return `${address.slice(0, 6)}…${address.slice(-4)}`;
-}
-
 export function WalletAddress({
   address,
   showCopyIcon = true,
@@ -103,6 +98,7 @@ export function WalletAddress({
   showCopy, // back-compat alias
 }: WalletAddressProps) {
   const [copied, setCopied] = useState(false);
+  const formatAddress = useAddressFormat();
 
   // Resolve alias: if old showCopy prop is explicitly passed, honour it
   const iconVisible = showCopy !== undefined ? showCopy : showCopyIcon;
@@ -140,7 +136,7 @@ export function WalletAddress({
         className="font-mono text-sm"
         title={address}
       >
-        {truncateAddress(address)}
+        {formatAddress(address)}
       </span>
 
       {iconVisible && (

--- a/stellargrant-fe/hooks/useAddressFormat.ts
+++ b/stellargrant-fe/hooks/useAddressFormat.ts
@@ -1,0 +1,32 @@
+/**
+ * useAddressFormat — Issue #386.
+ *
+ * Returns a truncation function derived from the user's `addressFormat`
+ * preference:
+ *   short  → first-6 … last-4   (default)
+ *   medium → first-8 … last-6
+ *   full   → no truncation
+ */
+
+"use client";
+
+import { useCallback } from "react";
+import { useUserPreferences, type AddressFormat } from "@/hooks/useUserPreferences";
+
+/** Pure truncator — exposed for non-React callers and easy testing. */
+export function formatAddressFor(format: AddressFormat, address: string): string {
+  if (!address) return address;
+  if (format === "full") return address;
+  if (format === "medium") {
+    return address.length > 14 ? `${address.slice(0, 8)}…${address.slice(-6)}` : address;
+  }
+  return address.length > 10 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
+}
+
+export function useAddressFormat(): (address: string) => string {
+  const { preferences } = useUserPreferences();
+  return useCallback(
+    (address: string) => formatAddressFor(preferences.addressFormat, address),
+    [preferences.addressFormat],
+  );
+}

--- a/stellargrant-fe/hooks/useUserPreferences.ts
+++ b/stellargrant-fe/hooks/useUserPreferences.ts
@@ -1,0 +1,177 @@
+/**
+ * useUserPreferences — Issue #386.
+ *
+ * Typed access to the user's personal preferences (notifications, display,
+ * developer options) persisted to `localStorage` under `sg-preferences`.
+ *
+ * Reads are SSR-safe (returns defaults on the server) and writes are
+ * partial — pass only the keys you want to change.
+ */
+
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+export const STORAGE_KEY = "sg-preferences";
+
+export type AddressFormat = "short" | "medium" | "full";
+export type XlmDecimals = 2 | 4 | 7;
+export type DateFormat = "relative" | "absolute";
+
+export interface UserPreferences {
+  // Notifications
+  notifyOnFunding: boolean;
+  notifyOnMilestoneSubmit: boolean;
+  notifyOnVote: boolean;
+  notifyOnPayout: boolean;
+
+  // Display
+  addressFormat: AddressFormat;
+  xlmDecimals: XlmDecimals;
+  dateFormat: DateFormat;
+
+  // Developer
+  showTxHashes: boolean;
+  debugMode: boolean;
+}
+
+export const DEFAULT_PREFERENCES: UserPreferences = {
+  notifyOnFunding: true,
+  notifyOnMilestoneSubmit: true,
+  notifyOnVote: true,
+  notifyOnPayout: true,
+
+  addressFormat: "short",
+  xlmDecimals: 7,
+  dateFormat: "relative",
+
+  showTxHashes: false,
+  debugMode: false,
+};
+
+const PREF_CHANGED_EVENT = "sg:preferences-changed";
+
+/**
+ * Coerce arbitrary JSON to a valid `UserPreferences` by falling back to defaults
+ * for any missing or out-of-range value.
+ */
+export function mergePreferences(raw: unknown): UserPreferences {
+  if (!raw || typeof raw !== "object") return { ...DEFAULT_PREFERENCES };
+  const r = raw as Partial<Record<keyof UserPreferences, unknown>>;
+  const bool = (v: unknown, fallback: boolean): boolean =>
+    typeof v === "boolean" ? v : fallback;
+
+  const addressFormat: AddressFormat =
+    r.addressFormat === "short" || r.addressFormat === "medium" || r.addressFormat === "full"
+      ? r.addressFormat
+      : DEFAULT_PREFERENCES.addressFormat;
+
+  const xlmDecimals: XlmDecimals =
+    r.xlmDecimals === 2 || r.xlmDecimals === 4 || r.xlmDecimals === 7
+      ? r.xlmDecimals
+      : DEFAULT_PREFERENCES.xlmDecimals;
+
+  const dateFormat: DateFormat =
+    r.dateFormat === "relative" || r.dateFormat === "absolute"
+      ? r.dateFormat
+      : DEFAULT_PREFERENCES.dateFormat;
+
+  return {
+    notifyOnFunding: bool(r.notifyOnFunding, DEFAULT_PREFERENCES.notifyOnFunding),
+    notifyOnMilestoneSubmit: bool(
+      r.notifyOnMilestoneSubmit,
+      DEFAULT_PREFERENCES.notifyOnMilestoneSubmit,
+    ),
+    notifyOnVote: bool(r.notifyOnVote, DEFAULT_PREFERENCES.notifyOnVote),
+    notifyOnPayout: bool(r.notifyOnPayout, DEFAULT_PREFERENCES.notifyOnPayout),
+    addressFormat,
+    xlmDecimals,
+    dateFormat,
+    showTxHashes: bool(r.showTxHashes, DEFAULT_PREFERENCES.showTxHashes),
+    debugMode: bool(r.debugMode, DEFAULT_PREFERENCES.debugMode),
+  };
+}
+
+/** SSR-safe read from localStorage. */
+export function readPreferences(): UserPreferences {
+  if (typeof window === "undefined") return { ...DEFAULT_PREFERENCES };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_PREFERENCES };
+    return mergePreferences(JSON.parse(raw));
+  } catch {
+    return { ...DEFAULT_PREFERENCES };
+  }
+}
+
+function persistPreferences(prefs: UserPreferences): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    window.dispatchEvent(new CustomEvent(PREF_CHANGED_EVENT));
+  } catch {
+    // Storage may be unavailable (Safari private mode, quota); silently degrade.
+  }
+}
+
+export interface UseUserPreferencesResult {
+  preferences: UserPreferences;
+  /** Update one or more keys. */
+  setPreferences: (patch: Partial<UserPreferences>) => void;
+  /** Wipe all custom preferences and revert to the defaults. */
+  reset: () => void;
+}
+
+/** Memoised snapshot so React's bail-out comparison is stable. */
+let cachedSnapshot: UserPreferences = DEFAULT_PREFERENCES;
+let cachedSnapshotRaw: string | null | undefined = undefined;
+
+function getSnapshot(): UserPreferences {
+  if (typeof window === "undefined") return DEFAULT_PREFERENCES;
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (raw === cachedSnapshotRaw) return cachedSnapshot;
+  cachedSnapshotRaw = raw;
+  cachedSnapshot = readPreferences();
+  return cachedSnapshot;
+}
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const onChange = () => {
+    // Invalidate the snapshot cache so the next getSnapshot reads fresh.
+    cachedSnapshotRaw = undefined;
+    callback();
+  };
+  window.addEventListener(PREF_CHANGED_EVENT, onChange);
+  window.addEventListener("storage", onChange);
+  return () => {
+    window.removeEventListener(PREF_CHANGED_EVENT, onChange);
+    window.removeEventListener("storage", onChange);
+  };
+}
+
+export function useUserPreferences(): UseUserPreferencesResult {
+  const preferences = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    () => DEFAULT_PREFERENCES,
+  );
+
+  const setPreferences = useCallback((patch: Partial<UserPreferences>) => {
+    const current = typeof window !== "undefined" ? readPreferences() : DEFAULT_PREFERENCES;
+    persistPreferences({ ...current, ...patch });
+  }, []);
+
+  const reset = useCallback(() => {
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        // ignore
+      }
+      window.dispatchEvent(new CustomEvent(PREF_CHANGED_EVENT));
+    }
+  }, []);
+
+  return { preferences, setPreferences, reset };
+}

--- a/stellargrant-fe/lib/apiProxy.ts
+++ b/stellargrant-fe/lib/apiProxy.ts
@@ -1,0 +1,93 @@
+/**
+ * Server-side helpers for the Next.js API proxy layer (Issue #371).
+ *
+ * Every proxy route in `app/api/*` forwards to the Express backend through
+ * `proxyGet`. The backend URL is read from the *private* `API_URL` env var
+ * (with a fallback to the legacy `NEXT_PUBLIC_API_URL` for environments that
+ * still set it) so it never reaches client-side JavaScript. An optional shared
+ * secret is forwarded as `X-Internal-Secret`.
+ *
+ * Upstream errors are normalised into a stable JSON shape:
+ *   { error: string, code: string, status: number }
+ */
+
+import { NextResponse } from "next/server";
+
+/** Internal backend base URL — server-side only. */
+export const INTERNAL_API_URL =
+  process.env.API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:4000";
+
+/** Optional shared secret forwarded to the upstream as `X-Internal-Secret`. */
+export const INTERNAL_API_SECRET = process.env.API_SECRET ?? "";
+
+export interface ProxyErrorBody {
+  error: string;
+  code: string;
+  status: number;
+}
+
+const TIMEOUT_MS = 10_000;
+
+/**
+ * Forward `path` (with the caller's query string) to the upstream API. Returns
+ * the upstream JSON on success or a normalised `ProxyErrorBody` on any kind of
+ * failure. Always emits a `Cache-Control: s-maxage=<revalidate>` header so the
+ * Vercel/Next edge layer can cache the response.
+ */
+export async function proxyGet(
+  request: Request,
+  upstreamPath: string,
+  options: { revalidate: number; forwardSearch?: boolean } = { revalidate: 30 },
+): Promise<NextResponse> {
+  const { revalidate, forwardSearch = true } = options;
+
+  let url = `${INTERNAL_API_URL}${upstreamPath}`;
+  if (forwardSearch) {
+    const search = new URL(request.url).searchParams.toString();
+    if (search) url += `?${search}`;
+  }
+
+  const headers: HeadersInit = { Accept: "application/json" };
+  if (INTERNAL_API_SECRET) {
+    headers["X-Internal-Secret"] = INTERNAL_API_SECRET;
+  }
+
+  const cacheHeader = `public, s-maxage=${revalidate}, stale-while-revalidate=${revalidate}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      headers,
+      next: { revalidate },
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      return jsonError({
+        error: `Upstream returned ${res.status}`,
+        code: "UPSTREAM_ERROR",
+        status: res.status,
+      });
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data, { headers: { "Cache-Control": cacheHeader } });
+  } catch (err) {
+    const aborted = err instanceof Error && err.name === "AbortError";
+    return jsonError({
+      error: aborted ? "Upstream request timed out" : "Failed to reach upstream API",
+      code: aborted ? "UPSTREAM_TIMEOUT" : "UPSTREAM_UNREACHABLE",
+      status: 503,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Build a normalised error response. */
+export function jsonError(body: ProxyErrorBody): NextResponse {
+  return NextResponse.json(body, { status: body.status });
+}

--- a/stellargrant-fe/tests/hooks/useAddressFormat.test.tsx
+++ b/stellargrant-fe/tests/hooks/useAddressFormat.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  useAddressFormat,
+  formatAddressFor,
+} from "@/hooks/useAddressFormat";
+import { useUserPreferences, STORAGE_KEY } from "@/hooks/useUserPreferences";
+
+const FULL = "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("formatAddressFor", () => {
+  it("short → 6 + 4", () => {
+    expect(formatAddressFor("short", FULL)).toBe(`${FULL.slice(0, 6)}…${FULL.slice(-4)}`);
+  });
+
+  it("medium → 8 + 6", () => {
+    expect(formatAddressFor("medium", FULL)).toBe(`${FULL.slice(0, 8)}…${FULL.slice(-6)}`);
+  });
+
+  it("full → unchanged", () => {
+    expect(formatAddressFor("full", FULL)).toBe(FULL);
+  });
+
+  it("does not truncate addresses that are already short", () => {
+    expect(formatAddressFor("short", "GABC")).toBe("GABC");
+    expect(formatAddressFor("medium", "GABC")).toBe("GABC");
+  });
+
+  it("passes through an empty string", () => {
+    expect(formatAddressFor("short", "")).toBe("");
+  });
+});
+
+describe("useAddressFormat", () => {
+  it("uses the short format by default", () => {
+    const { result } = renderHook(() => useAddressFormat());
+    expect(result.current(FULL)).toBe(`${FULL.slice(0, 6)}…${FULL.slice(-4)}`);
+  });
+
+  it("updates when the user switches to medium", () => {
+    const { result } = renderHook(() => ({
+      format: useAddressFormat(),
+      prefs: useUserPreferences(),
+    }));
+    act(() => result.current.prefs.setPreferences({ addressFormat: "medium" }));
+    expect(result.current.format(FULL)).toBe(`${FULL.slice(0, 8)}…${FULL.slice(-6)}`);
+  });
+
+  it("reflects 'full' from stored preferences on mount", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ addressFormat: "full" }),
+    );
+    const { result } = renderHook(() => useAddressFormat());
+    expect(result.current(FULL)).toBe(FULL);
+  });
+});

--- a/stellargrant-fe/tests/hooks/useUserPreferences.test.tsx
+++ b/stellargrant-fe/tests/hooks/useUserPreferences.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  useUserPreferences,
+  readPreferences,
+  mergePreferences,
+  DEFAULT_PREFERENCES,
+  STORAGE_KEY,
+} from "@/hooks/useUserPreferences";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("mergePreferences", () => {
+  it("returns defaults for missing keys", () => {
+    expect(mergePreferences({})).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("ignores out-of-range values", () => {
+    const merged = mergePreferences({
+      addressFormat: "weird",
+      xlmDecimals: 5,
+      dateFormat: "bogus",
+      notifyOnFunding: "yes",
+    });
+    expect(merged.addressFormat).toBe(DEFAULT_PREFERENCES.addressFormat);
+    expect(merged.xlmDecimals).toBe(DEFAULT_PREFERENCES.xlmDecimals);
+    expect(merged.dateFormat).toBe(DEFAULT_PREFERENCES.dateFormat);
+    expect(merged.notifyOnFunding).toBe(DEFAULT_PREFERENCES.notifyOnFunding);
+  });
+
+  it("keeps valid values", () => {
+    const merged = mergePreferences({
+      addressFormat: "medium",
+      xlmDecimals: 2,
+      dateFormat: "absolute",
+      notifyOnFunding: false,
+    });
+    expect(merged.addressFormat).toBe("medium");
+    expect(merged.xlmDecimals).toBe(2);
+    expect(merged.dateFormat).toBe("absolute");
+    expect(merged.notifyOnFunding).toBe(false);
+  });
+});
+
+describe("readPreferences", () => {
+  it("returns defaults when storage is empty", () => {
+    expect(readPreferences()).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("returns defaults when storage is malformed", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(readPreferences()).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("reads from storage", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ ...DEFAULT_PREFERENCES, addressFormat: "medium" }),
+    );
+    expect(readPreferences().addressFormat).toBe("medium");
+  });
+});
+
+describe("useUserPreferences", () => {
+  it("starts with defaults on first render", () => {
+    const { result } = renderHook(() => useUserPreferences());
+    expect(result.current.preferences).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("persists a patch to localStorage and reflects it in state", () => {
+    const { result } = renderHook(() => useUserPreferences());
+    act(() => {
+      result.current.setPreferences({ addressFormat: "medium", xlmDecimals: 2 });
+    });
+    expect(result.current.preferences.addressFormat).toBe("medium");
+    expect(result.current.preferences.xlmDecimals).toBe(2);
+    const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.addressFormat).toBe("medium");
+  });
+
+  it("survives a 'page refresh' (re-mount reads from storage)", () => {
+    const { result, unmount } = renderHook(() => useUserPreferences());
+    act(() => result.current.setPreferences({ dateFormat: "absolute" }));
+    unmount();
+    const { result: result2 } = renderHook(() => useUserPreferences());
+    // useEffect synchronously runs on mount under @testing-library/react
+    expect(result2.current.preferences.dateFormat).toBe("absolute");
+  });
+
+  it("reset wipes storage and reverts to defaults", () => {
+    const { result } = renderHook(() => useUserPreferences());
+    act(() => result.current.setPreferences({ notifyOnFunding: false }));
+    expect(result.current.preferences.notifyOnFunding).toBe(false);
+    act(() => result.current.reset());
+    expect(result.current.preferences).toEqual(DEFAULT_PREFERENCES);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/stellargrant-fe/tests/lib/apiProxy.test.ts
+++ b/stellargrant-fe/tests/lib/apiProxy.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { proxyGet } from "@/lib/apiProxy";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function makeRequest(url: string): Request {
+  return new Request(url);
+}
+
+describe("proxyGet", () => {
+  it("forwards the upstream payload on success with the right cache header", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ grants: ["a", "b"] }), { status: 200 }),
+    );
+
+    const res = await proxyGet(
+      makeRequest("http://test/api/grants?cursor=1&limit=10"),
+      "/grants",
+      { revalidate: 30 },
+    );
+
+    const upstreamUrl = fetchMock.mock.calls[0][0] as string;
+    expect(upstreamUrl).toContain("/grants?cursor=1&limit=10");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe(
+      "public, s-maxage=30, stale-while-revalidate=30",
+    );
+    expect(await res.json()).toEqual({ grants: ["a", "b"] });
+  });
+
+  it("normalises an upstream non-ok response", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("nope", { status: 502 }));
+    const res = await proxyGet(makeRequest("http://test/api/x"), "/x", {
+      revalidate: 5,
+    });
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: "Upstream returned 502",
+      code: "UPSTREAM_ERROR",
+      status: 502,
+    });
+  });
+
+  it("normalises a network failure into a 503", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("ECONNREFUSED"));
+    const res = await proxyGet(makeRequest("http://test/api/x"), "/x", {
+      revalidate: 5,
+    });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: "Failed to reach upstream API",
+      code: "UPSTREAM_UNREACHABLE",
+      status: 503,
+    });
+  });
+
+  it("normalises an aborted upstream into a timeout error", async () => {
+    fetchMock.mockImplementationOnce(() => {
+      const e = new Error("aborted");
+      e.name = "AbortError";
+      return Promise.reject(e);
+    });
+    const res = await proxyGet(makeRequest("http://test/api/x"), "/x", {
+      revalidate: 5,
+    });
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: "Upstream request timed out",
+      code: "UPSTREAM_TIMEOUT",
+      status: 503,
+    });
+  });
+
+  it("can skip query forwarding when forwardSearch is false", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    await proxyGet(
+      makeRequest("http://test/api/stats?cursor=xyz"),
+      "/stats",
+      { revalidate: 60, forwardSearch: false },
+    );
+    const upstreamUrl = fetchMock.mock.calls[0][0] as string;
+    expect(upstreamUrl).not.toContain("?");
+  });
+});


### PR DESCRIPTION
## Summary

Two assigned issues bundled into one PR. Each delivers a focused, fully unit-tested core matching existing conventions (`app/api/*` route handlers, `lib/` server helpers, `hooks/`, colocated vitest tests, design-system styled components).

- **#371 — Next.js API proxy routes** (`lib/apiProxy.ts` + six new `app/api/*` handlers): `proxyGet(request, path, { revalidate })` forwards to the upstream Express API using a *private* `API_URL` env var (with a `NEXT_PUBLIC_API_URL` fallback for environments that still set it) and an optional `X-Internal-Secret` header. Network failures, upstream non-2xx, and timeouts are all normalised to `{ error, code, status }` JSON. New routes: **`/api/grants`** (30 s), **`/api/grants/:id/milestones/:idx`** (30 s), **`/api/leaderboard`** (300 s), **`/api/stats`** (60 s), **`/api/dashboard/:address`** (10 s), **`/api/contributors/:address`** (120 s) — matching the table in the issue. The existing `/api/grants/:id` and `/api/grants/:id/funders` routes were already implemented and are left untouched.
- **#386 — User settings page** (`hooks/useUserPreferences.ts` + `hooks/useAddressFormat.ts` + `components/settings/*` + `app/settings/page.tsx`): typed `UserPreferences` (notifications / display / developer) persisted to `localStorage` under `sg-preferences` via `useSyncExternalStore` (SSR-safe, no setState-in-effect warning, multi-tab `storage` event syncing). Includes the `ToggleSwitch` and `RadioGroup` design-system primitives. `WalletAddress` now uses `useAddressFormat`, so the user's `addressFormat` preference (short/medium/full) takes effect across the app. `/settings` has a wallet panel, a reset-to-defaults button with a confirmation dialog, and `metadata.title` set per spec.

## Test plan

- [x] `vitest run` — **429 / 429 tests pass** (18 new across the two hooks, 5 for `apiProxy`; the existing 6 `WalletAddress` tests still pass after the format-hook migration).
- [x] `tsc --noEmit` clean for the new files.
- [x] `eslint` clean for the new files.

## Notes

- `NEXT_PUBLIC_API_URL` is intentionally NOT removed from `lib/constants.ts` in this PR — many client modules still import it, and migrating every hook (`useGrants`, `useGrant`, `useMyGrants`, `LiveStatsBar`, etc.) to call the new relative `/api/...` URLs is a larger refactor that's left as a follow-up. The new proxy layer is fully usable today and the private `API_URL` is the variable the new routes read.
- The repo's `.gitignore` excludes all `.env*` files, so `.env.local.example` cannot be committed; the new env vars (`API_URL`, `API_SECRET`) are read in code with sensible defaults.

Closes #371
Closes #386