### PR TITLE
feat(api): Add Grant Feedback and Rating System

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,13 +11,8 @@ If you discover a security vulnerability within this project, please send an ema
 ## Addressing Security Alerts
 
 Our CI pipeline includes automated security scanning for dependencies:
-<<<<<<< HEAD
-1. **GitHub Actions Workflow**: Every PR is scanned using `npm audit --audit-level=high`. The build will fail if any high-severity vulnerabilities are found.
-2. **Dependabot**: We use Dependabot to automatically check for dependency updates on a weekly basis.
-=======
 1. **GitHub Actions Workflow**: Every PR is scanned using `npm audit --audit-level=high` (for JS/TS packages) and standard security pipelines for other languages. The build will fail if any high-severity vulnerabilities are found.
 2. **Dependabot**: We use Dependabot to automatically check for dependency updates on a weekly schedule across all ecosystem (npm, cargo).
->>>>>>> ab330db (OAuth-Integration-and-Automated-Security-Scanning)
 
 ### Process for Patching Vulnerabilities
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -27,6 +27,7 @@
         "passport-twitter": "^0.1.5",
         "pg": "^8.13.3",
         "prom-client": "^14.0.0",
+        "rate-limit-redis": "^4.2.0",
         "reflect-metadata": "^0.2.2",
         "socket.io": "^4.8.3",
         "swagger-jsdoc": "^6.2.8",
@@ -1783,7 +1784,7 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
       "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -1793,7 +1794,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-os": "^3.0.1"
@@ -1837,7 +1838,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
       "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-path": "^3.0.0"
@@ -4377,6 +4378,13 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4905,6 +4913,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/rate-limit-redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express-rate-limit": ">= 6"
       }
     },
     "node_modules/raw-body": {
@@ -5500,7 +5520,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
       "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ssh-remote-port-forward": {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -37,6 +37,7 @@ import { GrantReviewer } from "./entities/GrantReviewer";
 import { MilestoneApproval } from "./entities/MilestoneApproval";
 import { Milestone } from "./entities/Milestone";
 import { MilestoneComment } from "./entities/MilestoneComment";
+import { GrantFeedback } from "./entities/GrantFeedback";
 import { WebhookDispatcher } from "./services/webhook-dispatcher";
 import { buildUserRouter } from "./routes/users";
 import { buildGrantReviewerRouter } from "./routes/grant-reviewers";
@@ -64,6 +65,7 @@ export const createApp = (dataSource: DataSource, sorobanClient: SorobanContract
   const approvalRepo = dataSource.getRepository(MilestoneApproval);
   const milestoneRepo = dataSource.getRepository(Milestone);
   const commentsRepo = dataSource.getRepository(MilestoneComment);
+  const feedbackRepo = dataSource.getRepository(GrantFeedback);
 
   const grantSyncService = new GrantSyncService(dataSource, sorobanClient);
   const signatureService = new SignatureService();
@@ -75,7 +77,18 @@ export const createApp = (dataSource: DataSource, sorobanClient: SorobanContract
   const webhookDispatcher = new WebhookDispatcher(dataSource);
 
   app.get("/health", (_req, res) => res.json({ ok: true }));
-  app.use("/grants", buildGrantRouter(grantRepo, grantSyncService));
+  app.use(
+    "/grants",
+    buildGrantRouter(
+      grantRepo,
+      grantSyncService,
+      feedbackRepo,
+      signatureService,
+      activityRepo,
+      reviewerRepo,
+      responseCacheService,
+    ),
+  );
   app.use("/milestone_proof", buildMilestoneProofRouter(proofRepo, signatureService, grantRepo, userRepo));
   app.use("/search", buildSearchRouter(dataSource));
   app.use("/leaderboard", buildLeaderboardRouter(leaderboardService));

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -81,7 +81,18 @@ export const createApp = (dataSource: DataSource, sorobanClient: SorobanContract
   const webhookDispatcher = new WebhookDispatcher(dataSource);
 
   app.get("/health", (_req, res) => res.json({ ok: true }));
-  app.use("/grants", buildGrantRouter(grantRepo, grantSyncService));
+  app.use(
+    "/grants",
+    buildGrantRouter(
+      grantRepo,
+      grantSyncService,
+      feedbackRepo,
+      signatureService,
+      activityRepo,
+      reviewerRepo,
+      responseCacheService,
+    ),
+  );
   app.use("/grants", buildGrantDraftsRouter(dataSource, webhookDispatcher));
   app.use("/milestone_proof", buildMilestoneProofRouter(proofRepo, signatureService, grantRepo, userRepo));
   app.use("/search", buildSearchRouter(dataSource));

--- a/api/src/db/data-source.ts
+++ b/api/src/db/data-source.ts
@@ -25,6 +25,7 @@ import { UserRole } from "../entities/UserRole";
 import { UserWatchlist } from "../entities/UserWatchlist";
 import { WebhookDeliveryLog } from "../entities/WebhookDeliveryLog";
 import { WebhookSubscription } from "../entities/WebhookSubscription";
+import { GrantFeedback } from "../entities/GrantFeedback";
 
 const entities = [
   Activity,
@@ -33,6 +34,7 @@ const entities = [
   Contributor,
   FeeCollection,
   Grant,
+  GrantFeedback,
   GrantHistory,
   GrantReviewer,
   GrantView,

--- a/api/src/db/migrations/1700000002000-AddGrantFeedbackTable.ts
+++ b/api/src/db/migrations/1700000002000-AddGrantFeedbackTable.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex, TableUnique } from "typeorm";
+
+export class AddGrantFeedbackTable1700000002000 implements MigrationInterface {
+  name = "AddGrantFeedbackTable1700000002000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "grant_feedback",
+        columns: [
+          {
+            name: "id",
+            type: "int",
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: "increment",
+          },
+          {
+            name: "grantId",
+            type: "int",
+          },
+          {
+            name: "reviewerAddress",
+            type: "varchar",
+            length: "120",
+          },
+          {
+            name: "role",
+            type: "varchar",
+            length: "20",
+          },
+          {
+            name: "rating",
+            type: "smallint",
+          },
+          {
+            name: "comment",
+            type: "text",
+            isNullable: true,
+          },
+          {
+            name: "createdAt",
+            type: "timestamp",
+            default: "now()",
+          },
+        ],
+        uniques: [
+          new TableUnique({
+            name: "UQ_grant_feedback_grantId_reviewerAddress",
+            columnNames: ["grantId", "reviewerAddress"],
+          }),
+        ],
+      }),
+      true
+    );
+
+    await queryRunner.createIndex(
+      "grant_feedback",
+      new TableIndex({
+        name: "IDX_grant_feedback_grantId",
+        columnNames: ["grantId"],
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable("grant_feedback", true);
+  }
+}

--- a/api/src/db/typeorm.config.ts
+++ b/api/src/db/typeorm.config.ts
@@ -25,6 +25,7 @@ import { WebhookSubscription } from "../entities/WebhookSubscription";
 import { WebhookDeliveryLog } from "../entities/WebhookDeliveryLog";
 import { Role } from "../entities/Role";
 import { UserRole } from "../entities/UserRole";
+import { GrantFeedback } from "../entities/GrantFeedback";
 
 // Used by the TypeORM CLI (migration:generate, migration:run, migration:revert)
 export default new DataSource({
@@ -35,7 +36,7 @@ export default new DataSource({
     Contributor, ReputationLog, AuditLog, UserWatchlist, Activity, GrantView,
     ReconciliationCheckpoint, RateLimitLog, Community, MilestoneComment,
     GrantHistory, FeeCollection, PlatformConfig, Report,
-    WebhookSubscription, WebhookDeliveryLog, Role, UserRole,
+    WebhookSubscription, WebhookDeliveryLog, Role, UserRole, GrantFeedback,
   ],
   migrations: ["src/db/migrations/*.ts"],
   synchronize: false,

--- a/api/src/entities/GrantFeedback.ts
+++ b/api/src/entities/GrantFeedback.ts
@@ -1,0 +1,27 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Unique, Index } from "typeorm";
+
+@Entity({ name: "grant_feedback" })
+@Unique(["grantId", "reviewerAddress"])
+export class GrantFeedback {
+  @PrimaryGeneratedColumn("increment")
+  id!: number;
+
+  @Index()
+  @Column({ type: "int" })
+  grantId!: number;
+
+  @Column({ type: "varchar", length: 120 })
+  reviewerAddress!: string;
+
+  @Column({ type: "varchar", length: 20 })
+  role!: "funder" | "reviewer" | "recipient";
+
+  @Column({ type: "smallint" })
+  rating!: number; // 1-5
+
+  @Column({ type: "text", nullable: true })
+  comment!: string | null;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/api/src/routes/grants.ts
+++ b/api/src/routes/grants.ts
@@ -1,7 +1,23 @@
 import { Router } from "express";
 import { Repository } from "typeorm";
+import { z } from "zod";
 import { Grant } from "../entities/Grant";
+import { GrantFeedback } from "../entities/GrantFeedback";
+import { Activity } from "../entities/Activity";
+import { GrantReviewer } from "../entities/GrantReviewer";
 import { GrantSyncService } from "../services/grant-sync-service";
+import { SignatureService } from "../services/signature-service";
+import { ResponseCacheService, responseCacheKeys } from "../services/response-cache";
+
+const feedbackSchema = z.object({
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(1000).optional().nullable(),
+  role: z.enum(["funder", "reviewer", "recipient"]),
+  address: z.string().regex(/^G[A-Z2-7]{55}$/),
+  signature: z.string(),
+  nonce: z.string(),
+  timestamp: z.number(),
+});
 
 const translations: Record<string, Record<number, { title: string; description: string }>> = {
   es: {
@@ -42,7 +58,15 @@ function localizeGrant(grant: Grant, lang?: string): any {
   return localized;
 }
 
-export const buildGrantRouter = (grantRepo: Repository<Grant>, syncService: GrantSyncService) => {
+export const buildGrantRouter = (
+  grantRepo: Repository<Grant>,
+  syncService: GrantSyncService,
+  feedbackRepo: Repository<GrantFeedback>,
+  signatureService: SignatureService,
+  activityRepo: Repository<Activity>,
+  reviewerRepo: Repository<GrantReviewer>,
+  responseCache: ResponseCacheService,
+) => {
   const router = Router();
 
   router.get("/", async (req, res, next) => {
@@ -61,8 +85,8 @@ export const buildGrantRouter = (grantRepo: Repository<Grant>, syncService: Gran
   });
 
   router.get("/:id", async (req, res, next) => {
+    const id = Number(req.params.id);
     try {
-      const id = Number(req.params.id);
       if (Number.isNaN(id)) {
         res.status(400).json({ error: "Invalid grant id" });
         return;
@@ -79,6 +103,179 @@ export const buildGrantRouter = (grantRepo: Repository<Grant>, syncService: Gran
       const lang = req.header("Accept-Language");
       res.json({ data: localizeGrant(grant, lang) });
     } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get("/:id/feedback", async (req, res, next) => {
+    const id = Number(req.params.id);
+    try {
+      if (Number.isNaN(id)) {
+        res.status(400).json({ error: "Invalid grant id" });
+        return;
+      }
+
+      const cacheKey = responseCacheKeys.grantFeedback(id);
+      if (responseCache.isEnabled()) {
+        const hit = await responseCache.get(cacheKey);
+        if (hit) {
+          res.type("application/json").send(hit);
+          return;
+        }
+      }
+
+      await syncService.syncGrant(id);
+      const grant = await grantRepo.findOne({ where: { id } });
+      if (!grant) {
+        res.status(404).json({ error: "Grant not found" });
+        return;
+      }
+
+      const feedbacks = await feedbackRepo.find({
+        where: { grantId: id },
+        order: { createdAt: "DESC", id: "DESC" },
+      });
+
+      const count = feedbacks.length;
+      const averageRating = count > 0
+        ? Number((feedbacks.reduce((sum, f) => sum + f.rating, 0) / count).toFixed(1))
+        : 0;
+
+      const items = feedbacks.map((f) => ({
+        role: f.role,
+        rating: f.rating,
+        comment: f.comment,
+        createdAt: f.createdAt.toISOString(),
+        reviewerAddress: null,
+      }));
+
+      const responseBody = {
+        data: {
+          averageRating,
+          feedbackCount: count,
+          items,
+        },
+      };
+
+      const serialized = JSON.stringify(responseBody);
+      await responseCache.set(cacheKey, serialized, 300);
+
+      res.type("application/json").send(serialized);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post("/:id/feedback", async (req, res, next) => {
+    const id = Number(req.params.id);
+    try {
+      if (Number.isNaN(id)) {
+        res.status(400).json({ error: "Invalid grant id" });
+        return;
+      }
+
+      await syncService.syncGrant(id);
+      const grant = await grantRepo.findOne({ where: { id } });
+      if (!grant) {
+        res.status(404).json({ error: "Grant not found" });
+        return;
+      }
+
+      const parsed = feedbackSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: "Invalid payload", details: parsed.error.issues });
+        return;
+      }
+
+      const payload = parsed.data;
+
+      if (grant.status !== "completed") {
+        res.status(400).json({ error: "Feedback is only accepted for completed grants" });
+        return;
+      }
+
+      const maxSkewMs = 5 * 60 * 1000;
+      if (Math.abs(Date.now() - payload.timestamp) > maxSkewMs) {
+        res.status(400).json({ error: "Expired intent timestamp" });
+        return;
+      }
+
+      const signatureIsValid = signatureService.verify({
+        grantId: id,
+        rating: payload.rating,
+        role: payload.role,
+        address: payload.address,
+        nonce: payload.nonce,
+        timestamp: payload.timestamp,
+        signature: payload.signature,
+      });
+
+      if (!signatureIsValid) {
+        res.status(401).json({ error: "Invalid Stellar signature" });
+        return;
+      }
+
+      let isAuthorized = false;
+      if (payload.role === "recipient") {
+        isAuthorized = (grant.recipient === payload.address);
+      } else if (payload.role === "reviewer") {
+        const reviewer = await reviewerRepo.findOne({
+          where: { grantId: id, reviewerStellarAddress: payload.address },
+        });
+        isAuthorized = !!reviewer;
+      } else if (payload.role === "funder") {
+        const activity = await activityRepo.findOne({
+          where: {
+            type: "grant_funded",
+            entityType: "grant",
+            entityId: id,
+            actorAddress: payload.address,
+          },
+        });
+        isAuthorized = !!activity;
+      }
+
+      if (!isAuthorized) {
+        res.status(403).json({
+          error: `Address is not authorized as a ${payload.role} for this grant`,
+        });
+        return;
+      }
+
+      const existing = await feedbackRepo.findOne({
+        where: { grantId: id, reviewerAddress: payload.address },
+      });
+      if (existing) {
+        res.status(409).json({
+          error: "Duplicate feedback submission",
+          rating: existing.rating,
+        });
+        return;
+      }
+
+      const feedback = await feedbackRepo.save({
+        grantId: id,
+        reviewerAddress: payload.address,
+        role: payload.role,
+        rating: payload.rating,
+        comment: payload.comment ?? null,
+      });
+
+      const cacheKey = responseCacheKeys.grantFeedback(id);
+      await responseCache.delete(cacheKey);
+
+      res.status(201).json({ data: feedback });
+    } catch (error: any) {
+      if (error?.code === "23505" || error?.code === "SQLITE_CONSTRAINT") {
+        const existing = await feedbackRepo.findOne({
+          where: { grantId: id, reviewerAddress: req.body.address },
+        });
+        res.status(409).json({
+          error: "Duplicate feedback submission",
+          rating: existing?.rating,
+        });
+        return;
+      }
       next(error);
     }
   });

--- a/api/src/services/response-cache.ts
+++ b/api/src/services/response-cache.ts
@@ -3,6 +3,7 @@ const CACHE_PREFIX = "sg:cache:v1:";
 export const responseCacheKeys = {
   stats: () => `${CACHE_PREFIX}stats`,
   grantsFirstPage: (lang: string) => `${CACHE_PREFIX}grants:first:${lang}`,
+  grantFeedback: (grantId: number) => `${CACHE_PREFIX}feedback:${grantId}`,
 };
 
 /**

--- a/api/src/services/signature-service.ts
+++ b/api/src/services/signature-service.ts
@@ -18,6 +18,16 @@ export type AdminIntent = {
   signature: string;
 };
 
+export type FeedbackIntent = {
+  grantId: number;
+  rating: number;
+  role: "funder" | "reviewer" | "recipient";
+  address: string;
+  nonce: string;
+  timestamp: number;
+  signature: string;
+};
+
 export class SignatureService {
   buildIntentMessage(payload: Omit<MilestoneProofIntent, "signature">): string {
     return [
@@ -41,18 +51,44 @@ export class SignatureService {
     ].join("|");
   }
 
-  verify(payload: MilestoneProofIntent): boolean {
-    if (!StrKey.isValidEd25519PublicKey(payload.submittedBy)) {
-      return false;
+  buildFeedbackIntentMessage(payload: Omit<FeedbackIntent, "signature">): string {
+    return [
+      "stellargrant:feedback:v1",
+      payload.grantId,
+      payload.rating,
+      payload.role,
+      payload.address,
+      payload.nonce,
+      payload.timestamp,
+    ].join("|");
+  }
+
+  verify(payload: MilestoneProofIntent | FeedbackIntent): boolean {
+    if ("address" in payload) {
+      if (!StrKey.isValidEd25519PublicKey(payload.address)) {
+        return false;
+      }
+
+      const keypair = Keypair.fromPublicKey(payload.address);
+      const message = this.buildFeedbackIntentMessage(payload);
+
+      return keypair.verify(
+        Buffer.from(message, "utf8"),
+        Buffer.from(payload.signature, "base64"),
+      );
+    } else {
+      if (!StrKey.isValidEd25519PublicKey(payload.submittedBy)) {
+        return false;
+      }
+
+      const keypair = Keypair.fromPublicKey(payload.submittedBy);
+      const message = this.buildIntentMessage(payload);
+
+      return keypair.verify(
+        Buffer.from(message, "utf8"),
+        Buffer.from(payload.signature, "base64"),
+      );
     }
-
-    const keypair = Keypair.fromPublicKey(payload.submittedBy);
-    const message = this.buildIntentMessage(payload);
-
-    return keypair.verify(
-      Buffer.from(message, "utf8"),
-      Buffer.from(payload.signature, "base64"),
-    );
   }
 
   verifyAdmin(payload: AdminIntent): boolean {

--- a/api/tests/e2e/feedback.e2e.test.ts
+++ b/api/tests/e2e/feedback.e2e.test.ts
@@ -1,0 +1,182 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import request from "supertest";
+import { beforeAll, afterAll, describe, expect, it } from "vitest";
+import { DataSource } from "typeorm";
+import { createApp } from "../../src/app";
+import { buildDataSource } from "../../src/db/data-source";
+import { SignatureService } from "../../src/services/signature-service";
+import { MockSorobanContractClient } from "../../src/soroban/mock-client";
+import { Activity } from "../../src/entities/Activity";
+import { GrantReviewer } from "../../src/entities/GrantReviewer";
+import { Grant } from "../../src/entities/Grant";
+
+describe("Feedback E2E Tests", () => {
+  let dataSource: DataSource;
+  const sorobanClient = new MockSorobanContractClient();
+  const signatureService = new SignatureService();
+
+  const funderKey = Keypair.random();
+  const reviewerKey = Keypair.random();
+  const customRecipientKey = Keypair.random();
+
+  beforeAll(async () => {
+    dataSource = buildDataSource("sqljs://memory");
+    await dataSource.initialize();
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+  });
+
+  const setupData = async (app: any) => {
+    // Seed grants from mock soroban client
+    await request(app).get("/grants");
+
+    // Retrieve and update grant 3 recipient
+    const grantRepo = dataSource.getRepository(Grant);
+    const grant3 = await grantRepo.findOne({ where: { id: 3 } });
+    if (grant3) {
+      grant3.recipient = customRecipientKey.publicKey();
+      await grantRepo.save(grant3);
+    }
+
+    // Seed reviewer
+    const reviewerRepo = dataSource.getRepository(GrantReviewer);
+    await reviewerRepo.save({
+      grantId: 3,
+      reviewerStellarAddress: reviewerKey.publicKey(),
+    });
+
+    // Seed funder activity
+    const activityRepo = dataSource.getRepository(Activity);
+    await activityRepo.save({
+      type: "grant_funded",
+      entityType: "grant",
+      entityId: 3,
+      actorAddress: funderKey.publicKey(),
+    });
+  };
+
+  it("handles feedback flows completely", async () => {
+    const app = createApp(dataSource, sorobanClient);
+    await setupData(app);
+
+    // 1. GET feedback should initially return empty items
+    const getRes1 = await request(app).get("/grants/3/feedback");
+    expect(getRes1.status).toBe(200);
+    expect(getRes1.body.data.averageRating).toBe(0);
+    expect(getRes1.body.data.feedbackCount).toBe(0);
+    expect(getRes1.body.data.items).toHaveLength(0);
+
+    // 2. Reject feedback on non-completed grant (e.g. grant 1 is active)
+    const payloadActiveGrant = {
+      rating: 5,
+      comment: "Should fail",
+      role: "funder" as const,
+      address: funderKey.publicKey(),
+      nonce: "nonce-active",
+      timestamp: Date.now(),
+      signature: "dummy-sig",
+    };
+    const badGrantRes = await request(app)
+      .post("/grants/1/feedback")
+      .send(payloadActiveGrant);
+    expect(badGrantRes.status).toBe(400);
+
+    // 3. POST feedback - reject invalid signature
+    const payloadInvalidSig = {
+      rating: 5,
+      comment: "Invalid signature",
+      role: "reviewer" as const,
+      address: reviewerKey.publicKey(),
+      nonce: "nonce-invalid-sig",
+      timestamp: Date.now(),
+      signature: Buffer.from("x".repeat(64)).toString("base64"),
+    };
+    const invalidSigRes = await request(app)
+      .post("/grants/3/feedback")
+      .send(payloadInvalidSig);
+    expect(invalidSigRes.status).toBe(401);
+
+    // 4. POST feedback - reject unauthorized role (e.g. random user claiming reviewer)
+    const randomKey = Keypair.random();
+    const payloadUnauth = {
+      rating: 4,
+      comment: "I am not authorized",
+      role: "reviewer" as const,
+      address: randomKey.publicKey(),
+      nonce: "nonce-unauth",
+      timestamp: Date.now(),
+    };
+    const msgUnauth = signatureService.buildFeedbackIntentMessage({
+      grantId: 3,
+      ...payloadUnauth,
+    });
+    const sigUnauth = randomKey.sign(Buffer.from(msgUnauth, "utf8")).toString("base64");
+    const unauthRes = await request(app)
+      .post("/grants/3/feedback")
+      .send({ ...payloadUnauth, signature: sigUnauth });
+    expect(unauthRes.status).toBe(403);
+
+    // 5. POST feedback - accept valid reviewer feedback
+    const payloadReviewer = {
+      rating: 4,
+      comment: "Reviewer comments here.",
+      role: "reviewer" as const,
+      address: reviewerKey.publicKey(),
+      nonce: "nonce-reviewer",
+      timestamp: Date.now(),
+    };
+    const msgReviewer = signatureService.buildFeedbackIntentMessage({
+      grantId: 3,
+      ...payloadReviewer,
+    });
+    const sigReviewer = reviewerKey.sign(Buffer.from(msgReviewer, "utf8")).toString("base64");
+    const reviewerRes = await request(app)
+      .post("/grants/3/feedback")
+      .send({ ...payloadReviewer, signature: sigReviewer });
+    expect(reviewerRes.status).toBe(201);
+    expect(reviewerRes.body.data.rating).toBe(4);
+
+    // 6. POST feedback - accept valid funder feedback
+    const payloadFunder = {
+      rating: 5,
+      comment: "Funder comments here.",
+      role: "funder" as const,
+      address: funderKey.publicKey(),
+      nonce: "nonce-funder",
+      timestamp: Date.now(),
+    };
+    const msgFunder = signatureService.buildFeedbackIntentMessage({
+      grantId: 3,
+      ...payloadFunder,
+    });
+    const sigFunder = funderKey.sign(Buffer.from(msgFunder, "utf8")).toString("base64");
+    const funderRes = await request(app)
+      .post("/grants/3/feedback")
+      .send({ ...payloadFunder, signature: sigFunder });
+    expect(funderRes.status).toBe(201);
+
+    // 7. POST feedback - reject duplicate submission (funder again)
+    const duplicateRes = await request(app)
+      .post("/grants/3/feedback")
+      .send({ ...payloadFunder, signature: sigFunder });
+    expect(duplicateRes.status).toBe(409);
+    expect(duplicateRes.body.rating).toBe(5);
+
+    // 8. GET feedback should now return the average, count, and masked reviewerAddress
+    const getRes2 = await request(app).get("/grants/3/feedback");
+    expect(getRes2.status).toBe(200);
+    expect(getRes2.body.data.averageRating).toBe(4.5);
+    expect(getRes2.body.data.feedbackCount).toBe(2);
+    expect(getRes2.body.data.items).toHaveLength(2);
+    // privacy mask check
+    expect(getRes2.body.data.items[0].reviewerAddress).toBeNull();
+    expect(getRes2.body.data.items[1].reviewerAddress).toBeNull();
+    // Verify sorting (descending by createdAt)
+    expect(getRes2.body.data.items[0].role).toBe("funder");
+    expect(getRes2.body.data.items[1].role).toBe("reviewer");
+  });
+});

--- a/stellargrant-contracts/COVERAGE.md
+++ b/stellargrant-contracts/COVERAGE.md
@@ -92,11 +92,8 @@ Add the following secret to your GitHub repository:
 |---|---|
 | `CODECOV_TOKEN` | *(Token from your Codecov dashboard — Settings → Repository Upload Token)* |
 
-<<<<<<< HEAD
 > **Fork PR note**: GitHub does not expose repository secrets to workflows triggered from forks (security policy). This means coverage upload will silently skip on fork PRs but **will succeed** on pushes to `main` from the base repository. CI will still pass — `fail_ci_if_error` is set to `false` to handle this gracefully.
 
-=======
->>>>>>> 2fd7037 (feat: add milestone deadlines, expiry logic, and fund reclaim mechanism)
 ### Badge
 
 Add this to the root `README.md`, replacing `<owner>` and `<repo>` with your GitHub username and repository name:


### PR DESCRIPTION
closes #446 

## Summary of Changes
- **New Entity**: Created `GrantFeedback` storing rating (1-5), role, comment, and verified reviewer address.
- **Unique Constraint**: Added constraint on `[grantId, reviewerAddress]` to allow only one feedback entry per user per grant.
- **REST Endpoints**:
  - `GET /grants/:id/feedback`: Returns aggregated average ratings, feedback counts, and lists reviews anonymously (reviewerAddress is masked as `null`).
  - `POST /grants/:id/feedback`: Enforces feedback payload validation (via Zod), signature verification, authorization rules, completed status check, and cache invalidation.
- **Signature Service**: Added Ed25519 signature checks using the intent message scheme:
  `stellargrant:feedback:v1|{grantId}|{rating}|{role}|{address}|{nonce}|{timestamp}`
- **Cache Policy**: Implemented 5-minute TTL caching on feedback retrieval using `ResponseCacheService`.
- **E2E Testing**: Introduced comprehensive test suite `feedback.e2e.test.ts` covering duplicate prevention, role checks, and signature validations.

## Reason for Changes
Resolves issue #446 to support the rating component on the frontend, allowing reviewers, funders, and recipients to securely submit structured feedback post-grant completion.
.
