### PR TITLE
Feat/dispute panel 343

### DIFF
--- a/stellargrant-fe/app/dispute/page.tsx
+++ b/stellargrant-fe/app/dispute/page.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from "next";
+import DisputePanelClient from "@/components/dispute/DisputePanelClient";
+
+export const metadata: Metadata = {
+  title: "Council Dispute Panel — StellarGrant Protocol",
+  description: "Council dispute resolution panel for StellarGrant Protocol milestones.",
+};
+
+export default function DisputePage() {
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-5xl">
+      <DisputePanelClient />
+    </div>
+  );
+}

--- a/stellargrant-fe/components/dispute/DisputeHistory.tsx
+++ b/stellargrant-fe/components/dispute/DisputeHistory.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { formatTokenAmount } from "@/lib/tokens/utils";
+
+export interface ResolvedDispute {
+  id: string;
+  grantTitle: string;
+  milestoneIdx: number;
+  milestoneTitle: string;
+  resolution: "payout" | "refund";
+  resolvedAt: Date | string;
+  fundedAmount: bigint;
+  token: string;
+}
+
+interface DisputeHistoryProps {
+  history: ResolvedDispute[];
+}
+
+export function DisputeHistory({ history }: DisputeHistoryProps) {
+  return (
+    <details className="group border border-border-color/20 bg-surface/10 p-4 transition-all duration-300 [&_summary::-webkit-details-marker]:hidden">
+      <summary className="flex items-center justify-between cursor-pointer list-none select-none font-orbitron text-xs font-bold text-text-primary uppercase tracking-widest">
+        <span>Resolved Disputes ({history.length})</span>
+        <span className="text-text-muted group-open:rotate-180 transition-transform duration-300">
+          ▼
+        </span>
+      </summary>
+
+      {history.length === 0 ? (
+        <p className="font-mono text-xs text-text-muted mt-4 text-center">
+          No resolved disputes in history.
+        </p>
+      ) : (
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full font-mono text-left text-xs border-collapse">
+            <thead>
+              <tr className="border-b border-border-color/10 text-text-muted text-[10px] uppercase tracking-wider">
+                <th className="py-2 font-normal">Grant / Milestone</th>
+                <th className="py-2 font-normal">Resolution</th>
+                <th className="py-2 font-normal text-right">Amount</th>
+                <th className="py-2 font-normal text-right">Date</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border-color/5">
+              {history.map((h) => {
+                const isXlm = h.token.toLowerCase() === "native" || h.token.length < 10;
+                const decimals = isXlm ? 7 : 6;
+                const symbol = isXlm ? "XLM" : "USDC";
+
+                const formatted = formatTokenAmount(h.fundedAmount, decimals, {
+                  symbol,
+                  showSymbol: true,
+                });
+
+                const formattedDate = new Date(h.resolvedAt).toLocaleDateString(undefined, {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                });
+
+                return (
+                  <tr key={h.id} className="hover:bg-white/5 transition-colors">
+                    <td className="py-3 pr-4">
+                      <span className="font-bold text-text-primary block text-[11px] uppercase tracking-wide truncate max-w-[200px] sm:max-w-xs">
+                        {h.grantTitle}
+                      </span>
+                      <span className="text-[10px] text-text-muted block mt-0.5">
+                        Milestone #{h.milestoneIdx + 1}: {h.milestoneTitle}
+                      </span>
+                    </td>
+                    <td className="py-3">
+                      {h.resolution === "payout" ? (
+                        <span className="px-2 py-0.5 border border-success/20 bg-success/10 text-success text-[10px] font-semibold uppercase tracking-wider">
+                          Payout Approved
+                        </span>
+                      ) : (
+                        <span className="px-2 py-0.5 border border-danger/20 bg-danger/10 text-danger text-[10px] font-semibold uppercase tracking-wider">
+                          Funders Refunded
+                        </span>
+                      )}
+                    </td>
+                    <td className="py-3 text-right font-semibold text-text-primary text-[11px]">
+                      {formatted}
+                    </td>
+                    <td className="py-3 text-right text-text-muted text-[10px]">
+                      {formattedDate}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </details>
+  );
+}

--- a/stellargrant-fe/components/dispute/DisputePanel.tsx
+++ b/stellargrant-fe/components/dispute/DisputePanel.tsx
@@ -68,7 +68,7 @@ export function DisputePanel({
         councilAddress,
       });
 
-      const hash = await execute({
+      await execute({
         method: txParams.method,
         args: txParams.args,
         onSuccess: (txHash) => {
@@ -84,7 +84,7 @@ export function DisputePanel({
           console.error("Resolution transaction failed:", err);
         },
       });
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error("Error executing resolution:", err);
     }
   };
@@ -197,7 +197,7 @@ export function DisputePanel({
                 {confirmingAction === "approve" ? (
                   <>
                     You are resolving this dispute in favor of the <span className="text-success font-semibold">Contributor</span>.
-                    This will release the escrowed stake of <span className="text-text-primary font-bold">{formattedAmount}</span> to the contributor's payout address.
+                    This will release the escrowed stake of <span className="text-text-primary font-bold">{formattedAmount}</span> to the contributor&apos;s payout address.
                   </>
                 ) : (
                   <>

--- a/stellargrant-fe/components/dispute/DisputePanel.tsx
+++ b/stellargrant-fe/components/dispute/DisputePanel.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useState } from "react";
+import { useContractTransaction } from "@/hooks/useContractTransaction";
+import { contractClient } from "@/lib/stellar/contract";
+import { ProofViewer } from "@/components/milestones/ProofViewer";
+import RichTextRenderer from "@/components/ui/RichTextRenderer";
+import { formatTokenAmount } from "@/lib/tokens/utils";
+import { useWalletStore } from "@/lib/store/walletStore";
+import { toast } from "@/lib/toast";
+
+interface DisputePanelProps {
+  grantId: string;
+  grantTitle: string;
+  milestoneIdx: number;
+  milestoneTitle: string;
+  proofHash: string;
+  contributorArgument: string | null;  // from API metadata
+  funderArgument: string | null;       // from API metadata
+  fundedAmount: bigint;
+  token: string;
+  priorVotes: { approved: number; rejected: number };
+  onResolved: () => void;
+}
+
+export function DisputePanel({
+  grantId,
+  grantTitle,
+  milestoneIdx,
+  milestoneTitle,
+  proofHash,
+  contributorArgument,
+  funderArgument,
+  fundedAmount,
+  token,
+  priorVotes,
+  onResolved,
+}: DisputePanelProps) {
+  const { address: councilAddress } = useWalletStore();
+  const { execute, isPending, isSimulating, error: txError, reset } = useContractTransaction();
+  const [confirmingAction, setConfirmingAction] = useState<"approve" | "refund" | null>(null);
+
+  const isXlm = token.toLowerCase() === "native" || token.length < 10;
+  const decimals = isXlm ? 7 : 6;
+  const symbol = isXlm ? "XLM" : "USDC";
+
+  const formattedAmount = formatTokenAmount(fundedAmount, decimals, {
+    symbol,
+    showSymbol: true,
+  });
+
+  const handleResolve = async (approvePayout: boolean) => {
+    if (!councilAddress) {
+      toast({
+        title: "Wallet Not Connected",
+        description: "Connect your wallet as a Council member to resolve disputes.",
+        variant: "error",
+      });
+      return;
+    }
+
+    try {
+      reset();
+      const txParams = await contractClient.resolveDispute({
+        grantId,
+        milestoneIdx,
+        approvePayout,
+        councilAddress,
+      });
+
+      const hash = await execute({
+        method: txParams.method,
+        args: txParams.args,
+        onSuccess: (txHash) => {
+          toast({
+            title: approvePayout ? "Payout Approved" : "Funders Refunded",
+            description: `Dispute resolved successfully! Tx: ${txHash.slice(0, 10)}...`,
+            variant: "success",
+          });
+          setConfirmingAction(null);
+          onResolved();
+        },
+        onError: (err) => {
+          console.error("Resolution transaction failed:", err);
+        },
+      });
+    } catch (err: any) {
+      console.error("Error executing resolution:", err);
+    }
+  };
+
+  const isBusy = isPending || isSimulating;
+
+  return (
+    <div className="bg-surface/30 backdrop-blur-md border border-border-color/30 border-l-4 border-l-danger/60 p-6 space-y-6 hover:border-danger/30 transition-all duration-300">
+      {/* Header Info */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-4 border-b border-border-color/10">
+        <div>
+          <span className="font-mono text-[10px] tracking-widest text-danger font-semibold uppercase bg-danger/10 px-2 py-0.5 border border-danger/20 inline-block mb-1.5">
+            ● DISPUTED
+          </span>
+          <h3 className="font-orbitron text-base font-bold text-text-primary uppercase tracking-wide">
+            {grantTitle}
+          </h3>
+          <p className="font-mono text-xs text-text-muted mt-1">
+            Milestone #{milestoneIdx + 1}: <span className="text-text-primary font-semibold">{milestoneTitle}</span>
+          </p>
+        </div>
+        <div className="text-right shrink-0">
+          <span className="font-mono text-[10px] text-text-muted block uppercase tracking-widest">
+            Stake Amount
+          </span>
+          <span className="font-orbitron text-lg font-black text-accent-primary">
+            {formattedAmount}
+          </span>
+        </div>
+      </div>
+
+      {/* Prior Votes / Tally */}
+      <div className="flex flex-wrap items-center gap-4 bg-surface/20 border border-border-color/10 px-4 py-2 font-mono text-xs">
+        <span className="text-text-muted uppercase tracking-wider text-[10px]">
+          Milestone Vote Before Dispute:
+        </span>
+        <div className="flex gap-3">
+          <span className="text-success font-semibold">✓ {priorVotes.approved} approved</span>
+          <span className="text-danger font-semibold">✗ {priorVotes.rejected} rejected</span>
+        </div>
+      </div>
+
+      {/* Arguments Section */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 font-mono text-xs">
+        {/* Contributor Card */}
+        <div className="p-4 border border-border-color/20 bg-surface/10 space-y-3">
+          <h4 className="font-orbitron text-xs font-bold text-success uppercase tracking-widest border-b border-border-color/10 pb-2 flex items-center justify-between">
+            <span>Contributor Argument</span>
+            <span className="text-[10px] text-text-muted normal-case font-mono font-normal">Claim Payout</span>
+          </h4>
+          <div className="text-text-muted text-[11px] leading-relaxed max-h-[150px] overflow-y-auto pr-1">
+            {contributorArgument ? (
+              <RichTextRenderer content={contributorArgument} />
+            ) : (
+              "No argument submitted."
+            )}
+          </div>
+        </div>
+
+        {/* Funder Card */}
+        <div className="p-4 border border-border-color/20 bg-surface/10 space-y-3">
+          <h4 className="font-orbitron text-xs font-bold text-danger uppercase tracking-widest border-b border-border-color/10 pb-2 flex items-center justify-between">
+            <span>Funder Argument</span>
+            <span className="text-[10px] text-text-muted normal-case font-mono font-normal">Request Refund</span>
+          </h4>
+          <div className="text-text-muted text-[11px] leading-relaxed max-h-[150px] overflow-y-auto pr-1">
+            {funderArgument ? (
+              <RichTextRenderer content={funderArgument} />
+            ) : (
+              "No argument submitted."
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Milestone Proof Panel */}
+      <div className="space-y-2">
+        <span className="font-mono text-[10px] text-text-muted uppercase tracking-widest block">
+          Milestone Proof
+        </span>
+        <ProofViewer proofHash={proofHash} />
+      </div>
+
+      {/* Actions / Confirmation Prompt */}
+      <div className="pt-4 border-t border-border-color/10">
+        {confirmingAction === null ? (
+          <div className="flex flex-col sm:flex-row gap-3 justify-end">
+            <button
+              type="button"
+              onClick={() => setConfirmingAction("refund")}
+              className="px-5 py-2.5 font-mono text-xs uppercase tracking-widest border border-danger/40 text-danger hover:bg-danger/10 transition-colors"
+            >
+              ✗ Refund Funders
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingAction("approve")}
+              className="px-5 py-2.5 font-mono text-xs uppercase tracking-widest bg-success text-black font-bold hover:bg-success/80 transition-colors"
+            >
+              ✓ Approve Payout to Contributor
+            </button>
+          </div>
+        ) : (
+          <div className="bg-surface/40 border border-border-color/30 p-4 space-y-4 font-mono text-xs text-left animate-fadeIn">
+            <div>
+              <span className="font-orbitron text-[11px] font-bold text-accent-secondary uppercase tracking-widest block mb-1">
+                Confirm Resolution Plan
+              </span>
+              <p className="text-text-muted text-[11px]">
+                {confirmingAction === "approve" ? (
+                  <>
+                    You are resolving this dispute in favor of the <span className="text-success font-semibold">Contributor</span>.
+                    This will release the escrowed stake of <span className="text-text-primary font-bold">{formattedAmount}</span> to the contributor's payout address.
+                  </>
+                ) : (
+                  <>
+                    You are resolving this dispute in favor of the <span className="text-danger font-semibold">Funders</span>.
+                    This will claw back the milestone allocation of <span className="text-text-primary font-bold">{formattedAmount}</span> and make it refundable to the original funders.
+                  </>
+                )}
+              </p>
+            </div>
+
+            {txError && (
+              <div className="text-danger bg-danger/10 border border-danger/20 p-2.5 break-all max-h-[100px] overflow-y-auto">
+                Error: {txError}
+              </div>
+            )}
+
+            <div className="flex flex-wrap items-center justify-between gap-3 pt-2">
+              <span className="text-[10px] text-text-muted italic">
+                {isSimulating
+                  ? "Simulating resolution..."
+                  : isPending
+                  ? "Signing & broadcasting transaction..."
+                  : "Freighter wallet signature required."}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={isBusy}
+                  onClick={() => {
+                    setConfirmingAction(null);
+                    reset();
+                  }}
+                  className="px-4 py-2 border border-border-color/40 text-text-muted hover:text-text-primary transition-colors disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={isBusy}
+                  onClick={() => handleResolve(confirmingAction === "approve")}
+                  className="px-4 py-2 bg-accent-primary text-black font-bold hover:bg-accent-primary/80 transition-colors disabled:opacity-50 flex items-center gap-2"
+                >
+                  {isBusy && <div className="h-3 w-3 animate-spin rounded-full border border-black border-t-transparent" />}
+                  Confirm
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/stellargrant-fe/components/dispute/DisputePanelClient.tsx
+++ b/stellargrant-fe/components/dispute/DisputePanelClient.tsx
@@ -21,6 +21,57 @@ interface DisputeItem {
   priorVotes: { approved: number; rejected: number };
 }
 
+interface RawDisputeResponse {
+  grantId: string | number;
+  grantTitle?: string;
+  milestoneIdx: number;
+  milestoneTitle?: string;
+  proofHash?: string;
+  contributorArgument?: string | null;
+  funderArgument?: string | null;
+  fundedAmount?: string | number;
+  token?: string;
+  priorVotes?: { approved: number; rejected: number };
+}
+
+interface RawGrantResponse {
+  id: string | number;
+  status: string | number;
+  title: string;
+  token?: string;
+}
+
+interface RawMilestoneResponse {
+  idx: number;
+  title?: string;
+  proof_hash?: string;
+  amount?: string | number;
+  token?: string;
+  approvals?: number;
+  rejections?: number;
+  state?: string;
+  approved?: boolean;
+  submitted?: boolean;
+}
+
+interface RawMetaResponse {
+  contributorArgument?: string | null;
+  funderArgument?: string | null;
+  priorVotes?: { approved: number; rejected: number };
+}
+
+interface RawHistoryResponse {
+  id?: string;
+  grantId: string | number;
+  grantTitle?: string;
+  milestoneIdx: number;
+  milestoneTitle?: string;
+  resolution?: string;
+  resolvedAt?: string;
+  fundedAmount?: string | number;
+  token?: string;
+}
+
 export default function DisputePanelClient() {
   const { address } = useWalletStore();
   const [isCouncil, setIsCouncil] = useState<boolean | null>(null);
@@ -67,7 +118,7 @@ export default function DisputePanelClient() {
         // Fetch Open Disputes
         let openDisputes: DisputeItem[] = [];
         try {
-          const rawOpen = await apiGet<any[]>("/disputes?status=open");
+          const rawOpen = await apiGet<RawDisputeResponse[]>("/disputes?status=open");
           if (Array.isArray(rawOpen)) {
             openDisputes = rawOpen.map((item) => ({
               grantId: String(item.grantId),
@@ -85,7 +136,7 @@ export default function DisputePanelClient() {
         } catch (err) {
           console.warn("Direct disputes endpoint failed, attempting fallback query...", err);
           // Fallback: Fetch all grants and filter by disputed status/milestones
-          const allGrants = await apiGet<any[]>("/grants");
+          const allGrants = await apiGet<RawGrantResponse[]>("/grants");
           if (Array.isArray(allGrants)) {
             const disputedGrants = allGrants.filter(
               (g) => g.status === "Disputed" || Number(g.status) === 5
@@ -93,7 +144,7 @@ export default function DisputePanelClient() {
             
             for (const g of disputedGrants) {
               try {
-                const milestones = await apiGet<any[]>(`/grants/${g.id}/milestones`);
+                const milestones = await apiGet<RawMilestoneResponse[]>(`/grants/${g.id}/milestones`);
                 if (Array.isArray(milestones)) {
                   const disputedMilestones = milestones.filter(
                     (m) => m.state === "Disputed" || m.approved === false && m.submitted === true // Or status state check
@@ -124,7 +175,7 @@ export default function DisputePanelClient() {
         for (const dispute of openDisputes) {
           if (!dispute.contributorArgument || !dispute.funderArgument) {
             try {
-              const meta = await apiGet<any>(
+              const meta = await apiGet<RawMetaResponse>(
                 `/grants/${dispute.grantId}/milestones/${dispute.milestoneIdx}/dispute`
               );
               if (meta) {
@@ -146,7 +197,7 @@ export default function DisputePanelClient() {
         // Fetch Resolved Disputes
         let resolvedDisputes: ResolvedDispute[] = [];
         try {
-          const rawHistory = await apiGet<any[]>("/disputes?status=resolved");
+          const rawHistory = await apiGet<RawHistoryResponse[]>("/disputes?status=resolved");
           if (Array.isArray(rawHistory)) {
             resolvedDisputes = rawHistory.map((item) => ({
               id: item.id || `${item.grantId}-${item.milestoneIdx}`,
@@ -167,9 +218,9 @@ export default function DisputePanelClient() {
           setDisputes(openDisputes);
           setHistory(resolvedDisputes);
         }
-      } catch (err: any) {
+      } catch (err: unknown) {
         if (!cancelled) {
-          setErrorMsg(err?.message || "Failed to load dispute panel data.");
+          setErrorMsg((err as Error)?.message || "Failed to load dispute panel data.");
         }
       } finally {
         if (!cancelled) {

--- a/stellargrant-fe/components/dispute/DisputePanelClient.tsx
+++ b/stellargrant-fe/components/dispute/DisputePanelClient.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { WalletGuard } from "@/components/wallet/WalletGuard";
+import { useWalletStore } from "@/lib/store/walletStore";
+import { contractClient } from "@/lib/stellar/contract";
+import { DisputePanel } from "./DisputePanel";
+import { DisputeHistory, ResolvedDispute } from "./DisputeHistory";
+import { apiGet } from "@/lib/api";
+
+interface DisputeItem {
+  grantId: string;
+  grantTitle: string;
+  milestoneIdx: number;
+  milestoneTitle: string;
+  proofHash: string;
+  contributorArgument: string | null;
+  funderArgument: string | null;
+  fundedAmount: bigint;
+  token: string;
+  priorVotes: { approved: number; rejected: number };
+}
+
+export default function DisputePanelClient() {
+  const { address } = useWalletStore();
+  const [isCouncil, setIsCouncil] = useState<boolean | null>(null);
+  const [checkingCouncil, setCheckingCouncil] = useState(false);
+  const [disputes, setDisputes] = useState<DisputeItem[]>([]);
+  const [history, setHistory] = useState<ResolvedDispute[]>([]);
+  const [loadingData, setLoadingData] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
+  // 1. Check council membership on mount/wallet change
+  useEffect(() => {
+    if (!address) {
+      setIsCouncil(null);
+      return;
+    }
+
+    const checkMember = async () => {
+      setCheckingCouncil(true);
+      try {
+        const member = await contractClient.isCouncilMember({ address });
+        setIsCouncil(member);
+      } catch (err) {
+        console.error("Error checking council membership:", err);
+        setIsCouncil(false);
+      } finally {
+        setCheckingCouncil(false);
+      }
+    };
+
+    void checkMember();
+  }, [address]);
+
+  // 2. Fetch disputes and history when council status is verified
+  useEffect(() => {
+    if (!isCouncil) return;
+
+    let cancelled = false;
+
+    const fetchData = async () => {
+      setLoadingData(true);
+      setErrorMsg(null);
+      try {
+        // Fetch Open Disputes
+        let openDisputes: DisputeItem[] = [];
+        try {
+          const rawOpen = await apiGet<any[]>("/disputes?status=open");
+          if (Array.isArray(rawOpen)) {
+            openDisputes = rawOpen.map((item) => ({
+              grantId: String(item.grantId),
+              grantTitle: item.grantTitle || `Grant #${item.grantId}`,
+              milestoneIdx: Number(item.milestoneIdx),
+              milestoneTitle: item.milestoneTitle || `Milestone #${item.milestoneIdx + 1}`,
+              proofHash: item.proofHash || "",
+              contributorArgument: item.contributorArgument ?? null,
+              funderArgument: item.funderArgument ?? null,
+              fundedAmount: BigInt(item.fundedAmount || 0),
+              token: item.token || "native",
+              priorVotes: item.priorVotes || { approved: 0, rejected: 0 },
+            }));
+          }
+        } catch (err) {
+          console.warn("Direct disputes endpoint failed, attempting fallback query...", err);
+          // Fallback: Fetch all grants and filter by disputed status/milestones
+          const allGrants = await apiGet<any[]>("/grants");
+          if (Array.isArray(allGrants)) {
+            const disputedGrants = allGrants.filter(
+              (g) => g.status === "Disputed" || Number(g.status) === 5
+            );
+            
+            for (const g of disputedGrants) {
+              try {
+                const milestones = await apiGet<any[]>(`/grants/${g.id}/milestones`);
+                if (Array.isArray(milestones)) {
+                  const disputedMilestones = milestones.filter(
+                    (m) => m.state === "Disputed" || m.approved === false && m.submitted === true // Or status state check
+                  );
+                  for (const m of disputedMilestones) {
+                    openDisputes.push({
+                      grantId: String(g.id),
+                      grantTitle: g.title,
+                      milestoneIdx: Number(m.idx),
+                      milestoneTitle: m.title || `Milestone #${m.idx + 1}`,
+                      proofHash: m.proof_hash || "",
+                      contributorArgument: null,
+                      funderArgument: null,
+                      fundedAmount: BigInt(m.amount || 0),
+                      token: m.token || g.token || "native",
+                      priorVotes: { approved: m.approvals || 0, rejected: m.rejections || 0 },
+                    });
+                  }
+                }
+              } catch (milestoneErr) {
+                console.error(`Failed to fetch milestones for fallback grant #${g.id}:`, milestoneErr);
+              }
+            }
+          }
+        }
+
+        // Fetch detailed arguments for open disputes
+        for (const dispute of openDisputes) {
+          if (!dispute.contributorArgument || !dispute.funderArgument) {
+            try {
+              const meta = await apiGet<any>(
+                `/grants/${dispute.grantId}/milestones/${dispute.milestoneIdx}/dispute`
+              );
+              if (meta) {
+                dispute.contributorArgument = meta.contributorArgument ?? dispute.contributorArgument;
+                dispute.funderArgument = meta.funderArgument ?? dispute.funderArgument;
+                if (meta.priorVotes) {
+                  dispute.priorVotes = meta.priorVotes;
+                }
+              }
+            } catch (metaErr) {
+              console.warn(
+                `Failed to fetch argument metadata for Grant #${dispute.grantId} Milestone #${dispute.milestoneIdx}`,
+                metaErr
+              );
+            }
+          }
+        }
+
+        // Fetch Resolved Disputes
+        let resolvedDisputes: ResolvedDispute[] = [];
+        try {
+          const rawHistory = await apiGet<any[]>("/disputes?status=resolved");
+          if (Array.isArray(rawHistory)) {
+            resolvedDisputes = rawHistory.map((item) => ({
+              id: item.id || `${item.grantId}-${item.milestoneIdx}`,
+              grantTitle: item.grantTitle || `Grant #${item.grantId}`,
+              milestoneIdx: Number(item.milestoneIdx),
+              milestoneTitle: item.milestoneTitle || `Milestone #${item.milestoneIdx + 1}`,
+              resolution: item.resolution === "payout" ? "payout" : "refund",
+              resolvedAt: item.resolvedAt || new Date().toISOString(),
+              fundedAmount: BigInt(item.fundedAmount || 0),
+              token: item.token || "native",
+            }));
+          }
+        } catch (historyErr) {
+          console.warn("Direct resolved disputes endpoint failed.", historyErr);
+        }
+
+        if (!cancelled) {
+          setDisputes(openDisputes);
+          setHistory(resolvedDisputes);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setErrorMsg(err?.message || "Failed to load dispute panel data.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingData(false);
+        }
+      }
+    };
+
+    void fetchData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isCouncil, refreshTrigger]);
+
+  if (checkingCouncil) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 space-y-4">
+        <div className="w-8 h-8 border-4 border-accent-secondary border-t-transparent rounded-full animate-spin" />
+        <p className="font-mono text-sm text-text-muted">Verifying Council authorization...</p>
+      </div>
+    );
+  }
+
+  if (isCouncil === false) {
+    return (
+      <div className="max-w-md mx-auto my-12">
+        <div className="bg-surface/60 backdrop-blur-md border border-warning/20 p-8 text-center space-y-6 shadow-xl relative overflow-hidden group">
+          {/* Animated glow background */}
+          <div className="absolute inset-0 bg-warning/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+          
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-warning/10 border border-warning/30 text-warning animate-pulse">
+            <svg
+              className="w-8 h-8"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+          </div>
+
+          <div className="space-y-2">
+            <h2 className="font-orbitron text-lg font-bold text-text-primary uppercase tracking-wider">
+              Restricted Access
+            </h2>
+            <p className="font-mono text-xs text-text-muted leading-relaxed">
+              This panel is only accessible to StellarGrant Council members.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <WalletGuard>
+      <div className="space-y-8">
+        {/* Dashboard Header */}
+        <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 border-b border-border-color/10 pb-6">
+          <div>
+            <span className="font-mono text-xs text-accent-secondary uppercase tracking-widest block mb-1">
+              [ Administrative Dashboard ]
+            </span>
+            <h1 className="font-orbitron text-2xl font-bold uppercase tracking-wider text-text-primary">
+              Council Dispute Panel
+            </h1>
+          </div>
+          
+          <div className="flex gap-4 font-mono text-xs">
+            <div className="bg-surface/20 border border-border-color/20 px-4 py-2">
+              <span className="text-text-muted block text-[10px] uppercase tracking-wider">Open Disputes</span>
+              <span className="text-base font-bold text-danger">{disputes.length} active</span>
+            </div>
+            <div className="bg-surface/20 border border-border-color/20 px-4 py-2">
+              <span className="text-text-muted block text-[10px] uppercase tracking-wider">Resolved History</span>
+              <span className="text-base font-bold text-success">{history.length} cases</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Loading Spinner */}
+        {loadingData && (
+          <div className="grid gap-6">
+            <div className="shimmer h-64 rounded-none border border-border-color/20" />
+            <div className="shimmer h-64 rounded-none border border-border-color/20" />
+          </div>
+        )}
+
+        {/* Error State */}
+        {errorMsg && !loadingData && (
+          <div className="bg-danger/10 border border-danger/20 p-4 font-mono text-xs text-danger text-center flex flex-col items-center gap-3">
+            <span>{errorMsg}</span>
+            <button
+              onClick={() => setRefreshTrigger((c) => c + 1)}
+              className="px-4 py-1.5 bg-danger text-black font-bold uppercase tracking-widest text-[10px]"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {/* Content list */}
+        {!loadingData && !errorMsg && (
+          <div className="space-y-8">
+            {disputes.length === 0 ? (
+              <div className="bg-surface/10 border border-border-color/20 p-12 text-center">
+                <p className="font-mono text-xs text-text-muted uppercase tracking-widest">
+                  ✓ All quiet. No active disputes require attention.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-6">
+                {disputes.map((dispute) => (
+                  <DisputePanel
+                    key={`${dispute.grantId}-${dispute.milestoneIdx}`}
+                    {...dispute}
+                    onResolved={() => setRefreshTrigger((c) => c + 1)}
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Historical disputes */}
+            <DisputeHistory history={history} />
+          </div>
+        )}
+      </div>
+    </WalletGuard>
+  );
+}

--- a/stellargrant-fe/lib/schemas/grant.ts
+++ b/stellargrant-fe/lib/schemas/grant.ts
@@ -1,59 +1,78 @@
 import { z } from "zod";
 
-export const GrantBasicInfoSchema = z.object({
-  title: z
-    .string()
+export const step1Schema = z.object({
+  title: z.string()
     .min(10, "Title must be at least 10 characters")
     .max(120, "Title must be at most 120 characters"),
-  description: z
-    .string()
+  description: z.string()
     .min(50, "Description must be at least 50 characters")
-    .max(2000, "Description must be at most 2000 characters"),
-  category: z.string().optional(),
+    .max(5000, "Description must be at most 5000 characters"),
+  recipientAddress: z.string().regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address"),
+  totalBudget: z.number({ message: "Budget must be a number" })
+    .positive("Budget must be greater than 0")
+    .max(10000000, "Budget cannot exceed 10,000,000"),
+  budgetToken: z.enum(["native", "USDC"], { message: "Select a funding token" }),
+  deadline: z.string().refine(
+    (d) => !isNaN(Date.parse(d)) && new Date(d) > new Date(),
+    "Deadline must be in the future"
+  ),
 });
 
-export const GrantBudgetSchema = z.object({
-  token: z.enum(["XLM", "USDC"], { message: "Select a funding token" }),
-  target: z.coerce
-    .bigint()
-    .refine((v) => v > BigInt(0), "Target amount must be greater than 0"),
-  platformFee: z.coerce.number().min(0).max(100).default(2),
+export const step2Schema = z.object({
+  milestones: z.array(
+    z.object({
+      title: z.string()
+        .min(5, "Milestone title must be at least 5 characters")
+        .max(100, "Milestone title must be at most 100 characters"),
+      description: z.string()
+        .min(20, "Milestone description must be at least 20 characters"),
+      reward: z.number({ message: "Reward must be a number" })
+        .positive("Reward must be greater than 0"),
+    })
+  )
+  .min(1, "At least one milestone required")
+  .max(10, "Maximum 10 milestones allowed"),
 });
 
-export const GrantTimelineSchema = z.object({
-  startDate: z.coerce
-    .date()
-    .refine((d) => d >= new Date(), "Start date cannot be in the past"),
-  deadline: z.coerce
-    .date()
-    .refine((d) => d > new Date(), "Deadline must be in the future"),
+export const step3Schema = z.object({
+  reviewers: z.array(
+    z.string().regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar address")
+  )
+  .min(3, "Minimum 3 reviewers required")
+  .max(7, "Maximum 7 reviewers")
+  .refine(
+    (arr) => new Set(arr).size === arr.length,
+    "Duplicate reviewer addresses"
+  ),
+  quorum: z.number({ message: "Quorum must be a number" })
+    .min(1, "Quorum must be at least 1"),
 });
 
-export const GrantMilestoneSchema = z.object({
-  milestones: z
-    .array(
-      z.object({
-        title: z
-          .string()
-          .min(5, "Milestone title must be at least 5 characters"),
-        description: z
-          .string()
-          .min(20, "Milestone description must be at least 20 characters"),
-        proofType: z.enum(["ipfs", "github", "manual"]).default("ipfs"),
-      }),
-    )
-    .min(1, "At least one milestone is required")
-    .max(20, "Maximum 20 milestones allowed"),
-});
+export const fullGrantSchema = step1Schema
+  .merge(step2Schema)
+  .merge(step3Schema)
+  .superRefine((data, ctx) => {
+    // 1. Milestone rewards sum must equal totalBudget
+    const sum = data.milestones.reduce((acc, m) => acc + (m.reward || 0), 0);
+    if (Math.abs(sum - data.totalBudget) > 0.0001) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["milestones"],
+        message: `Sum of milestone rewards (${sum}) must equal the total budget (${data.totalBudget})`,
+      });
+    }
 
-export const GrantReviewersSchema = z.object({
-  reviewers: z
-    .array(z.string().regex(/^G[A-Z0-9]{55}$/, "Invalid Stellar address"))
-    .min(1, "At least one reviewer is required")
-    .max(7, "Maximum 7 reviewers allowed"),
-});
+    // 2. Quorum <= reviewers.length
+    if (data.quorum > data.reviewers.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["quorum"],
+        message: `Quorum (${data.quorum}) cannot exceed the number of reviewers (${data.reviewers.length})`,
+      });
+    }
+  });
 
-export const CompleteGrantSchema = GrantBasicInfoSchema.merge(GrantBudgetSchema)
-  .merge(GrantTimelineSchema)
-  .merge(GrantMilestoneSchema)
-  .merge(GrantReviewersSchema);
+export type GrantFormData = z.infer<typeof fullGrantSchema>;
+export type Step1FormData = z.infer<typeof step1Schema>;
+export type Step2FormData = z.infer<typeof step2Schema>;
+export type Step3FormData = z.infer<typeof step3Schema>;

--- a/stellargrant-fe/lib/stellar/contract.ts
+++ b/stellargrant-fe/lib/stellar/contract.ts
@@ -6,7 +6,7 @@
  */
 
 import { networkPassphraseConfig } from "./client";
-import { nativeToScVal, xdr } from "@stellar/stellar-sdk";
+import { nativeToScVal } from "@stellar/stellar-sdk";
 
 const contractId = process.env.NEXT_PUBLIC_CONTRACT_ID || "";
 

--- a/stellargrant-fe/lib/stellar/contract.ts
+++ b/stellargrant-fe/lib/stellar/contract.ts
@@ -6,6 +6,7 @@
  */
 
 import { networkPassphraseConfig } from "./client";
+import { nativeToScVal, xdr } from "@stellar/stellar-sdk";
 
 const contractId = process.env.NEXT_PUBLIC_CONTRACT_ID || "";
 
@@ -131,6 +132,40 @@ export class ContractClient {
       // TODO: wire to milestoneReject contract method once added
       throw new Error("Milestone rejection not yet implemented in contract");
     }
+  }
+
+  /**
+   * Read-only: Check if an address is a council member
+   */
+  async isCouncilMember(params: { address: string }): Promise<boolean> {
+    const raw = process.env.NEXT_PUBLIC_COUNCIL_ADDRESSES ?? "";
+    const councilSet = new Set(
+      raw
+        .split(",")
+        .map((a) => a.trim())
+        .filter(Boolean)
+    );
+    return councilSet.has(params.address);
+  }
+
+  /**
+   * Write: Resolve milestone dispute
+   */
+  async resolveDispute(params: {
+    grantId: string;
+    milestoneIdx: number;
+    approvePayout: boolean;
+    councilAddress: string;
+  }) {
+    return {
+      method: "milestone_resolve_dispute",
+      args: [
+        nativeToScVal(params.councilAddress, { type: "address" }),
+        nativeToScVal(BigInt(params.grantId), { type: "u64" }),
+        nativeToScVal(params.milestoneIdx, { type: "u32" }),
+        nativeToScVal(params.approvePayout, { type: "bool" }),
+      ]
+    };
   }
 }
 

--- a/stellargrant-fe/tests/components/DisputePanel.test.tsx
+++ b/stellargrant-fe/tests/components/DisputePanel.test.tsx
@@ -23,8 +23,8 @@ const mockResolveDispute = vi.fn();
 
 vi.mock("@/lib/stellar/contract", () => ({
   contractClient: {
-    isCouncilMember: (args: any) => mockIsCouncilMember(args),
-    resolveDispute: (args: any) => mockResolveDispute(args),
+    isCouncilMember: (args: unknown) => mockIsCouncilMember(args),
+    resolveDispute: (args: unknown) => mockResolveDispute(args),
   },
 }));
 
@@ -38,7 +38,7 @@ vi.mock("@/components/milestones/ProofViewer", () => ({
 
 const mockApiGet = vi.fn();
 vi.mock("@/lib/api", () => ({
-  apiGet: (url: string, params?: any) => mockApiGet(url, params),
+  apiGet: (url: string, params?: unknown) => mockApiGet(url, params),
 }));
 
 // Mock wallet address

--- a/stellargrant-fe/tests/components/DisputePanel.test.tsx
+++ b/stellargrant-fe/tests/components/DisputePanel.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import DisputePanelClient from "@/components/dispute/DisputePanelClient";
+import { DisputePanel } from "@/components/dispute/DisputePanel";
+import { DisputeHistory } from "@/components/dispute/DisputeHistory";
+
+// 1. Mocks
+const mockExecute = vi.fn();
+const mockReset = vi.fn();
+
+vi.mock("@/hooks/useContractTransaction", () => ({
+  useContractTransaction: () => ({
+    execute: mockExecute,
+    isPending: false,
+    isSimulating: false,
+    error: null,
+    reset: mockReset,
+  }),
+}));
+
+const mockIsCouncilMember = vi.fn();
+const mockResolveDispute = vi.fn();
+
+vi.mock("@/lib/stellar/contract", () => ({
+  contractClient: {
+    isCouncilMember: (args: any) => mockIsCouncilMember(args),
+    resolveDispute: (args: any) => mockResolveDispute(args),
+  },
+}));
+
+vi.mock("@/components/wallet/WalletGuard", () => ({
+  WalletGuard: ({ children }: { children: React.ReactNode }) => <div data-testid="wallet-guard">{children}</div>,
+}));
+
+vi.mock("@/components/milestones/ProofViewer", () => ({
+  ProofViewer: ({ proofHash }: { proofHash: string }) => <div data-testid="proof-viewer">Proof: {proofHash}</div>,
+}));
+
+const mockApiGet = vi.fn();
+vi.mock("@/lib/api", () => ({
+  apiGet: (url: string, params?: any) => mockApiGet(url, params),
+}));
+
+// Mock wallet address
+const mockAddress = "GBCOUNCIL1234567890";
+vi.mock("@/lib/store/walletStore", () => ({
+  useWalletStore: () => ({
+    address: mockAddress,
+  }),
+}));
+
+describe("Dispute Resolution Panel Components", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("DisputeHistory", () => {
+    it("renders empty state correctly", () => {
+      render(<DisputeHistory history={[]} />);
+      expect(screen.getByText("Resolved Disputes (0)")).toBeTruthy();
+      expect(screen.getByText("No resolved disputes in history.")).toBeTruthy();
+    });
+
+    it("renders resolved disputes table", () => {
+      const history = [
+        {
+          id: "1-0",
+          grantTitle: "Project Alpha",
+          milestoneIdx: 0,
+          milestoneTitle: "Setup Architecture",
+          resolution: "payout" as const,
+          resolvedAt: "2026-05-29T12:00:00Z",
+          fundedAmount: 10000000n,
+          token: "native",
+        },
+      ];
+
+      render(<DisputeHistory history={history} />);
+      expect(screen.getByText("Project Alpha")).toBeTruthy();
+      expect(screen.getByText("Milestone #1: Setup Architecture")).toBeTruthy();
+      expect(screen.getByText("Payout Approved")).toBeTruthy();
+    });
+  });
+
+  describe("DisputePanel", () => {
+    const defaultProps = {
+      grantId: "42",
+      grantTitle: "DeFi Aggregator",
+      milestoneIdx: 1,
+      milestoneTitle: "Smart Contract Audit",
+      proofHash: "QmHash123",
+      contributorArgument: "I completed the audit successfully.",
+      funderArgument: "The audit has critical gaps.",
+      fundedAmount: 50000000n,
+      token: "native",
+      priorVotes: { approved: 2, rejected: 1 },
+      onResolved: vi.fn(),
+    };
+
+    it("renders all dispute information correctly", async () => {
+      render(<DisputePanel {...defaultProps} />);
+      
+      expect(screen.getByText("DeFi Aggregator")).toBeTruthy();
+      expect(screen.getByText(/Milestone #2:/)).toBeTruthy();
+      expect(screen.getByText("Smart Contract Audit")).toBeTruthy();
+      expect(screen.getByTestId("proof-viewer")).toBeTruthy();
+
+      await waitFor(() => {
+        expect(screen.getByText("I completed the audit successfully.")).toBeTruthy();
+        expect(screen.getByText("The audit has critical gaps.")).toBeTruthy();
+      });
+    });
+
+    it("requires confirmation prompt before resolving", async () => {
+      render(<DisputePanel {...defaultProps} />);
+      
+      const approveBtn = screen.getByText("✓ Approve Payout to Contributor");
+      fireEvent.click(approveBtn);
+
+      expect(screen.getByText("Confirm Resolution Plan")).toBeTruthy();
+      expect(screen.getByText(/You are resolving this dispute in favor of the/)).toBeTruthy();
+      expect(screen.getByText("Contributor")).toBeTruthy();
+
+      const confirmBtn = screen.getByText("Confirm");
+      
+      mockResolveDispute.mockResolvedValue({
+        method: "milestone_resolve_dispute",
+        args: [],
+      });
+      mockExecute.mockResolvedValue("mock_tx_hash");
+
+      fireEvent.click(confirmBtn);
+
+      await waitFor(() => {
+        expect(mockResolveDispute).toHaveBeenCalledWith({
+          grantId: "42",
+          milestoneIdx: 1,
+          approvePayout: true,
+          councilAddress: mockAddress,
+        });
+        expect(mockExecute).toHaveBeenCalled();
+      });
+    });
+
+    it("handles refund confirmation flow correctly", async () => {
+      render(<DisputePanel {...defaultProps} />);
+      
+      const refundBtn = screen.getByText("✗ Refund Funders");
+      fireEvent.click(refundBtn);
+
+      expect(screen.getByText("Confirm Resolution Plan")).toBeTruthy();
+      expect(screen.getByText("Funders")).toBeTruthy();
+
+      const confirmBtn = screen.getByText("Confirm");
+      
+      mockResolveDispute.mockResolvedValue({
+        method: "milestone_resolve_dispute",
+        args: [],
+      });
+      mockExecute.mockResolvedValue("mock_tx_hash");
+
+      fireEvent.click(confirmBtn);
+
+      await waitFor(() => {
+        expect(mockResolveDispute).toHaveBeenCalledWith({
+          grantId: "42",
+          milestoneIdx: 1,
+          approvePayout: false,
+          councilAddress: mockAddress,
+        });
+        expect(mockExecute).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("DisputePanelClient", () => {
+    it("renders Restricted Access screen for non-council members", async () => {
+      mockIsCouncilMember.mockResolvedValue(false);
+
+      render(<DisputePanelClient />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Restricted Access")).toBeTruthy();
+        expect(screen.getByText("This panel is only accessible to StellarGrant Council members.")).toBeTruthy();
+      });
+    });
+
+    it("renders dashboard and active disputes list for council members", async () => {
+      mockIsCouncilMember.mockResolvedValue(true);
+      mockApiGet.mockImplementation((url: string) => {
+        if (url === "/disputes?status=open") {
+          return Promise.resolve([
+            {
+              grantId: "101",
+              grantTitle: "SDK Refactoring",
+              milestoneIdx: 0,
+              milestoneTitle: "Initial Draft",
+              proofHash: "QmProof",
+              contributorArgument: "Done.",
+              funderArgument: "No.",
+              fundedAmount: 15000000n,
+              token: "native",
+              priorVotes: { approved: 0, rejected: 0 },
+            },
+          ]);
+        }
+        if (url === "/disputes?status=resolved") {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      render(<DisputePanelClient />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Council Dispute Panel")).toBeTruthy();
+        expect(screen.getByText("SDK Refactoring")).toBeTruthy();
+        expect(screen.getByText("Done.")).toBeTruthy();
+      });
+    });
+  });
+});

--- a/stellargrant-fe/tests/token-utils.test.ts
+++ b/stellargrant-fe/tests/token-utils.test.ts
@@ -163,7 +163,7 @@ describe("convertTokenDecimals", () => {
 
   it("should handle large decimal differences", () => {
     // From 18 decimals (ETH) to 7 decimals (XLM)
-    expect(convertTokenDecimals(BigInt("1000000000000000000"), 18, 7)).toBe(BigInt("100000000000"));
+    expect(convertTokenDecimals(BigInt("1000000000000000000"), 18, 7)).toBe(10000000n);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements the Council-gated Dispute Resolution Panel at `/dispute` as specified in issue #343.

Council members can now view all disputed milestones, read arguments from both the contributor and funder, inspect the milestone proof inline, and execute on-chain resolution transactions via Freighter — all from a single, secured dashboard.

---

## Changes

### New Files

- **`app/dispute/page.tsx`** — Next.js server page at `/dispute` with metadata title `"Council Dispute Panel — StellarGrant Protocol"`. Renders the `DisputePanelClient` orchestrator inside a max-width container.

- **`components/dispute/DisputePanel.tsx`** — Individual active dispute card component. Shows grant/milestone metadata, funded amount at stake, prior vote tally, contributor vs funder arguments (rendered via `<RichTextRenderer />` for Markdown content), inline milestone proof via `<ProofViewer />`, and two-step confirmation action buttons for "Approve Payout" and "Refund Funders".

- **`components/dispute/DisputeHistory.tsx`** — Collapsible `<details>` history section listing resolved disputes (grant title, milestone, resolution type, amount, date) in a compact read-only table.

- **`components/dispute/DisputePanelClient.tsx`** — Client-side orchestrator that:
  - Requires wallet connection (via `WalletGuard`)
  - Checks council membership on mount (`contractClient.isCouncilMember`)
  - Renders a styled "Restricted Access" screen with amber warning icon for non-council wallets
  - Fetches open disputes from `GET /disputes?status=open` with a fallback to filtering disputed grants/milestones
  - Fetches dispute argument metadata from `GET /grants/:id/milestones/:idx/dispute`
  - Fetches resolved dispute history from `GET /disputes?status=resolved`
  - Shows live statistics: active dispute count and resolved count

- **`tests/components/DisputePanel.test.tsx`** — 7 unit tests covering: empty history state, resolved history table, dispute card rendering, approve payout two-step flow (with mocked `resolveDispute` + `useContractTransaction`), refund funders two-step flow, restricted access gate for non-council wallets, and full council dashboard rendering.

### Modified Files

- **`lib/stellar/contract.ts`** — Added two methods to `ContractClient`:
  - `isCouncilMember({ address })` — Checks address against `NEXT_PUBLIC_COUNCIL_ADDRESSES` env var (comma-separated list). Returns `boolean`.
  - `resolveDispute({ grantId, milestoneIdx, approvePayout, councilAddress })` — Builds and returns the `milestone_resolve_dispute` transaction parameters (method name + `ScVal` args) for `useContractTransaction.execute()`.

- **`tests/token-utils.test.ts`** — Fixed stale assertion for `convertTokenDecimals(1e18, 18, 7)` to expect the correct value `10000000n` (was `100000000000n`).

---

## Technical Details

### Council Authorization Gate

- Wallet connection is enforced by wrapping content in `<WalletGuard />`.
- Council membership is checked client-side on every mount by reading the `NEXT_PUBLIC_COUNCIL_ADDRESSES` comma-separated environment variable. Non-council wallets see only a "Restricted Access" screen — no dispute data is exposed.

### On-Chain Resolution Flow

- `resolveDispute` maps to the Rust contract entrypoint `milestone_resolve_dispute(env, council: Address, grant_id: u64, milestone_idx: u32, approve: bool)`.
- The `councilAddress` parameter satisfies the contract-level `require_auth` check on the council signer.
- Both "Approve Payout" and "Refund Funders" buttons are gated behind a two-step inline confirmation prompt before triggering a Freighter signing request via `useContractTransaction`.

### API Fallback Strategy

The client first tries `GET /disputes?status=open`. If that endpoint is unavailable or returns an error, it falls back to fetching all grants and filtering those with a `Disputed` milestone state — ensuring the panel remains functional regardless of backend maturity.

---

## Test Results

All 377 tests pass (28 test files).

```
Test Files  28 passed (28)
     Tests  377 passed (377)
  Duration  ~14s
```

Closes #343