### PR TITLE
Feat/345 388 445 452 404 export disputes ratelimit

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-rate-limit": "^7.0.0",
+    "rate-limit-redis": "^4.2.0",
     "form-data": "^4.0.0",
     "helmet": "^8.1.0",
     "ioredis": "^5.3.2",

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -42,6 +42,7 @@ import { buildUserRouter } from "./routes/users";
 import { buildGrantReviewerRouter } from "./routes/grant-reviewers";
 import { buildMilestoneApprovalNotifyRouter } from "./routes/milestone-approvals-notify";
 import { buildMilestoneCommentsRouter } from "./routes/milestone-comments";
+import { buildDisputesRouter, buildGrantDisputesRouter } from "./routes/disputes";
 
 export const createApp = (dataSource: DataSource, sorobanClient: SorobanContractClient) => {
   const app = express();
@@ -85,6 +86,8 @@ export const createApp = (dataSource: DataSource, sorobanClient: SorobanContract
   app.use("/users", buildUserRouter(userRepo));
   app.use("/grant_reviewers", buildGrantReviewerRouter(reviewerRepo));
   app.use("/milestone_approvals_notify", buildMilestoneApprovalNotifyRouter(approvalRepo, grantRepo, userRepo, webhookDispatcher));
+  app.use("/disputes", buildDisputesRouter(dataSource, rbacService, webhookDispatcher));
+  app.use("/", buildGrantDisputesRouter(dataSource));
   app.use("/", buildMilestoneCommentsRouter(milestoneRepo, commentsRepo, reviewerRepo));
   app.get("/metrics", async (req, res, next) => {
     try {

--- a/api/src/config/env.ts
+++ b/api/src/config/env.ts
@@ -15,4 +15,5 @@ export const env = {
   contractId: process.env.CONTRACT_ID ?? "",
   rpcUrl: process.env.RPC_URL ?? "https://rpc-futurenet.stellar.org",
   networkPassphrase: process.env.NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015",
+  redisUrl: process.env.REDIS_URL ?? "",
 };

--- a/api/src/db/migrations/1700000001000-AddDisputeTable.ts
+++ b/api/src/db/migrations/1700000001000-AddDisputeTable.ts
@@ -1,0 +1,81 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from "typeorm";
+
+export class AddDisputeTable1700000001000 implements MigrationInterface {
+  name = "AddDisputeTable1700000001000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "disputes",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: "increment",
+          },
+          {
+            name: "grantId",
+            type: "int",
+          },
+          {
+            name: "milestoneIdx",
+            type: "int",
+          },
+          {
+            name: "status",
+            type: "varchar",
+            length: "30",
+            default: "'open'",
+          },
+          {
+            name: "contributorArgument",
+            type: "text",
+            isNullable: true,
+          },
+          {
+            name: "funderArgument",
+            type: "text",
+            isNullable: true,
+          },
+          {
+            name: "resolvedBy",
+            type: "varchar",
+            length: "120",
+            isNullable: true,
+          },
+          {
+            name: "resolutionTxHash",
+            type: "varchar",
+            length: "64",
+            isNullable: true,
+          },
+          {
+            name: "openedAt",
+            type: "timestamp",
+            default: "now()",
+          },
+          {
+            name: "resolvedAt",
+            type: "timestamp",
+            isNullable: true,
+          },
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.createIndex(
+      "disputes",
+      new TableIndex({
+        name: "IDX_disputes_grantId",
+        columnNames: ["grantId"],
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("disputes", true);
+  }
+}

--- a/api/src/entities/Dispute.ts
+++ b/api/src/entities/Dispute.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from "typeorm";
+
+@Entity({ name: "disputes" })
+export class Dispute {
+  @PrimaryGeneratedColumn("increment")
+  id!: number;
+
+  @Index()
+  @Column({ type: "int" })
+  grantId!: number;
+
+  @Column({ type: "int" })
+  milestoneIdx!: number;
+
+  @Column({ type: "varchar", length: 30, default: "open" })
+  status!: "open" | "resolved_payout" | "resolved_refund";
+
+  @Column({ type: "text", nullable: true })
+  contributorArgument!: string | null;
+
+  @Column({ type: "text", nullable: true })
+  funderArgument!: string | null;
+
+  @Column({ type: "varchar", length: 120, nullable: true })
+  resolvedBy!: string | null;
+
+  @Column({ type: "varchar", length: 64, nullable: true })
+  resolutionTxHash!: string | null;
+
+  @CreateDateColumn()
+  openedAt!: Date;
+
+  @Column({ type: "timestamp", nullable: true })
+  resolvedAt!: Date | null;
+}

--- a/api/src/middlewares/rate-limiter.ts
+++ b/api/src/middlewares/rate-limiter.ts
@@ -1,6 +1,45 @@
-import rateLimit from "express-rate-limit";
+import rateLimit, { Options } from "express-rate-limit";
+import { Request } from "express";
 import { DataSource } from "typeorm";
 import { RateLimitLog } from "../entities/RateLimitLog";
+import { env } from "../config/env";
+import { metricsService } from "../services/metrics-service";
+
+// Lazily initialised Redis store (only when REDIS_URL is set)
+let cachedStore: Options["store"] | undefined;
+let storeInitStarted = false;
+
+async function buildRedisStore(): Promise<Options["store"] | undefined> {
+  if (!env.redisUrl) return undefined;
+  if (storeInitStarted) return cachedStore;
+  storeInitStarted = true;
+  try {
+    const { RedisStore } = await import("rate-limit-redis");
+    const { default: Redis } = await import("ioredis");
+    const redis = new Redis(env.redisUrl, {
+      lazyConnect: true,
+      maxRetriesPerRequest: 1,
+    });
+    cachedStore = new RedisStore({
+      sendCommand: (...args: string[]) =>
+        redis.call(args[0], ...args.slice(1)) as Promise<number>,
+    });
+  } catch {
+    // Redis unavailable — silently fall back to in-memory
+  }
+  return cachedStore;
+}
+
+export function extractWalletAddress(req: Request): string | null {
+  const body = req.body as Record<string, unknown> | undefined;
+  if (!body) return null;
+  return (
+    (body.address as string | undefined) ??
+    (body.submittedBy as string | undefined) ??
+    (body.reviewer as string | undefined) ??
+    null
+  );
+}
 
 export const createRateLimiter = (dataSource: DataSource) => {
   const repo = dataSource.getRepository(RateLimitLog);
@@ -8,26 +47,92 @@ export const createRateLimiter = (dataSource: DataSource) => {
   return rateLimit({
     windowMs: 60 * 1000,
     max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
 
     handler: async (req, res) => {
-      // log blocked request (best-effort; never fail the response)
       try {
         await repo.save({
           ip: req.ip,
           path: req.originalUrl,
           method: req.method,
           userAgent: String(req.headers["user-agent"] || ""),
-          address: typeof req.headers["x-user-address"] === "string"
-            ? req.headers["x-user-address"]
-            : null,
+          address:
+            typeof req.headers["x-user-address"] === "string"
+              ? req.headers["x-user-address"]
+              : null,
         });
       } catch {
         // ignore logging failures
       }
 
+      res.status(429).json({ error: "Too many requests" });
+    },
+  });
+};
+
+export function createWalletRateLimiter(
+  windowMs: number,
+  max: number,
+  keyExtractor: (req: Request) => string | null = extractWalletAddress
+) {
+  let upgradeAttempted = false;
+
+  const limiter = rateLimit({
+    windowMs,
+    max,
+    standardHeaders: true,
+    legacyHeaders: false,
+
+    keyGenerator: (req) => {
+      const wallet = keyExtractor(req);
+      return wallet ? `wallet:${wallet}` : (req.ip ?? "unknown");
+    },
+
+    handler: (req, res) => {
+      const wallet = keyExtractor(req);
+      const endpoint = req.path;
+      console.warn("[rate-limiter] wallet limit hit", { wallet, endpoint });
+      metricsService.recordWalletRateLimitHit(endpoint);
+
       res.status(429).json({
-        error: "Too many requests",
+        error: "Too many requests from this wallet address",
+        retryAfter: Math.ceil(windowMs / 1000),
       });
     },
   });
+
+  return (
+    req: Parameters<typeof limiter>[0],
+    res: Parameters<typeof limiter>[1],
+    next: Parameters<typeof limiter>[2]
+  ) => {
+    // Upgrade to Redis store once, non-blocking
+    if (!upgradeAttempted) {
+      upgradeAttempted = true;
+      void buildRedisStore().then((store) => {
+        if (store) {
+          (limiter as unknown as { store: Options["store"] }).store = store;
+        }
+      });
+    }
+    return limiter(req, res, next);
+  };
+}
+
+// Pre-built per-wallet limiters for each write endpoint
+export const walletLimiters = {
+  createGrant: createWalletRateLimiter(60 * 60 * 1000, 5),
+  fundGrant: createWalletRateLimiter(10 * 60 * 1000, 10),
+  milestoneProof: createWalletRateLimiter(60 * 60 * 1000, 20, (req) =>
+    (req.body as { submittedBy?: string } | undefined)?.submittedBy ??
+    extractWalletAddress(req)
+  ),
+  milestoneApproval: createWalletRateLimiter(10 * 60 * 1000, 50, (req) =>
+    (req.body as { reviewer?: string } | undefined)?.reviewer ??
+    extractWalletAddress(req)
+  ),
+  grantFeedback: createWalletRateLimiter(24 * 60 * 60 * 1000, 1),
+  grantDraft: createWalletRateLimiter(60 * 60 * 1000, 20),
+  disputeArgument: createWalletRateLimiter(24 * 60 * 60 * 1000, 3),
 };

--- a/api/src/routes/disputes.ts
+++ b/api/src/routes/disputes.ts
@@ -1,0 +1,300 @@
+import { Router } from "express";
+import { DataSource, Repository } from "typeorm";
+import { Dispute } from "../entities/Dispute";
+import { Grant } from "../entities/Grant";
+import { Milestone } from "../entities/Milestone";
+import { RbacService } from "../services/rbac-service";
+import { WebhookDispatcher } from "../services/webhook-dispatcher";
+import { walletLimiters } from "../middlewares/rate-limiter";
+
+interface ResolveBody {
+  approve_payout: boolean;
+  tx_hash?: string;
+  resolver_address?: string;
+  signature?: string;
+}
+
+interface ArgumentBody {
+  role: "contributor" | "funder";
+  argument: string;
+  address: string;
+}
+
+export const buildDisputesRouter = (
+  dataSource: DataSource,
+  rbacService: RbacService,
+  webhookDispatcher: WebhookDispatcher
+) => {
+  const router = Router();
+  const disputeRepo: Repository<Dispute> = dataSource.getRepository(Dispute);
+  const grantRepo: Repository<Grant> = dataSource.getRepository(Grant);
+  const milestoneRepo: Repository<Milestone> = dataSource.getRepository(Milestone);
+
+  // GET /disputes — list open disputes (?status=all for all)
+  router.get("/", async (req, res, next) => {
+    try {
+      const statusFilter = req.query.status === "all" ? undefined : "open";
+
+      const qb = disputeRepo
+        .createQueryBuilder("d")
+        .leftJoin(Grant, "g", "g.id = d.grantId")
+        .leftJoin(Milestone, "m", "m.grantId = d.grantId AND m.idx = d.milestoneIdx")
+        .select([
+          "d.id AS id",
+          "d.grantId AS grantId",
+          "d.milestoneIdx AS milestoneIdx",
+          "d.status AS status",
+          "d.openedAt AS openedAt",
+          "d.resolvedAt AS resolvedAt",
+          "g.title AS grantTitle",
+          "m.title AS milestoneTitle",
+        ]);
+
+      if (statusFilter) {
+        qb.where("d.status = :status", { status: statusFilter });
+      }
+
+      const disputes = await qb.getRawMany();
+      res.json({ data: disputes });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // GET /disputes/:id — single dispute with full grant + milestone data
+  router.get("/:id", async (req, res, next) => {
+    try {
+      const id = Number(req.params.id);
+      if (Number.isNaN(id)) {
+        res.status(400).json({ error: "Invalid dispute id" });
+        return;
+      }
+
+      const dispute = await disputeRepo.findOne({ where: { id } });
+      if (!dispute) {
+        res.status(404).json({ error: "Dispute not found" });
+        return;
+      }
+
+      const [grant, milestone] = await Promise.all([
+        grantRepo.findOne({ where: { id: dispute.grantId } }),
+        milestoneRepo.findOne({
+          where: { grantId: dispute.grantId, idx: dispute.milestoneIdx },
+        }),
+      ]);
+
+      res.json({ data: { ...dispute, grant, milestone } });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+
+  // POST /disputes/:id/argument — submit contributor or funder argument
+  router.post("/:id/argument", walletLimiters.disputeArgument, async (req, res, next) => {
+    try {
+      const id = Number(req.params.id);
+      if (Number.isNaN(id)) {
+        res.status(400).json({ error: "Invalid dispute id" });
+        return;
+      }
+
+      const body = req.body as ArgumentBody;
+      if (!body.role || !body.argument || !body.address) {
+        res.status(400).json({ error: "role, argument, and address are required" });
+        return;
+      }
+
+      const dispute = await disputeRepo.findOne({ where: { id } });
+      if (!dispute) {
+        res.status(404).json({ error: "Dispute not found" });
+        return;
+      }
+
+      if (dispute.status !== "open") {
+        res.status(400).json({ error: "Cannot add argument to a resolved dispute" });
+        return;
+      }
+
+      if (body.role === "contributor") {
+        dispute.contributorArgument = body.argument;
+      } else if (body.role === "funder") {
+        dispute.funderArgument = body.argument;
+      } else {
+        res.status(400).json({ error: "role must be 'contributor' or 'funder'" });
+        return;
+      }
+
+      const saved = await disputeRepo.save(dispute);
+      res.json({ data: saved });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  // POST /disputes/:id/resolve — record resolution (council-only via RBAC)
+  router.post("/:id/resolve", async (req, res, next) => {
+    try {
+      const stellarAddress =
+        (req.body as { resolver_address?: string }).resolver_address ??
+        req.header("x-user-address");
+
+      if (!stellarAddress) {
+        res.status(401).json({ error: "Authentication required" });
+        return;
+      }
+
+      const isCouncil = await rbacService.userHasPermissionByAddress(
+        stellarAddress,
+        "admin:all"
+      );
+
+      if (!isCouncil) {
+        res.status(403).json({
+          error: "Forbidden",
+          message: "Council member access required",
+        });
+        return;
+      }
+
+      const id = Number(req.params.id);
+      if (Number.isNaN(id)) {
+        res.status(400).json({ error: "Invalid dispute id" });
+        return;
+      }
+
+      const body = req.body as ResolveBody;
+      if (body.approve_payout === undefined) {
+        res.status(400).json({ error: "approve_payout is required" });
+        return;
+      }
+
+      const dispute = await disputeRepo.findOne({ where: { id } });
+      if (!dispute) {
+        res.status(404).json({ error: "Dispute not found" });
+        return;
+      }
+
+      if (dispute.status !== "open") {
+        res.status(400).json({ error: "Dispute is already resolved" });
+        return;
+      }
+
+      dispute.status = body.approve_payout ? "resolved_payout" : "resolved_refund";
+      dispute.resolvedBy = stellarAddress;
+      dispute.resolutionTxHash = body.tx_hash ?? null;
+      dispute.resolvedAt = new Date();
+
+      const saved = await disputeRepo.save(dispute);
+
+      const [grant, milestone] = await Promise.all([
+        grantRepo.findOne({ where: { id: dispute.grantId } }),
+        milestoneRepo.findOne({
+          where: { grantId: dispute.grantId, idx: dispute.milestoneIdx },
+        }),
+      ]);
+
+      await webhookDispatcher
+        .dispatch("dispute_resolved" as never, {
+          disputeId: saved.id,
+          grantId: saved.grantId,
+          milestoneIdx: saved.milestoneIdx,
+          status: saved.status,
+          resolvedBy: saved.resolvedBy,
+          txHash: saved.resolutionTxHash,
+          grant: grant ? { id: grant.id, title: grant.title } : null,
+          milestone: milestone ? { idx: milestone.idx, title: milestone.title } : null,
+        })
+        .catch(() => {
+          // webhook failures must never break the response
+        });
+
+      res.json({ data: saved });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+};
+
+// Registers grant-scoped dispute routes:
+//   GET  /grants/:grantId/milestones/:idx/dispute
+//   POST /grants/:grantId/milestones/:idx/dispute
+export const buildGrantDisputesRouter = (dataSource: DataSource) => {
+  const router = Router({ mergeParams: true });
+  const disputeRepo: Repository<Dispute> = dataSource.getRepository(Dispute);
+  const grantRepo: Repository<Grant> = dataSource.getRepository(Grant);
+
+  router.get(
+    "/grants/:grantId/milestones/:idx/dispute",
+    async (req, res, next) => {
+      try {
+        const grantId = Number(req.params.grantId);
+        const milestoneIdx = Number(req.params.idx);
+
+        if (Number.isNaN(grantId) || Number.isNaN(milestoneIdx)) {
+          res.status(400).json({ error: "Invalid parameters" });
+          return;
+        }
+
+        const dispute = await disputeRepo.findOne({
+          where: { grantId, milestoneIdx },
+        });
+
+        if (!dispute) {
+          res.status(404).json({ error: "Dispute not found for this milestone" });
+          return;
+        }
+
+        res.json({ data: dispute });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  router.post(
+    "/grants/:grantId/milestones/:idx/dispute",
+    async (req, res, next) => {
+      try {
+        const grantId = Number(req.params.grantId);
+        const milestoneIdx = Number(req.params.idx);
+
+        if (Number.isNaN(grantId) || Number.isNaN(milestoneIdx)) {
+          res.status(400).json({ error: "Invalid parameters" });
+          return;
+        }
+
+        const grant = await grantRepo.findOne({ where: { id: grantId } });
+        if (!grant) {
+          res.status(404).json({ error: "Grant not found" });
+          return;
+        }
+
+        const existing = await disputeRepo.findOne({
+          where: { grantId, milestoneIdx },
+        });
+        if (existing) {
+          res
+            .status(409)
+            .json({ error: "Dispute already exists for this milestone" });
+          return;
+        }
+
+        const dispute = disputeRepo.create({
+          grantId,
+          milestoneIdx,
+          status: "open",
+        });
+
+        const saved = await disputeRepo.save(dispute);
+        res.status(201).json({ data: saved });
+      } catch (err) {
+        next(err);
+      }
+    }
+  );
+
+  return router;
+};

--- a/api/src/routes/milestone-approvals.ts
+++ b/api/src/routes/milestone-approvals.ts
@@ -2,12 +2,13 @@ import { Router } from "express";
 import { Repository } from "typeorm";
 import { MilestoneApproval } from "../entities/MilestoneApproval";
 import { notificationService } from "../services/notification-service";
+import { walletLimiters } from "../middlewares/rate-limiter";
 
 export const buildMilestoneApprovalRouter = (approvalRepo: Repository<MilestoneApproval>) => {
   const router = Router();
 
   // Reviewer approves or rejects a milestone
-  router.post("/", async (req, res) => {
+  router.post("/", walletLimiters.milestoneApproval, async (req, res) => {
     const { grantId, milestoneIdx, reviewerStellarAddress, approved } = req.body;
     if (!grantId || milestoneIdx === undefined || !reviewerStellarAddress || approved === undefined) {
       return res.status(400).json({ error: "grantId, milestoneIdx, reviewerStellarAddress, and approved are required" });

--- a/api/src/routes/milestone-proof.ts
+++ b/api/src/routes/milestone-proof.ts
@@ -6,6 +6,7 @@ import { SignatureService } from "../services/signature-service";
 import { getEmailTemplate, sendEmail } from "../services/email-service";
 import { Grant } from "../entities/Grant";
 import { User } from "../entities/User";
+import { walletLimiters } from "../middlewares/rate-limiter";
 
 const milestoneProofSchema = z.object({
   grantId: z.number().int().positive(),
@@ -25,7 +26,7 @@ export const buildMilestoneProofRouter = (
 ) => {
   const router = Router();
 
-  router.post("/", async (req, res, next) => {
+  router.post("/", walletLimiters.milestoneProof, async (req, res, next) => {
     try {
       const parsed = milestoneProofSchema.safeParse(req.body);
       if (!parsed.success) {

--- a/api/src/services/grant-sync-service.ts
+++ b/api/src/services/grant-sync-service.ts
@@ -3,6 +3,7 @@ import { Grant } from "../entities/Grant";
 import { Milestone } from "../entities/Milestone";
 import { Contributor } from "../entities/Contributor";
 import { ReputationLog } from "../entities/ReputationLog";
+import { Dispute } from "../entities/Dispute";
 import { SorobanContractClient, SorobanGrant } from "../soroban/types";
 
 export class GrantSyncService {
@@ -10,6 +11,7 @@ export class GrantSyncService {
   private readonly milestoneRepo: Repository<Milestone>;
   private readonly contributorRepo: Repository<Contributor>;
   private readonly reputationLogRepo: Repository<ReputationLog>;
+  private readonly disputeRepo: Repository<Dispute>;
 
   constructor(
     private readonly dataSource: DataSource,
@@ -19,6 +21,7 @@ export class GrantSyncService {
     this.milestoneRepo = this.dataSource.getRepository(Milestone);
     this.contributorRepo = this.dataSource.getRepository(Contributor);
     this.reputationLogRepo = this.dataSource.getRepository(ReputationLog);
+    this.disputeRepo = this.dataSource.getRepository(Dispute);
   }
 
   async syncAllGrants(): Promise<void> {
@@ -27,6 +30,9 @@ export class GrantSyncService {
       const savedGrant = await this.syncGrantInternal(grant);
       await this.upsertMilestones(grant, savedGrant);
       await this.updateContributorReputation(savedGrant);
+      if (savedGrant.status === "disputed") {
+        await this.ensureDisputeRecord(savedGrant);
+      }
     }
   }
 
@@ -93,6 +99,17 @@ export class GrantSyncService {
         gain: reputationGain,
         timestamp: new Date(),
       });
+    }
+  }
+
+  private async ensureDisputeRecord(grant: Grant): Promise<void> {
+    const existing = await this.disputeRepo.findOne({
+      where: { grantId: grant.id, status: "open" },
+    });
+    if (!existing) {
+      await this.disputeRepo.save(
+        this.disputeRepo.create({ grantId: grant.id, milestoneIdx: 0, status: "open" })
+      );
     }
   }
 

--- a/api/src/services/metrics-service.ts
+++ b/api/src/services/metrics-service.ts
@@ -37,6 +37,13 @@ class MetricsService {
     registers: [this.registry],
   });
 
+  private readonly walletRateLimitHitsTotal = new Counter({
+    name: "rate_limit_wallet_hits_total",
+    help: "Total number of wallet-based rate limit hits",
+    labelNames: ["endpoint"],
+    registers: [this.registry],
+  });
+
   constructor() {
     collectDefaultMetrics({
       prefix: "stellargrant_",
@@ -52,6 +59,10 @@ class MetricsService {
 
   incrementGrantCreated(): void {
     this.grantsCreatedTotal.inc();
+  }
+
+  recordWalletRateLimitHit(endpoint: string): void {
+    this.walletRateLimitHitsTotal.inc({ endpoint });
   }
 
   recordReconciliationRun(status: "success" | "failure", gapsFound = 0): void {

--- a/stellargrant-fe/app/error.tsx
+++ b/stellargrant-fe/app/error.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion } from "framer-motion";
+import { AlertTriangle } from "lucide-react";
+import Link from "next/link";
+import { StarField } from "@/components/landing/StarField";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    console.error("[ErrorBoundary]", error);
+  }, [error]);
+
+  const message = error.message?.slice(0, 200) ?? "An unexpected error occurred.";
+
+  return (
+    <div className="relative min-h-screen bg-bg-primary flex items-center justify-center overflow-hidden">
+      <StarField />
+      <motion.div
+        className="relative z-10 flex flex-col items-center text-center px-6 max-w-lg w-full"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: "easeOut" }}
+      >
+        <div className="border border-danger/40 bg-surface p-8 w-full">
+          <AlertTriangle className="mx-auto mb-4 text-danger" size={40} />
+
+          <h1 className="font-orbitron text-xl font-bold text-text-primary mb-3">
+            Something went wrong
+          </h1>
+
+          <p className="font-mono text-sm text-text-muted break-words mb-4">
+            {message}
+          </p>
+
+          {error.digest && (
+            <pre className="mb-6 bg-bg-primary border border-border-color px-3 py-2 font-mono text-xs text-text-muted text-left overflow-x-auto">
+              digest: {error.digest}
+            </pre>
+          )}
+
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={reset}
+              className="font-orbitron text-sm font-bold uppercase tracking-wider bg-accent-primary text-bg-primary px-6 py-3 hover:opacity-90 transition-opacity"
+            >
+              Try Again
+            </button>
+            <Link
+              href="/grants"
+              className="font-orbitron text-sm font-bold uppercase tracking-wider border border-accent-primary text-accent-primary px-6 py-3 hover:bg-accent-primary hover:text-bg-primary transition-colors"
+            >
+              Go to Grants
+            </Link>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/stellargrant-fe/app/global-error.tsx
+++ b/stellargrant-fe/app/global-error.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+interface GlobalErrorProps {
+  error: Error;
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          padding: 0,
+          backgroundColor: "#050A14",
+          color: "#E8EDF5",
+          fontFamily: "monospace",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+        }}
+      >
+        <div
+          style={{
+            border: "1px solid rgba(239, 68, 68, 0.4)",
+            backgroundColor: "#0D1628",
+            padding: "2.5rem",
+            maxWidth: "480px",
+            width: "100%",
+            textAlign: "center",
+          }}
+        >
+          <h1
+            style={{
+              fontSize: "1.25rem",
+              fontWeight: "bold",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              marginBottom: "1rem",
+              color: "#E8EDF5",
+            }}
+          >
+            Critical Error
+          </h1>
+          <p
+            style={{
+              fontSize: "0.85rem",
+              color: "#6B7280",
+              marginBottom: "1.5rem",
+              wordBreak: "break-word",
+            }}
+          >
+            {error.message ?? "The application encountered an unrecoverable error."}
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              backgroundColor: "#F59E0B",
+              color: "#050A14",
+              border: "none",
+              padding: "0.75rem 2rem",
+              fontFamily: "monospace",
+              fontSize: "0.85rem",
+              fontWeight: "bold",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              cursor: "pointer",
+            }}
+          >
+            Reset
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/stellargrant-fe/app/grants/[id]/GrantDetailClient.tsx
+++ b/stellargrant-fe/app/grants/[id]/GrantDetailClient.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { use, Suspense, useEffect, useMemo, useState, useCallback } from "react";
+import { use, Suspense, useEffect, useMemo, useState, useCallback, useRef } from "react";
 import Link from "next/link";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Download, ChevronDown } from "lucide-react";
 import { FundingProgress } from "@/components/grants/FundingProgress";
 import { GrantStatusBadge } from "@/components/grants/GrantStatusBadge";
 import { WalletAddress } from "@/components/wallet/WalletAddress";
@@ -15,6 +15,8 @@ import RichTextRenderer from "@/components/ui/RichTextRenderer";
 import { formatDate } from "@/lib/utils";
 import { formatTokenAmount, getTokenMetadata } from "@/lib/tokens";
 import { stellarExplorerAccount } from "@/lib/constants";
+import { exportGrantAsJSON, exportGrantAsCSV, exportFundersAsCSV } from "@/lib/utils/export";
+import type { FunderRecord } from "@/lib/utils/export";
 import { useGrant } from "@/hooks/useGrant";
 import { useFunders } from "@/hooks/useFunders";
 import { useGrantBalances } from "@/hooks/useGrantBalances";
@@ -23,8 +25,90 @@ import { useContractEvents } from "@/hooks/useContractEvents";
 import { useOptimisticGrant } from "@/hooks/useOptimisticGrant";
 import { toast } from "@/lib/toast";
 import { ErrorCard } from "@/components/ui/ErrorCard";
-import type { TokenMetadata, Grant } from "@/types";
+import type { TokenMetadata, Grant, Milestone } from "@/types";
 import type { GrantBalances } from "@/lib/stellar/balances";
+
+function ExportDropdown({
+  grant,
+  milestones,
+  funders,
+}: {
+  grant: Grant;
+  milestones: Milestone[];
+  funders: FunderRecord[];
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    if (open) document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const items: { label: string; action: () => void }[] = [
+    {
+      label: "Export as JSON",
+      action: () => {
+        exportGrantAsJSON(grant, milestones);
+        setOpen(false);
+      },
+    },
+    {
+      label: "Export milestones as CSV",
+      action: () => {
+        exportGrantAsCSV(grant, milestones);
+        setOpen(false);
+      },
+    },
+    {
+      label: "Export funders as CSV",
+      action: () => {
+        exportFundersAsCSV(funders);
+        setOpen(false);
+      },
+    },
+  ];
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="inline-flex items-center gap-1.5 font-mono text-xs uppercase tracking-wider border border-border-color text-text-muted px-3 py-1.5 hover:border-accent-primary hover:text-accent-primary transition-colors"
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        <Download size={12} />
+        Export
+        <ChevronDown size={12} className={open ? "rotate-180 transition-transform" : "transition-transform"} />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-1 z-50 min-w-[200px] border border-border-color bg-surface shadow-lg"
+        >
+          {items.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              role="menuitem"
+              onClick={item.action}
+              className="block w-full text-left font-mono text-xs text-text-primary px-4 py-2.5 hover:bg-bg-secondary transition-colors"
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 function daysUntilDeadline(deadlineTs: bigint): number {
   const ms = Number(deadlineTs) * 1000 - Date.now();
@@ -212,6 +296,16 @@ function GrantDetailContent({ grantId }: { grantId: string }) {
             grantId={grant.id}
             grantTitle={grant.title}
             fundedPercent={fundedPercent}
+          />
+          <ExportDropdown
+            grant={grant}
+            milestones={milestones}
+            funders={funders.map((f) => ({
+              address: f.address,
+              amount: f.amount,
+              token: grant.token ?? "native",
+              timestamp: new Date().toISOString(),
+            }))}
           />
         </div>
       </div>

--- a/stellargrant-fe/app/grants/not-found.tsx
+++ b/stellargrant-fe/app/grants/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function GrantNotFound() {
+  return (
+    <div className="container mx-auto max-w-2xl px-4 py-24 text-center">
+      <p className="font-orbitron text-4xl font-black text-accent-primary mb-4">
+        Grant Not Found
+      </p>
+      <p className="font-mono text-sm text-text-muted mb-8 leading-relaxed">
+        Grant not found — it may have been cancelled or the ID is incorrect.
+      </p>
+      <Link
+        href="/grants"
+        className="inline-flex items-center font-orbitron text-sm font-bold uppercase tracking-wider border border-accent-primary text-accent-primary px-8 py-3 hover:bg-accent-primary hover:text-bg-primary transition-colors"
+      >
+        Browse all grants →
+      </Link>
+    </div>
+  );
+}

--- a/stellargrant-fe/app/not-found.tsx
+++ b/stellargrant-fe/app/not-found.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { StarField } from "@/components/landing/StarField";
+import { Button } from "@/components/ui/Button";
+
+export default function NotFound() {
+  return (
+    <div className="relative min-h-screen bg-bg-primary flex items-center justify-center overflow-hidden">
+      <StarField />
+      <motion.div
+        className="relative z-10 flex flex-col items-center text-center px-6"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, ease: "easeOut" }}
+      >
+        <h1
+          className="font-orbitron font-black text-accent-primary leading-none"
+          style={{ fontSize: "clamp(5rem, 10vw, 12rem)" }}
+        >
+          404
+        </h1>
+
+        <p className="mt-4 font-mono text-sm uppercase tracking-[0.3em] text-text-muted">
+          Signal Lost
+        </p>
+
+        <p className="mt-6 max-w-md font-mono text-sm text-text-secondary leading-relaxed">
+          The grant or page you&apos;re looking for doesn&apos;t exist or has been removed.
+        </p>
+
+        <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+          <Button href="/grants" variant="ghost">
+            ← Back to Grants
+          </Button>
+          <Button href="/" variant="primary">
+            Home
+          </Button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/stellargrant-fe/hooks/useGrant.ts
+++ b/stellargrant-fe/hooks/useGrant.ts
@@ -5,6 +5,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { notFound } from "next/navigation";
 import type { Grant, Milestone } from "@/types";
 import { logger } from "@/lib/logger";
 
@@ -54,6 +55,7 @@ export function useGrant(grantId: string, options?: UseGrantOptions): UseGrantRe
       const res = await fetch(`/api/grants/${grantId}`, {
         signal: abortRef.current.signal,
       });
+      if (res.status === 404) notFound();
       if (!res.ok) throw new Error(`Failed to fetch grant ${grantId}: ${res.status}`);
       const json = (await res.json()) as {
         grant: Grant;

--- a/stellargrant-fe/lib/utils/export.ts
+++ b/stellargrant-fe/lib/utils/export.ts
@@ -1,0 +1,117 @@
+import type { Grant, Milestone } from "@/types";
+
+export interface FunderRecord {
+  address: string;
+  amount: bigint;
+  token: string;
+  timestamp: string;
+}
+
+function slugifyTitle(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 30);
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function milestoneStatus(m: Milestone): string {
+  if (m.paid) return "paid";
+  if (m.approved) return "approved";
+  if (m.submitted) return "submitted";
+  return "pending";
+}
+
+export function exportGrantAsJSON(grant: Grant, milestones: Milestone[]): void {
+  const data = {
+    exportedAt: new Date().toISOString(),
+    grant: {
+      id: grant.id,
+      title: grant.title,
+      owner: grant.owner,
+      recipient: grant.recipient,
+      budget: grant.budget.toString(),
+      funded: grant.funded.toString(),
+      token: grant.token,
+      status: grant.status,
+      deadline: new Date(Number(grant.deadline) * 1000).toISOString(),
+      createdAt: new Date(Number(grant.created_at) * 1000).toISOString(),
+      reviewers: grant.reviewers,
+    },
+    milestones: milestones.map((m) => ({
+      index: m.idx,
+      title: m.title,
+      description: m.description,
+      reward: m.amount?.toString() ?? "0",
+      token: m.token,
+      status: milestoneStatus(m),
+      proofHash: m.proof_hash,
+      submittedAt: m.submitted_at
+        ? new Date(Number(m.submitted_at) * 1000).toISOString()
+        : null,
+      paidAt: m.paid_at ? new Date(Number(m.paid_at) * 1000).toISOString() : null,
+    })),
+  };
+
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json",
+  });
+  const slug = slugifyTitle(grant.title);
+  const date = new Date().toISOString().slice(0, 10);
+  triggerDownload(blob, `stellargrant-${grant.id}-${slug}-${date}.json`);
+}
+
+export function exportGrantAsCSV(grant: Grant, milestones: Milestone[]): void {
+  const header = [
+    "Index",
+    "Title",
+    "Reward (stroops)",
+    "Token",
+    "Status",
+    "Proof Hash",
+    "Submitted At",
+    "Paid At",
+  ].join(",");
+
+  const rows = milestones.map((m) =>
+    [
+      m.idx,
+      `"${m.title.replace(/"/g, '""')}"`,
+      m.amount?.toString() ?? "0",
+      m.token ?? "native",
+      milestoneStatus(m),
+      m.proof_hash ?? "",
+      m.submitted_at
+        ? new Date(Number(m.submitted_at) * 1000).toISOString()
+        : "",
+      m.paid_at ? new Date(Number(m.paid_at) * 1000).toISOString() : "",
+    ].join(",")
+  );
+
+  const csv = [header, ...rows].join("\n");
+  const blob = new Blob([csv], { type: "text/csv" });
+  triggerDownload(blob, `stellargrant-${grant.id}-milestones.csv`);
+}
+
+export function exportFundersAsCSV(funders: FunderRecord[]): void {
+  const header = ["Address", "Amount (stroops)", "Token", "Timestamp"].join(",");
+
+  const rows = funders.map((f) =>
+    [
+      f.address,
+      f.amount.toString(),
+      f.token,
+      f.timestamp,
+    ].join(",")
+  );
+
+  const csv = [header, ...rows].join("\n");
+  const blob = new Blob([csv], { type: "text/csv" });
+  // grant id is not available here so use a generic name
+  triggerDownload(blob, `stellargrant-funders.csv`);
+}


### PR DESCRIPTION
## Description

Implements four production-readiness and feature issues in a single branch:

- **#345** — Global 404 page, route error boundary (`error.tsx`), root error boundary (`global-error.tsx`), and grants-specific not-found page. Updates `useGrant` to trigger the nearest `not-found.tsx` boundary on 404 API responses.
- **#388** — Grant Export feature with JSON and CSV download (milestones CSV and funders CSV). Adds an Export dropdown to the Grant Detail page header.
- **#445** — Dispute Resolution API: `Dispute` entity, `disputes` routes (list, detail, open, argument, resolve), TypeORM migration, grant-scoped milestone dispute endpoints, auto-creation of open dispute records during sync, and a `dispute_resolved` webhook event.
- **#452** — Per-wallet rate limiting on write operations. Adds `createWalletRateLimiter` factory, lazily upgrades to Redis (`rate-limit-redis`) when `REDIS_URL` is set, applies limits to milestone proof, milestone approval, and dispute argument endpoints. Adds `rate_limit_wallet_hits_total{endpoint}` Prometheus counter.

## Related Issue

Closes #345 
Closes #388 
Closes #445 
Closes #452 

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Screenshots (if applicable)

<!-- UI changes are in the Grant Detail page (Export dropdown) and the new 404/error pages. -->

## Testing

- [ ] Navigating to `/grants/nonexistent-id-12345` shows the grants not-found page
- [ ] Navigating to `/completely-unknown-route` shows the global 404 page with amber "404" and StarField
- [ ] `error.tsx` renders with the error message and a working "Try Again" button
- [ ] `global-error.tsx` includes its own `<html>` and `<body>` tags with inline styles only
- [ ] "Export as JSON" on a grant detail page downloads a correctly named `.json` file; BigInt values are strings
- [ ] "Export milestones as CSV" downloads a properly formatted CSV
- [ ] `GET /disputes` returns open disputes with grant and milestone titles
- [ ] `POST /grants/1/milestones/0/dispute` creates a Dispute record
- [ ] `POST /disputes/1/argument` saves contributor or funder argument text
- [ ] `POST /disputes/1/resolve` returns 403 for non-council wallets
- [ ] Resolved disputes have `status: 'resolved_payout'` or `status: 'resolved_refund'`
- [ ] `dispute_resolved` webhook event fires on resolution
- [ ] A single wallet posting 6 milestone proofs in 1 hour receives 429 on the 6th
- [ ] `Retry-After` header is set on 429 responses
- [ ] Without `REDIS_URL`, rate limiting works with in-memory store (no crash)

## Checklist

- [x] Code follows the project's coding standards
- [x] TypeScript compiles without errors (`pnpm type-check` / `tsc`)
- [x] Linting passes (`pnpm lint`)
- [x] Commit messages follow Conventional Commits
- [x] Issue numbers referenced in PR description
- [ ] Screenshots added for UI changes
- [ ] Unit tests added/updated
