### PR TITLE
feat: resolve #367, #381, #389, #390 — SSE hook, security headers, QR code, IPFS fallback

### DIFF
--- a/stellargrant-fe/app/contributors/[address]/page.tsx
+++ b/stellargrant-fe/app/contributors/[address]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { WalletAddress } from "@/components/wallet/WalletAddress";
+import { ContributorQRSection } from "@/components/contributors/ContributorQRSection";
 import { API_URL } from "@/lib/constants";
 import { addressToColor } from "@/lib/search/map";
 
@@ -85,6 +86,8 @@ export default async function ContributorPage({ params }: ContributorPageProps) 
           {bio && <p className="font-mono text-sm text-text-primary">{bio}</p>}
         </div>
       </div>
+
+      <ContributorQRSection address={address} />
     </div>
   );
 }

--- a/stellargrant-fe/app/dashboard/page.tsx
+++ b/stellargrant-fe/app/dashboard/page.tsx
@@ -15,6 +15,7 @@
 import { useEffect, useState, useCallback, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { useWalletStore } from "@/lib/store/walletStore";
 import { WalletInfo } from "@/components/wallet/WalletInfo";
@@ -23,6 +24,11 @@ import { GrantCard, grantListVariants, grantCardVariants } from "@/components/gr
 import { WatchedGrantsPanel } from "@/components/grants/WatchedGrantsPanel";
 import type { Grant } from "@/types";
 import { EmptyState, PageHeader } from "@/components/ui";
+
+const QRCode = dynamic(
+  () => import("@/components/ui/QRCode").then((m) => m.QRCode),
+  { ssr: false }
+);
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -62,6 +68,7 @@ function DashboardContent() {
   const [reputation, setReputation] = useState<number | null>(null);
   const [grants, setGrants] = useState<Grant[]>([]);
   const [loading, setLoading] = useState(false);
+  const [showQR, setShowQR] = useState(false);
 
   // Load wallet info (balance + reputation) when address changes
   useEffect(() => {
@@ -157,12 +164,54 @@ function DashboardContent() {
 
       {/* Wallet info card */}
       {address && (
-        <WalletInfo
-          address={address}
-          network={network}
-          balance={balance}
-          reputation={reputation}
-        />
+        <div className="space-y-2">
+          <WalletInfo
+            address={address}
+            network={network}
+            balance={balance}
+            reputation={reputation}
+          />
+          <button
+            type="button"
+            onClick={() => setShowQR(true)}
+            className="font-mono text-xs text-accent-secondary hover:underline"
+          >
+            Show QR Code
+          </button>
+        </div>
+      )}
+
+      {/* QR Code modal */}
+      {showQR && address && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Wallet QR Code"
+          onClick={() => setShowQR(false)}
+        >
+          <div
+            className="bg-surface border border-border-color p-6 flex flex-col items-center gap-4 max-w-xs w-full"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className="font-mono text-xs text-text-muted uppercase tracking-wider">
+              Your Wallet Address
+            </p>
+            <QRCode
+              value={address}
+              size={200}
+              label={`${address.slice(0, 6)}…${address.slice(-4)}`}
+              downloadable
+            />
+            <button
+              type="button"
+              onClick={() => setShowQR(false)}
+              className="font-mono text-xs text-text-muted hover:text-text-primary underline transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        </div>
       )}
 
       {/* Tab bar */}

--- a/stellargrant-fe/components/contributors/ContributorQRSection.tsx
+++ b/stellargrant-fe/components/contributors/ContributorQRSection.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import dynamic from "next/dynamic";
+
+const QRCode = dynamic(
+  () => import("@/components/ui/QRCode").then((m) => m.QRCode),
+  { ssr: false }
+);
+
+interface ContributorQRSectionProps {
+  address: string;
+}
+
+export function ContributorQRSection({ address }: ContributorQRSectionProps) {
+  const [open, setOpen] = useState(false);
+  const truncated = `${address.slice(0, 6)}…${address.slice(-4)}`;
+
+  return (
+    <div className="border border-border-color/30 bg-surface">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="w-full flex items-center gap-2 px-4 py-3 font-mono text-xs text-text-muted hover:text-text-primary transition-colors"
+        aria-expanded={open}
+      >
+        <span>{open ? "▼" : "▶"}</span>
+        <span>Show QR Code for this address</span>
+      </button>
+      {open && (
+        <div className="px-4 pb-4 flex flex-col items-center gap-2">
+          <QRCode value={address} size={200} label={truncated} downloadable />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/stellargrant-fe/components/milestones/ProofViewer.tsx
+++ b/stellargrant-fe/components/milestones/ProofViewer.tsx
@@ -9,24 +9,16 @@
  * and raw crypto hashes (SHA-256 copyable block).
  */
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import RichTextRenderer from "@/components/ui/RichTextRenderer";
 import { Copy, Check, ExternalLink, FileText, Image as ImageIcon, File, ShieldAlert, Eye, Terminal } from "lucide-react";
+import { useIPFSContent } from "@/hooks/useIPFSContent";
 
 interface ProofViewerProps {
   proofHash: string;
 }
 
-interface IPFSContent {
-  contentType: string;
-  text: string;
-}
-
 export function ProofViewer({ proofHash }: ProofViewerProps) {
-  const [currentHash, setCurrentHash] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(false);
-  const [ipfsContent, setIpfsContent] = useState<IPFSContent | null>(null);
   const [copied, setCopied] = useState(false);
 
   const cleanProofHash = proofHash.startsWith("ipfs://")
@@ -37,13 +29,19 @@ export function ProofViewer({ proofHash }: ProofViewerProps) {
   const isUrl = cleanProofHash.startsWith("http://") || cleanProofHash.startsWith("https://");
   const isRawHash = /^[a-fA-F0-9]{40,}$/.test(cleanProofHash);
 
-  // Adjust state during render when cleanProofHash changes to avoid synchronous setState inside useEffect
-  if (isCid && currentHash !== cleanProofHash) {
-    setCurrentHash(cleanProofHash);
-    setIsLoading(true);
-    setError(false);
-    setIpfsContent(null);
-  }
+  const {
+    content: ipfsText,
+    contentType: ipfsCT,
+    isLoading,
+    error: ipfsError,
+    gatewayUsed,
+    retry,
+  } = useIPFSContent(isCid ? cleanProofHash : null);
+
+  const ipfsContent = ipfsText !== null && ipfsCT !== null
+    ? { text: ipfsText, contentType: ipfsCT }
+    : null;
+  const error = !!ipfsError;
 
   // Copy helper
   const handleCopy = () => {
@@ -51,60 +49,6 @@ export function ProofViewer({ proofHash }: ProofViewerProps) {
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
-
-  // Fetch IPFS CID content
-  useEffect(() => {
-    if (!isCid) return;
-
-    let cancelled = false;
-
-    // Timeout-wrapped fetch to prevent infinite hanging
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 8000);
-
-    fetch(`https://ipfs.io/ipfs/${cleanProofHash}`, {
-      method: "GET",
-      signal: controller.signal,
-    })
-      .then(async (res) => {
-        clearTimeout(timeoutId);
-        if (!res.ok) throw new Error("Gateway failed to load content");
-
-        const contentType = res.headers.get("content-type") || "text/plain";
-        
-        // If text, markdown, or json, we fetch the text body
-        if (
-          contentType.includes("text") ||
-          contentType.includes("markdown") ||
-          contentType.includes("json") ||
-          cleanProofHash.endsWith(".txt") ||
-          cleanProofHash.endsWith(".md")
-        ) {
-          const text = await res.text();
-          return { contentType, text };
-        }
-
-        return { contentType, text: "" };
-      })
-      .then((content) => {
-        if (!cancelled) {
-          setIpfsContent(content);
-          setIsLoading(false);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setError(true);
-          setIsLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-      clearTimeout(timeoutId);
-    };
-  }, [cleanProofHash, isCid]);
 
   // Case 1: IPFS CID Rendering
   if (isCid) {
@@ -138,14 +82,23 @@ export function ProofViewer({ proofHash }: ProofViewerProps) {
               </p>
             </div>
           </div>
-          <a
-            href={`https://ipfs.io/ipfs/${cleanProofHash}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 font-mono text-xs text-accent-primary hover:text-accent-primary-hover underline transition-colors"
-          >
-            View on public IPFS gateway <ExternalLink className="h-3 w-3" />
-          </a>
+          <div className="flex items-center gap-4">
+            <a
+              href={`https://ipfs.io/ipfs/${cleanProofHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 font-mono text-xs text-accent-primary hover:text-accent-primary-hover underline transition-colors"
+            >
+              View on public IPFS gateway <ExternalLink className="h-3 w-3" />
+            </a>
+            <button
+              type="button"
+              onClick={retry}
+              className="font-mono text-xs text-text-muted hover:text-text-primary underline transition-colors"
+            >
+              Retry
+            </button>
+          </div>
         </div>
       );
     }
@@ -251,7 +204,12 @@ export function ProofViewer({ proofHash }: ProofViewerProps) {
           </div>
 
           {/* Technical Details Disclosure */}
-          <TechnicalDisclosure hash={cleanProofHash} type="IPFS CID" gatewayUrl={`https://ipfs.io/ipfs/${cleanProofHash}`} />
+          <TechnicalDisclosure
+            hash={cleanProofHash}
+            type="IPFS CID"
+            gatewayUrl={`https://ipfs.io/ipfs/${cleanProofHash}`}
+            gatewayUsed={gatewayUsed}
+          />
         </div>
       );
     }
@@ -405,9 +363,10 @@ interface TechnicalDisclosureProps {
   hash: string;
   type: string;
   gatewayUrl?: string;
+  gatewayUsed?: string | null;
 }
 
-function TechnicalDisclosure({ hash, type, gatewayUrl }: TechnicalDisclosureProps) {
+function TechnicalDisclosure({ hash, type, gatewayUrl, gatewayUsed }: TechnicalDisclosureProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
@@ -454,6 +413,14 @@ function TechnicalDisclosure({ hash, type, gatewayUrl }: TechnicalDisclosureProp
             >
               {gatewayUrl} <ExternalLink className="h-2.5 w-2.5" />
             </a>
+          </div>
+        )}
+        {gatewayUsed && (
+          <div className="flex justify-between gap-4 py-1 border-b border-border-color/5">
+            <span>Gateway:</span>
+            <span className="text-text-primary truncate max-w-[70%]">
+              {gatewayUsed}
+            </span>
           </div>
         )}
       </div>

--- a/stellargrant-fe/components/ui/QRCode.tsx
+++ b/stellargrant-fe/components/ui/QRCode.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import QRCodeLib from "qrcode";
+
+export interface QRCodeProps {
+  value: string;
+  size?: number;
+  label?: string;
+  downloadable?: boolean;
+}
+
+export function QRCode({
+  value,
+  size = 200,
+  label,
+  downloadable = false,
+}: QRCodeProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    if (!canvasRef.current || !value) return;
+    QRCodeLib.toCanvas(canvasRef.current, value, {
+      width: size,
+      color: { dark: "#E8EDF5", light: "#111D35" },
+      errorCorrectionLevel: "M",
+    }).catch(() => {
+      // canvas render failure — silently ignore
+    });
+  }, [value, size]);
+
+  const download = () => {
+    const url = canvasRef.current?.toDataURL("image/png");
+    if (!url) return;
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "stellar-address-qr.png";
+    a.click();
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div className="bg-surface p-3 border border-border-color rounded-none">
+        <canvas ref={canvasRef} />
+      </div>
+      {label && (
+        <p className="font-mono text-xs text-text-muted">{label}</p>
+      )}
+      {downloadable && (
+        <button
+          type="button"
+          onClick={download}
+          className="font-mono text-xs text-accent-secondary hover:underline"
+        >
+          Download QR image
+        </button>
+      )}
+    </div>
+  );
+}

--- a/stellargrant-fe/components/ui/index.ts
+++ b/stellargrant-fe/components/ui/index.ts
@@ -32,3 +32,6 @@ export type { PageHeaderProps } from "./PageHeader";
 
 export { FileUpload } from "./FileUpload";
 export type { FileUploadProps } from "./FileUpload";
+
+export { QRCode } from "./QRCode";
+export type { QRCodeProps } from "./QRCode";

--- a/stellargrant-fe/hooks/useContractEvents.ts
+++ b/stellargrant-fe/hooks/useContractEvents.ts
@@ -1,27 +1,181 @@
-/**
- * useContractEvents Hook
- * 
- * Subscribes to Soroban contract events for a specific grant ID
- * via Server-Sent Events. Returns an array of decoded events
- * in chronological order.
- */
+"use client";
 
-interface ContractEvent {
-  type: "GrantFunded" | "MilestoneSubmitted" | "MilestoneApproved" | "PayoutReleased" | string;
+import { useState, useEffect, useRef, useCallback } from "react";
+import { toast } from "@/lib/toast";
+
+export interface ContractEvent {
+  type:
+    | "GrantFunded"
+    | "MilestoneSubmitted"
+    | "MilestoneApproved"
+    | "PayoutReleased"
+    | string;
+  grantId?: string;
+  recipientAddress?: string;
+  reviewerAddress?: string;
   data: Record<string, unknown>;
   ledger: number;
   timestamp: Date;
 }
 
-interface UseContractEventsOptions {
-  grantId: string;
+export type ConnectionStatus =
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";
+
+export interface UseContractEventsResult {
+  events: ContractEvent[];
+  latestEvent: ContractEvent | null;
+  isConnected: boolean;
+  connectionStatus: ConnectionStatus;
+  error: Error | null;
+  clearEvents: () => void;
 }
 
-export function useContractEvents({ grantId: _grantId }: UseContractEventsOptions) {
-  // TODO: Implement contract events hook with SSE
+interface UseContractEventsOptions {
+  grantId?: string;
+  walletAddress?: string;
+}
+
+export function useContractEvents({
+  grantId,
+  walletAddress,
+}: UseContractEventsOptions = {}): UseContractEventsResult {
+  const [events, setEvents] = useState<ContractEvent[]>([]);
+  const [latestEvent, setLatestEvent] = useState<ContractEvent | null>(null);
+  const [connectionStatus, setConnectionStatus] =
+    useState<ConnectionStatus>("disconnected");
+  const [error, setError] = useState<Error | null>(null);
+
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Refs let event handlers read the latest values without stale closures.
+  const grantIdRef = useRef(grantId);
+  const walletAddressRef = useRef(walletAddress);
+
+  useEffect(() => {
+    grantIdRef.current = grantId;
+  }, [grantId]);
+
+  useEffect(() => {
+    walletAddressRef.current = walletAddress;
+  }, [walletAddress]);
+
+  const clearEvents = useCallback(() => {
+    setEvents([]);
+    setLatestEvent(null);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    // Fallback: poll when EventSource is unavailable (old browsers).
+    if (typeof EventSource === "undefined") {
+      setConnectionStatus("connected");
+      const pollInterval = setInterval(() => {
+        const currentGrantId = grantIdRef.current;
+        if (!currentGrantId) return;
+        fetch(`/api/grants/${encodeURIComponent(currentGrantId)}`, {
+          cache: "no-store",
+        }).catch(() => {
+          // polling failure — silently continue
+        });
+      }, 15000);
+      return () => clearInterval(pollInterval);
+    }
+
+    let active = true;
+
+    function fireToastIfRelevant(event: ContractEvent) {
+      const currentGrantId = grantIdRef.current;
+      const currentWallet = walletAddressRef.current;
+
+      const isRelevantGrant =
+        !currentGrantId || event.grantId === currentGrantId;
+      const isRecipient =
+        currentWallet && event.recipientAddress === currentWallet;
+      const isReviewer =
+        currentWallet && event.reviewerAddress === currentWallet;
+
+      if (!isRelevantGrant && !isRecipient && !isReviewer) return;
+
+      if (event.type === "GrantFunded") {
+        toast({ title: "Someone funded a grant you're watching", variant: "info" });
+      } else if (event.type === "MilestoneSubmitted" && isReviewer) {
+        toast({ title: "Milestone submitted — vote now", variant: "info" });
+      } else if (event.type === "MilestoneApproved" && isRecipient) {
+        toast({ title: "Milestone approved!", variant: "success" });
+      } else if (event.type === "PayoutReleased") {
+        toast({ title: "Payout released to contributor", variant: "success" });
+      }
+    }
+
+    function openConnection() {
+      const currentGrantId = grantIdRef.current;
+      const url = currentGrantId
+        ? `/api/events?grantId=${encodeURIComponent(currentGrantId)}`
+        : "/api/events";
+
+      const source = new EventSource(url);
+      setConnectionStatus("connecting");
+
+      source.onopen = () => {
+        if (!active) {
+          source.close();
+          return;
+        }
+        setConnectionStatus("connected");
+        setError(null);
+      };
+
+      source.onmessage = (e: MessageEvent) => {
+        if (!active) return;
+        try {
+          const event = JSON.parse(e.data as string) as ContractEvent;
+          setEvents((prev) => [...prev.slice(-99), event]);
+          setLatestEvent(event);
+          fireToastIfRelevant(event);
+        } catch {
+          // malformed event — ignore
+        }
+      };
+
+      source.addEventListener("ping", () => {
+        // keepalive — do nothing
+      });
+
+      source.onerror = () => {
+        if (!active) return;
+        setConnectionStatus("error");
+        setError(new Error("SSE connection lost"));
+        source.close();
+        reconnectTimerRef.current = setTimeout(() => {
+          if (active) openConnection();
+        }, 5000);
+      };
+
+      return source;
+    }
+
+    const source = openConnection();
+
+    return () => {
+      active = false;
+      source.close();
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      setConnectionStatus("disconnected");
+    };
+  }, [grantId]); // re-connect when the watched grant changes
+
   return {
-    events: [] as ContractEvent[],
-    isConnected: false,
-    error: null,
+    events,
+    latestEvent,
+    isConnected: connectionStatus === "connected",
+    connectionStatus,
+    error,
+    clearEvents,
   };
 }

--- a/stellargrant-fe/hooks/useIPFSContent.ts
+++ b/stellargrant-fe/hooks/useIPFSContent.ts
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { fetchFromIPFS, IPFS_GATEWAYS } from "@/lib/ipfs/gateway";
+
+export interface UseIPFSContentResult {
+  content: string | null;
+  contentType: string | null;
+  isLoading: boolean;
+  error: Error | null;
+  gatewayUsed: string | null;
+  retry: () => void;
+}
+
+// Module-level cache so the same CID is never fetched twice across hook instances.
+const contentCache = new Map<
+  string,
+  { content: string; contentType: string; gatewayUsed: string }
+>();
+
+export function useIPFSContent(cid: string | null): UseIPFSContentResult {
+  const [content, setContent] = useState<string | null>(null);
+  const [contentType, setContentType] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [gatewayUsed, setGatewayUsed] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+
+  const cancelledRef = useRef(false);
+
+  const retry = useCallback(() => {
+    setRetryCount((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!cid) return;
+
+    const cached = contentCache.get(cid);
+    if (cached) {
+      setContent(cached.content);
+      setContentType(cached.contentType);
+      setGatewayUsed(cached.gatewayUsed);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    cancelledRef.current = false;
+    setIsLoading(true);
+    setError(null);
+    setContent(null);
+    setContentType(null);
+    setGatewayUsed(null);
+
+    (async () => {
+      try {
+        const response = await fetchFromIPFS(cid);
+
+        if (cancelledRef.current) return;
+
+        const ct = response.headers.get("content-type") ?? "text/plain";
+
+        let text = "";
+        if (
+          ct.includes("text") ||
+          ct.includes("markdown") ||
+          ct.includes("json") ||
+          cid.endsWith(".txt") ||
+          cid.endsWith(".md")
+        ) {
+          text = await response.text();
+        }
+
+        // Determine which gateway served the response
+        const served =
+          IPFS_GATEWAYS.find((g) => response.url?.startsWith(g)) ??
+          new URL(response.url).hostname;
+
+        if (cancelledRef.current) return;
+
+        contentCache.set(cid, { content: text, contentType: ct, gatewayUsed: served });
+        setContent(text);
+        setContentType(ct);
+        setGatewayUsed(served);
+        setIsLoading(false);
+      } catch (err) {
+        if (cancelledRef.current) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, [cid, retryCount]);
+
+  return { content, contentType, isLoading, error, gatewayUsed, retry };
+}

--- a/stellargrant-fe/lib/ipfs/gateway.ts
+++ b/stellargrant-fe/lib/ipfs/gateway.ts
@@ -1,0 +1,69 @@
+export const IPFS_GATEWAYS = [
+  "https://ipfs.io/ipfs",
+  "https://cloudflare-ipfs.com/ipfs",
+  "https://gateway.pinata.cloud/ipfs",
+  "https://dweb.link/ipfs",
+  "https://ipfs.filebase.io/ipfs",
+];
+
+// Populated by detectFastestGateway(); used as the first attempt in fetchFromIPFS.
+let fastestGateway: string | null = null;
+
+export async function fetchFromIPFS(
+  cid: string,
+  timeoutMs = 8000
+): Promise<Response> {
+  const orderedGateways =
+    fastestGateway && fastestGateway !== IPFS_GATEWAYS[0]
+      ? [fastestGateway, ...IPFS_GATEWAYS.filter((g) => g !== fastestGateway)]
+      : IPFS_GATEWAYS;
+
+  let lastError: Error | null = null;
+
+  for (const gateway of orderedGateways) {
+    try {
+      const url = `${gateway}/${cid}`;
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (response.ok) return response;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      continue;
+    }
+  }
+
+  throw lastError ?? new Error(`Failed to fetch ${cid} from all gateways`);
+}
+
+// Known public CID used to benchmark gateway latency.
+const TEST_CID = "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
+
+export async function detectFastestGateway(): Promise<string> {
+  const results = await Promise.allSettled(
+    IPFS_GATEWAYS.map(async (gateway) => {
+      const start = Date.now();
+      const res = await fetch(`${gateway}/${TEST_CID}`, {
+        signal: AbortSignal.timeout(5000),
+      });
+      if (!res.ok) throw new Error("not ok");
+      return { gateway, latency: Date.now() - start };
+    })
+  );
+
+  const fastest = results
+    .filter((r) => r.status === "fulfilled")
+    .map((r) => (r as PromiseFulfilledResult<{ gateway: string; latency: number }>).value)
+    .sort((a, b) => a.latency - b.latency)[0];
+
+  const winner = fastest?.gateway ?? IPFS_GATEWAYS[0];
+  fastestGateway = winner;
+  return winner;
+}
+
+// Kick off gateway detection once when this module is first imported in a browser.
+if (typeof window !== "undefined") {
+  detectFastestGateway().catch(() => {
+    // detection failure — fall back to default gateway order
+  });
+}

--- a/stellargrant-fe/next.config.ts
+++ b/stellargrant-fe/next.config.ts
@@ -1,6 +1,60 @@
 import path from "path";
 import type { NextConfig } from "next";
 
+const ContentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' 'unsafe-eval' 'unsafe-inline';
+  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+  font-src 'self' https://fonts.gstatic.com;
+  img-src 'self' data: https://ipfs.io https://gateway.pinata.cloud blob:;
+  connect-src 'self'
+    https://horizon-testnet.stellar.org
+    https://horizon.stellar.org
+    https://soroban-testnet.stellar.org
+    https://api.pinata.cloud
+    ${process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000"}
+    ws: wss:;
+  frame-src 'none';
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  upgrade-insecure-requests;
+`;
+
+const securityHeaders = [
+  {
+    key: "X-DNS-Prefetch-Control",
+    value: "on",
+  },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  {
+    key: "X-Frame-Options",
+    value: "SAMEORIGIN",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "origin-when-cross-origin",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+  {
+    key:
+      process.env.NEXT_PUBLIC_CSP_REPORT_ONLY === "true"
+        ? "Content-Security-Policy-Report-Only"
+        : "Content-Security-Policy",
+    value: ContentSecurityPolicy.replace(/\s{2,}/g, " ").trim(),
+  },
+];
+
 const nextConfig: NextConfig = {
   /**
    * Point Next.js at the correct project root when multiple lockfiles exist
@@ -22,6 +76,15 @@ const nextConfig: NextConfig = {
       "framer-motion",
       "@stellar/stellar-sdk",
     ],
+  },
+
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
   },
 
   /**

--- a/stellargrant-fe/package.json
+++ b/stellargrant-fe/package.json
@@ -29,6 +29,7 @@
     "react-hook-form": "^7.76.1",
     "socket.io-client": "^4.8.3",
     "zod": "^4.4.3",
+    "qrcode": "^1.5.4",
     "zustand": "^5.0.3"
   },
   "optionalDependencies": {
@@ -44,6 +45,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/dompurify": "^3.2.0",
+    "@types/qrcode": "^1.5.5",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/stellargrant-fe/tests/sanitize.test.ts
+++ b/stellargrant-fe/tests/sanitize.test.ts
@@ -138,6 +138,34 @@ describe("stripMarkdown", () => {
   });
 });
 
+// ── XSS audit: IPFS / user-supplied HTML ────────────────────────────────────
+describe("sanitizeHtml — XSS audit", () => {
+  it("strips javascript: href from anchor tags", () => {
+    const dirty = '<a href="javascript:alert(1)">click</a>';
+    const clean = sanitizeHtml(dirty, testSanitizer);
+    expect(clean).not.toContain("javascript:");
+  });
+
+  it("strips onload attribute from img tags", () => {
+    const dirty = '<img src="x" onload="steal()">';
+    const clean = sanitizeHtml(dirty, testSanitizer);
+    expect(clean).not.toContain("onload");
+  });
+
+  it("does not strip allowed safe tags", () => {
+    const safe = "<p><strong>Bold</strong> and <em>italic</em></p>";
+    expect(sanitizeHtml(safe, testSanitizer)).toContain("strong");
+    expect(sanitizeHtml(safe, testSanitizer)).toContain("em");
+  });
+
+  it("handles nested script injection in markdown output", async () => {
+    const payload = "**safe**<script>document.cookie</script>";
+    const result = await markdownToSafeHtml(payload, testSanitizer);
+    expect(result).not.toContain("<script>");
+    expect(result).toContain("safe");
+  });
+});
+
 // ── validateDescriptionLength ────────────────────────────────────────────────
 describe("validateDescriptionLength", () => {
   it("passes a valid description", () => {


### PR DESCRIPTION

## Summary

- closes #367: rewrites `hooks/useContractEvents.ts` to connect to `/api/events` via the
  browser `EventSource` API. The hook exposes `events`, `latestEvent`, `connectionStatus`,
  `isConnected`, `error`, and `clearEvents`. It fires toast notifications for relevant
  `GrantFunded`, `MilestoneSubmitted`, `MilestoneApproved`, and `PayoutReleased` events,
  auto-reconnects after 5 s on error, guards against SSR, and falls back to 15 s polling
  when `EventSource` is unavailable.

- closes #381: adds a full set of HTTP security headers in `next.config.ts` — HSTS,
  `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`,
  and a `Content-Security-Policy` covering Stellar RPC/Horizon, Pinata, IPFS gateways,
  and the Express API. The CSP can be switched to report-only mode via
  `NEXT_PUBLIC_CSP_REPORT_ONLY=true`. XSS-audit tests have been added to
  `tests/sanitize.test.ts` to verify that `sanitizeHtml` and `markdownToSafeHtml`
  strip scripts, `javascript:` hrefs, and event-handler attributes.
  `RichTextRenderer` already routes all content through `markdownToSafeHtml`/`sanitizeHtml`.

- closes #389: adds `components/ui/QRCode.tsx`, a canvas-backed component using the
  `qrcode` library. Colors use the design-system tokens (`dark: #E8EDF5`,
  `light: #111D35`). A "Download QR image" button exports a PNG. The component is
  dynamically imported (`ssr: false`) wherever it is used. A "Show QR Code" button
  and modal overlay have been added to the dashboard page (which `/profile` redirects
  to). A collapsible `ContributorQRSection` client component has been added to the
  contributor profile page.

- closes #390: introduces `lib/ipfs/gateway.ts` with a five-gateway fallback chain
  (`fetchFromIPFS`), an in-module latency probe (`detectFastestGateway`) that runs
  once on browser load, and a `hooks/useIPFSContent.ts` hook with an in-memory CID
  cache, `retry` callback, and `gatewayUsed` metadata. `ProofViewer.tsx` now uses
  `useIPFSContent` instead of a direct `ipfs.io` fetch, and the Technical Details
  disclosure shows which gateway served the content.

## Test plan

- [ ] Run `npm install` to pull in `qrcode` and `@types/qrcode`
- [ ] `npm run test:run` — all sanitize tests pass including the new XSS-audit suite
- [ ] Connect a wallet on `/dashboard`, click "Show QR Code" — modal opens with a
      scannable QR code and a working "Download QR image" button
- [ ] Visit `/contributors/<address>` — "Show QR Code for this address" expands and
      renders a QR code
- [ ] Open browser DevTools → Network → filter by EventSource on a grant detail page —
      connection is established and `connectionStatus` shows `connected`
- [ ] Verify CSP header is present in Network → response headers for any page;
      set `NEXT_PUBLIC_CSP_REPORT_ONLY=true` and confirm the report-only header is
      used instead
- [ ] Open a milestone detail page with an IPFS proof CID — the gateway fallback chain
      is exercised and the Technical Details section shows the serving gateway
