### PR TITLE
feat:Implements four interconnected protocol improvements to the StellarGrant Soroban smart contract:

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/constants.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/constants.rs
@@ -1,0 +1,76 @@
+// ── Financial ────────────────────────────────────────────────────────────────
+pub const BASIS_POINTS_SCALE: u32 = 10_000;
+pub const DEFAULT_PROTOCOL_FEE_BPS: u32 = 100; // 1%
+pub const MAX_PROTOCOL_FEE_BPS: u32 = 1_000; // 10% ceiling
+pub const MIN_GRANT_AMOUNT: i128 = 1_000_000; // 1 XLM in stroops
+pub const MAX_GRANT_AMOUNT: i128 = 1_000_000_000_000; // 1M XLM ceiling
+
+// ── Governance ───────────────────────────────────────────────────────────────
+pub const DEFAULT_QUORUM_THRESHOLD_BPS: u32 = 5_001; // >50%
+pub const MAX_REVIEWERS_PER_GRANT: u32 = 10;
+pub const MIN_REVIEWERS_PER_GRANT: u32 = 1;
+
+// ── Timelock / Ledger Timing ─────────────────────────────────────────────────
+pub const LEDGERS_PER_SECOND: u64 = 1; // Stellar avg ~5s; use 1 for conservative
+pub const LEDGERS_PER_HOUR: u32 = 720;
+pub const LEDGERS_PER_DAY: u32 = 17_280;
+pub const DEFAULT_TIMELOCK_DELAY_LEDGERS: u32 = 34_560; // 48 hours
+pub const DEFAULT_DISPUTE_WINDOW_LEDGERS: u32 = 17_280; // 24 hours
+
+// ── String Limits ─────────────────────────────────────────────────────────────
+pub const MAX_TITLE_LEN: u32 = 128;
+pub const MAX_DESCRIPTION_LEN: u32 = 1_024;
+pub const MAX_PROOF_URL_LEN: u32 = 512;
+pub const MAX_BIO_LEN: u32 = 256;
+
+// ── Pagination ────────────────────────────────────────────────────────────────
+pub const MAX_PAGE_SIZE: u32 = 50;
+pub const DEFAULT_PAGE_SIZE: u32 = 20;
+
+// ── Reputation ────────────────────────────────────────────────────────────────
+pub const MAX_REPUTATION_SCORE: u32 = 1_000;
+pub const REPUTATION_REJECTION_PENALTY: u32 = 200; // bps subtracted per rejection
+
+// ── Milestones ────────────────────────────────────────────────────────────────
+pub const MAX_MILESTONES_PER_GRANT: u32 = 20;
+pub const MAX_BATCH_SIZE: u32 = 10;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fee_invariants() {
+        assert!(DEFAULT_PROTOCOL_FEE_BPS <= MAX_PROTOCOL_FEE_BPS);
+        assert!(MAX_PROTOCOL_FEE_BPS <= BASIS_POINTS_SCALE);
+    }
+
+    #[test]
+    fn test_page_size_invariants() {
+        assert!(DEFAULT_PAGE_SIZE <= MAX_PAGE_SIZE);
+        assert!(MAX_PAGE_SIZE > 0);
+    }
+
+    #[test]
+    fn test_batch_milestone_invariants() {
+        assert!(MAX_BATCH_SIZE <= MAX_MILESTONES_PER_GRANT);
+        assert!(MAX_BATCH_SIZE > 0);
+    }
+
+    #[test]
+    fn test_reviewer_count_invariants() {
+        assert!(MIN_REVIEWERS_PER_GRANT <= MAX_REVIEWERS_PER_GRANT);
+    }
+
+    #[test]
+    fn test_ledger_timing_invariants() {
+        assert!(DEFAULT_DISPUTE_WINDOW_LEDGERS <= DEFAULT_TIMELOCK_DELAY_LEDGERS);
+        assert_eq!(LEDGERS_PER_DAY, DEFAULT_DISPUTE_WINDOW_LEDGERS);
+    }
+
+    #[test]
+    fn test_amount_invariants() {
+        assert!(MIN_GRANT_AMOUNT > 0);
+        assert!(MAX_GRANT_AMOUNT > MIN_GRANT_AMOUNT);
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -120,6 +120,31 @@ pub struct MilestonePaid {
     pub timestamp: u64,
 }
 
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContractMigrated {
+    pub from_version: u32,
+    pub to_version: u32,
+    pub run_by: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReviewerApproved {
+    pub reviewer: Address,
+    pub approved_by: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReviewerRevoked {
+    pub reviewer: Address,
+    pub revoked_by: Address,
+    pub timestamp: u64,
+}
+
 pub struct Events;
 
 impl Events {
@@ -296,6 +321,34 @@ impl Events {
             grant_id,
             milestone_idx,
             amount,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_contract_migrated(env: &Env, from_version: u32, to_version: u32, run_by: Address) {
+        let event = ContractMigrated {
+            from_version,
+            to_version,
+            run_by,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_reviewer_approved(env: &Env, reviewer: Address, approved_by: Address) {
+        let event = ReviewerApproved {
+            reviewer,
+            approved_by,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_reviewer_revoked(env: &Env, reviewer: Address, revoked_by: Address) {
+        let event = ReviewerRevoked {
+            reviewer,
+            revoked_by,
             timestamp: env.ledger().timestamp(),
         };
         event.publish(env);

--- a/stellargrant-contracts/contracts/stellar-grants/src/governance.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/governance.rs
@@ -1,0 +1,230 @@
+use soroban_sdk::{Address, Env, String};
+
+use crate::constants::MAX_BIO_LEN;
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{ContractError, Grant, Milestone, MilestoneState};
+
+pub struct VoteResult {
+    pub approved: bool,
+    pub quorum_reached: bool,
+    pub approval_pct: u32,
+}
+
+/// Cast a vote (approve = true, reject = false) on a milestone.
+/// Enforces: reviewer is registered, has not already voted, milestone is Submitted.
+/// Handles reputation-weighted tallying, quorum detection, voter rewards,
+/// milestone state finalization, and event emission.
+pub fn cast_vote(
+    env: &Env,
+    grant: &mut Grant,
+    milestone: &mut Milestone,
+    reviewer: &Address,
+    approve: bool,
+    reason: Option<String>,
+) -> Result<VoteResult, ContractError> {
+    if milestone.state != MilestoneState::Submitted {
+        env.panic_with_error(ContractError::MilestoneNotSubmitted);
+    }
+    if !grant.reviewers.contains(reviewer.clone()) {
+        env.panic_with_error(ContractError::Unauthorized);
+    }
+    if milestone.votes.contains_key(reviewer.clone()) {
+        env.panic_with_error(ContractError::AlreadyVoted);
+    }
+
+    if let Some(ref r) = reason {
+        if r.len() > MAX_BIO_LEN {
+            return Err(ContractError::InvalidInput);
+        }
+        milestone.reasons.set(reviewer.clone(), r.clone());
+    }
+
+    let reputation = Storage::get_reviewer_reputation(env, reviewer.clone());
+    milestone.votes.set(reviewer.clone(), approve);
+    if approve {
+        milestone.approvals += reputation;
+    } else {
+        milestone.rejections += reputation;
+    }
+
+    let mut total_weight: u32 = 0;
+    for r in grant.reviewers.iter() {
+        total_weight += Storage::get_reviewer_reputation(env, r);
+    }
+
+    let approval_quorum = quorum_reached(milestone.approvals, total_weight);
+    let rejection_quorum = quorum_reached(milestone.rejections, total_weight);
+    let vote_finalized = approval_quorum || rejection_quorum;
+
+    let total_votes = milestone.approvals + milestone.rejections;
+    let pct = approval_percentage(milestone.approvals, total_votes);
+
+    let result = VoteResult {
+        approved: approval_quorum,
+        quorum_reached: vote_finalized,
+        approval_pct: pct,
+    };
+
+    if vote_finalized {
+        milestone.status_updated_at = env.ledger().timestamp();
+
+        // Reward voters who aligned with the final outcome
+        for (voter, voted_approve) in milestone.votes.iter() {
+            if voted_approve == approval_quorum {
+                let rep = Storage::get_reviewer_reputation(env, voter.clone());
+                Storage::set_reviewer_reputation(env, voter.clone(), rep.saturating_add(1));
+            }
+        }
+
+        let grant_id = grant.id;
+        let milestone_idx = milestone.idx;
+        finalize_milestone(milestone, &result);
+        let new_state = if result.approved {
+            MilestoneState::Approved
+        } else {
+            MilestoneState::Rejected
+        };
+        Events::milestone_status_changed(env, grant_id, milestone_idx, new_state);
+    }
+
+    Events::milestone_voted(env, grant.id, milestone.idx, reviewer.clone(), approve, reason);
+
+    Ok(result)
+}
+
+/// Compute whether quorum is reached given current approvals and total reviewers.
+/// Quorum = strictly more than 50% of reviewers approved.
+pub fn quorum_reached(approvals: u32, total_reviewers: u32) -> bool {
+    if total_reviewers == 0 {
+        return false;
+    }
+    approvals * 2 > total_reviewers
+}
+
+/// Compute the approval percentage (0-100) from votes cast.
+pub fn approval_percentage(approvals: u32, total_voters: u32) -> u32 {
+    if total_voters == 0 {
+        return 0;
+    }
+    (approvals * 100) / total_voters
+}
+
+/// Finalize milestone state based on vote outcome.
+/// Sets MilestoneState::Approved or MilestoneState::Rejected.
+pub fn finalize_milestone(milestone: &mut Milestone, result: &VoteResult) {
+    if result.approved {
+        milestone.state = MilestoneState::Approved;
+    } else {
+        milestone.state = MilestoneState::Rejected;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quorum_zero_reviewers() {
+        assert!(!quorum_reached(0, 0));
+        assert!(!quorum_reached(1, 0));
+    }
+
+    #[test]
+    fn test_quorum_single_reviewer() {
+        assert!(quorum_reached(1, 1)); // 1/1 = 100%
+        assert!(!quorum_reached(0, 1)); // 0/1 = 0%
+    }
+
+    #[test]
+    fn test_quorum_exact_50_percent_not_reached() {
+        assert!(!quorum_reached(1, 2)); // exactly 50%, needs strictly more
+        assert!(!quorum_reached(2, 4)); // exactly 50%
+    }
+
+    #[test]
+    fn test_quorum_51_percent_reached() {
+        assert!(quorum_reached(2, 3)); // 66% > 50%
+        assert!(quorum_reached(3, 4)); // 75% > 50%
+        assert!(quorum_reached(3, 5)); // 60% > 50%
+    }
+
+    #[test]
+    fn test_quorum_all_reject_path() {
+        // If all reject, 0 approvals → no approval quorum
+        assert!(!quorum_reached(0, 3));
+        // But rejection quorum check: quorum_reached(3, 3) = true
+        assert!(quorum_reached(3, 3));
+    }
+
+    #[test]
+    fn test_approval_percentage_zero_voters() {
+        assert_eq!(approval_percentage(0, 0), 0);
+    }
+
+    #[test]
+    fn test_approval_percentage_full() {
+        assert_eq!(approval_percentage(5, 5), 100);
+    }
+
+    #[test]
+    fn test_approval_percentage_none() {
+        assert_eq!(approval_percentage(0, 5), 0);
+    }
+
+    #[test]
+    fn test_approval_percentage_partial() {
+        assert_eq!(approval_percentage(1, 2), 50);
+        assert_eq!(approval_percentage(2, 3), 66);
+    }
+
+    #[test]
+    fn test_finalize_milestone_approved() {
+        let env = soroban_sdk::Env::default();
+        let mut milestone = crate::types::Milestone {
+            idx: 0,
+            description: soroban_sdk::String::from_str(&env, "test"),
+            amount: 100,
+            state: MilestoneState::Submitted,
+            votes: soroban_sdk::Map::new(&env),
+            approvals: 3,
+            rejections: 0,
+            reasons: soroban_sdk::Map::new(&env),
+            status_updated_at: 0,
+            proof_url: None,
+            submission_timestamp: 0,
+        };
+        let result = VoteResult {
+            approved: true,
+            quorum_reached: true,
+            approval_pct: 100,
+        };
+        finalize_milestone(&mut milestone, &result);
+        assert_eq!(milestone.state, MilestoneState::Approved);
+    }
+
+    #[test]
+    fn test_finalize_milestone_rejected() {
+        let env = soroban_sdk::Env::default();
+        let mut milestone = crate::types::Milestone {
+            idx: 0,
+            description: soroban_sdk::String::from_str(&env, "test"),
+            amount: 100,
+            state: MilestoneState::Submitted,
+            votes: soroban_sdk::Map::new(&env),
+            approvals: 0,
+            rejections: 3,
+            reasons: soroban_sdk::Map::new(&env),
+            status_updated_at: 0,
+            proof_url: None,
+            submission_timestamp: 0,
+        };
+        let result = VoteResult {
+            approved: false,
+            quorum_reached: true,
+            approval_pct: 0,
+        };
+        finalize_milestone(&mut milestone, &result);
+        assert_eq!(milestone.state, MilestoneState::Rejected);
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -1,15 +1,20 @@
 #![no_std]
 #![allow(clippy::too_many_arguments)]
+mod constants;
 mod events;
+mod governance;
+mod migration;
 mod reentrancy;
+mod registry;
 mod storage;
 mod types;
 
 pub use events::Events;
 pub use storage::Storage;
 pub use types::{
-    ContractError, EscrowLifecycleState, EscrowMode, EscrowState, Grant, GrantFund, GrantStatus,
-    Milestone, MilestoneState, MilestoneSubmission,
+    ContractError, ContractVersion, EscrowLifecycleState, EscrowMode, EscrowState, Grant, GrantFund,
+    GrantStatus, MigrationRecord, Milestone, MilestoneState, MilestoneSubmission, RegistryEntry,
+    RegistryEntryType,
 };
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env, String, Vec};
@@ -19,8 +24,10 @@ pub struct StellarGrantsContract;
 
 #[contractimpl]
 impl StellarGrantsContract {
-    /// Initialize the contract
-    pub fn initialize(_env: Env) -> Result<(), ContractError> {
+    /// Initialize the contract and record the initial contract version.
+    pub fn initialize(env: Env, deployer: Address) -> Result<(), ContractError> {
+        deployer.require_auth();
+        migration::initialize_version(&env, &deployer, 1, 0, 0)?;
         Ok(())
     }
 
@@ -59,7 +66,7 @@ impl StellarGrantsContract {
             return Err(ContractError::InvalidInput);
         }
 
-        if num_milestones == 0 || num_milestones > 100 {
+        if num_milestones == 0 || num_milestones > constants::MAX_MILESTONES_PER_GRANT {
             return Err(ContractError::InvalidInput);
         }
 
@@ -153,7 +160,7 @@ impl StellarGrantsContract {
         Ok(grant_id)
     }
 
-    /// Register a contributor profile on-chain
+    /// Register a contributor profile on-chain and add to global registry.
     pub fn contributor_register(
         env: Env,
         contributor: Address,
@@ -164,10 +171,10 @@ impl StellarGrantsContract {
     ) -> Result<(), ContractError> {
         contributor.require_auth();
 
-        if name.is_empty() || name.len() > 100 {
+        if name.is_empty() || name.len() > constants::MAX_TITLE_LEN {
             return Err(ContractError::InvalidInput);
         }
-        if bio.len() > 500 {
+        if bio.len() > constants::MAX_BIO_LEN {
             return Err(ContractError::InvalidInput);
         }
 
@@ -188,7 +195,8 @@ impl StellarGrantsContract {
 
         Storage::set_contributor(&env, contributor.clone(), &profile);
 
-        Events::emit_contributor_registered(&env, contributor, name);
+        // Register in global index and emit contributor_registered event
+        registry::register_contributor(&env, &contributor, &name)?;
 
         Ok(())
     }
@@ -225,7 +233,6 @@ impl StellarGrantsContract {
                 return Err(ContractError::InvalidState);
             }
 
-            // Cannot cancel if all milestones are approved/paid out
             if grant.milestones_paid_out >= grant.total_milestones {
                 return Err(ContractError::InvalidState);
             }
@@ -277,7 +284,6 @@ impl StellarGrantsContract {
                 }
             }
 
-            // Update state
             grant.status = GrantStatus::Cancelled;
             grant.escrow_balance = 0;
             grant.reason = Some(reason.clone());
@@ -285,7 +291,6 @@ impl StellarGrantsContract {
 
             Storage::set_grant(&env, grant_id, &grant);
 
-            // Emit cancellation event
             Events::emit_grant_cancelled(&env, grant_id, caller, reason, total_refundable);
 
             Ok(())
@@ -306,7 +311,6 @@ impl StellarGrantsContract {
                 return Err(ContractError::GrantAlreadyReleased);
             }
 
-            // Quorum is interpreted as all milestones approved in current contract design.
             let _ =
                 Self::compute_total_paid_if_quorum_ready(&env, grant_id, grant.total_milestones)?;
             escrow_state.quorum_ready = true;
@@ -316,7 +320,6 @@ impl StellarGrantsContract {
                 return Ok(());
             }
 
-            // High-security grants remain locked until every multisig signer calls sign_release.
             escrow_state.lifecycle = EscrowLifecycleState::AwaitingMultisig;
             Storage::set_escrow_state(&env, grant_id, &escrow_state);
             Ok(())
@@ -463,6 +466,7 @@ impl StellarGrantsContract {
     }
 
     /// Allows authorized reviewers to vote on submitted milestones.
+    /// Delegates all voting logic to governance::cast_vote.
     pub fn milestone_vote(
         env: Env,
         grant_id: u64,
@@ -473,71 +477,15 @@ impl StellarGrantsContract {
     ) -> Result<bool, ContractError> {
         reviewer.require_auth();
 
-        // 1. Validation
-        let grant = Storage::get_grant_v(&env, grant_id);
+        let mut grant = Storage::get_grant_v(&env, grant_id);
         let mut milestone = Storage::get_milestone_v(&env, grant_id, milestone_idx);
 
-        if milestone.state != MilestoneState::Submitted {
-            env.panic_with_error(ContractError::MilestoneNotSubmitted);
-        }
-
-        if !grant.reviewers.contains(reviewer.clone()) {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
-
-        if milestone.votes.contains_key(reviewer.clone()) {
-            env.panic_with_error(ContractError::AlreadyVoted);
-        }
-
-        if let Some(ref fb) = feedback {
-            if fb.len() > 256 {
-                return Err(ContractError::InvalidInput);
-            }
-            milestone.reasons.set(reviewer.clone(), fb.clone());
-        }
-
-        let reputation = Storage::get_reviewer_reputation(&env, reviewer.clone());
-        milestone.votes.set(reviewer.clone(), approve);
-
-        if approve {
-            milestone.approvals += reputation;
-        } else {
-            milestone.rejections += reputation;
-        }
-
-        let mut total_weight: u32 = 0;
-        for r in grant.reviewers.iter() {
-            total_weight += Storage::get_reviewer_reputation(&env, r);
-        }
-
-        let quorum_threshold = (total_weight / 2) + 1;
-        let quorum_reached = milestone.approvals >= quorum_threshold;
-
-        if quorum_reached {
-            milestone.state = MilestoneState::Approved;
-            milestone.status_updated_at = env.ledger().timestamp();
-
-            // Reward harmonious voters who voted approve
-            for (voter, voted_approve) in milestone.votes.iter() {
-                if voted_approve {
-                    let mut rep = Storage::get_reviewer_reputation(&env, voter.clone());
-                    rep += 1;
-                    Storage::set_reviewer_reputation(&env, voter.clone(), rep);
-                }
-            }
-
-            Events::milestone_status_changed(
-                &env,
-                grant_id,
-                milestone_idx,
-                MilestoneState::Approved,
-            );
-        }
+        let result =
+            governance::cast_vote(&env, &mut grant, &mut milestone, &reviewer, approve, feedback)?;
 
         Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
-        Events::milestone_voted(&env, grant_id, milestone_idx, reviewer, approve, feedback);
 
-        Ok(quorum_reached)
+        Ok(result.quorum_reached)
     }
 
     /// Allows authorized reviewers to reject milestones with a reason.
@@ -550,7 +498,6 @@ impl StellarGrantsContract {
     ) -> Result<bool, ContractError> {
         reviewer.require_auth();
 
-        // 1. Validation
         let grant = Storage::get_grant_v(&env, grant_id);
         let mut milestone = Storage::get_milestone_v(&env, grant_id, milestone_idx);
 
@@ -583,7 +530,6 @@ impl StellarGrantsContract {
             milestone.state = MilestoneState::Rejected;
             milestone.status_updated_at = env.ledger().timestamp();
 
-            // Reward harmonious voters who voted reject
             for (voter, voted_approve) in milestone.votes.iter() {
                 if !voted_approve {
                     let mut rep = Storage::get_reviewer_reputation(&env, voter.clone());
@@ -650,7 +596,7 @@ impl StellarGrantsContract {
         if batch_len == 0 {
             return Err(ContractError::BatchEmpty);
         }
-        if batch_len > 20 {
+        if batch_len > constants::MAX_BATCH_SIZE {
             return Err(ContractError::BatchTooLarge);
         }
 
@@ -698,18 +644,15 @@ impl StellarGrantsContract {
                 return Err(ContractError::InvalidState);
             }
 
-            // Perform the token transfer from the funder to the contract
             let token_client = token::Client::new(&env, &grant.token);
             let contract_address = env.current_contract_address();
             token_client.transfer(&funder, &contract_address, &amount);
 
-            // Update escrow balance with overflow protection
             grant.escrow_balance = grant
                 .escrow_balance
                 .checked_add(amount)
                 .ok_or(ContractError::InvalidInput)?;
 
-            // Update funds tracking
             let mut funder_found = false;
             for i in 0..grant.funders.len() {
                 let mut fund_entry = grant.funders.get(i).unwrap();
@@ -767,6 +710,69 @@ impl StellarGrantsContract {
     ) -> Result<soroban_sdk::Map<Address, String>, ContractError> {
         let milestone = Self::get_milestone(env, grant_id, milestone_idx)?;
         Ok(milestone.reasons)
+    }
+
+    // ── Contract Version Query (#527) ───────────────────────────────────
+
+    /// Query the stored contract version.
+    pub fn get_contract_version(env: Env) -> Option<ContractVersion> {
+        migration::get_version(&env)
+    }
+
+    /// Run a versioned schema migration. Admin only.
+    pub fn run_migration(
+        env: Env,
+        admin: Address,
+        target_version: ContractVersion,
+    ) -> Result<MigrationRecord, ContractError> {
+        admin.require_auth();
+        migration::run_migration(&env, &admin, target_version)
+    }
+
+    /// Return the full migration history log.
+    pub fn migration_history(env: Env) -> Vec<MigrationRecord> {
+        migration::migration_history(&env)
+    }
+
+    // ── Global Registry (#520) ──────────────────────────────────────────
+
+    /// Paginated list of all registered contributors.
+    pub fn get_contributors_page(
+        env: Env,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<RegistryEntry> {
+        registry::get_contributors_page(&env, offset, limit)
+    }
+
+    /// Total count of registered contributors.
+    pub fn contributor_count(env: Env) -> u32 {
+        registry::contributor_count(&env)
+    }
+
+    /// Check if an address is on the approved reviewer allowlist.
+    pub fn is_approved_reviewer(env: Env, address: Address) -> bool {
+        registry::is_approved_reviewer(&env, &address)
+    }
+
+    /// Add an address to the approved reviewer allowlist. Admin only.
+    pub fn approve_reviewer(
+        env: Env,
+        admin: Address,
+        reviewer: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        registry::approve_reviewer(&env, &admin, &reviewer)
+    }
+
+    /// Remove an address from the approved reviewer allowlist. Admin only.
+    pub fn revoke_reviewer(
+        env: Env,
+        admin: Address,
+        reviewer: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        registry::revoke_reviewer(&env, &admin, &reviewer)
     }
 
     // ── Reviewer Staking (#42) ──────────────────────────────────────
@@ -895,7 +901,7 @@ impl StellarGrantsContract {
         if batch_len == 0 {
             return Err(ContractError::BatchEmpty);
         }
-        if batch_len > 20 {
+        if batch_len > constants::MAX_BATCH_SIZE {
             return Err(ContractError::BatchTooLarge);
         }
 

--- a/stellargrant-contracts/contracts/stellar-grants/src/migration.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/migration.rs
@@ -1,0 +1,105 @@
+use soroban_sdk::{Address, Env, String, Vec};
+
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{ContractError, ContractVersion, MigrationRecord};
+
+/// Return the current stored contract version.
+pub fn get_version(env: &Env) -> Option<ContractVersion> {
+    Storage::get_contract_version(env)
+}
+
+/// Set the initial version on first deploy. Can only be called once.
+pub fn initialize_version(
+    env: &Env,
+    deployer: &Address,
+    major: u32,
+    minor: u32,
+    patch: u32,
+) -> Result<(), ContractError> {
+    if Storage::get_contract_version(env).is_some() {
+        return Ok(());
+    }
+
+    let version = ContractVersion {
+        major,
+        minor,
+        patch,
+        deployed_at: env.ledger().timestamp(),
+        deployer: deployer.clone(),
+    };
+
+    Storage::set_contract_version(env, &version);
+    Ok(())
+}
+
+/// Run the migration from current version to `target_version`. Admin only.
+/// Internally dispatches to versioned migration functions (v1_to_v2, etc.).
+/// Idempotent: if already at target_version, returns a no-op MigrationRecord.
+pub fn run_migration(
+    env: &Env,
+    admin: &Address,
+    target_version: ContractVersion,
+) -> Result<MigrationRecord, ContractError> {
+    let global_admin = Storage::get_global_admin(env).ok_or(ContractError::Unauthorized)?;
+    if global_admin != *admin {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let current = Storage::get_contract_version(env).ok_or(ContractError::InvalidState)?;
+
+    let from_schema = current.major;
+    let to_schema = target_version.major;
+
+    // Idempotent: already at target version
+    if current.major == target_version.major
+        && current.minor == target_version.minor
+        && current.patch == target_version.patch
+    {
+        let record = MigrationRecord {
+            from_version: from_schema,
+            to_version: to_schema,
+            run_by: admin.clone(),
+            run_at: env.ledger().timestamp(),
+            success: true,
+            notes: String::from_str(env, "no-op: already at target version"),
+        };
+        return Ok(record);
+    }
+
+    // Dispatch to versioned migration step
+    let notes = if from_schema == 1 && to_schema == 2 {
+        migrate_v1_to_v2(env)?
+    } else {
+        String::from_str(env, "migration step completed")
+    };
+
+    Storage::set_contract_version(env, &target_version);
+
+    let record = MigrationRecord {
+        from_version: from_schema,
+        to_version: to_schema,
+        run_by: admin.clone(),
+        run_at: env.ledger().timestamp(),
+        success: true,
+        notes: notes.clone(),
+    };
+
+    let mut log: Vec<MigrationRecord> = Storage::get_migration_log(env);
+    log.push_back(record.clone());
+    Storage::set_migration_log(env, &log);
+
+    Events::emit_contract_migrated(env, from_schema, to_schema, admin.clone());
+
+    Ok(record)
+}
+
+/// Return the full migration history.
+pub fn migration_history(env: &Env) -> Vec<MigrationRecord> {
+    Storage::get_migration_log(env)
+}
+
+/// Internal: migration from schema v1 to v2 (placeholder — implement per future schema change).
+fn migrate_v1_to_v2(env: &Env) -> Result<String, ContractError> {
+    Ok(String::from_str(env, "migrated schema from v1 to v2"))
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/registry.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/registry.rs
@@ -1,0 +1,154 @@
+use soroban_sdk::{Address, Env, String, Vec};
+
+use crate::constants::MAX_PAGE_SIZE;
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{ContractError, RegistryEntry, RegistryEntryType};
+
+/// Add a contributor to the global registry index. Called on registration.
+pub fn register_contributor(
+    env: &Env,
+    address: &Address,
+    name: &String,
+) -> Result<(), ContractError> {
+    let mut index = Storage::get_contributor_index(env);
+
+    for entry in index.iter() {
+        if entry.address == *address {
+            return Err(ContractError::AlreadyRegistered);
+        }
+    }
+
+    let entry = RegistryEntry {
+        address: address.clone(),
+        registered_at: env.ledger().timestamp(),
+        is_active: true,
+        entry_type: RegistryEntryType::Contributor,
+    };
+
+    index.push_back(entry);
+    Storage::set_contributor_index(env, &index);
+
+    Events::emit_contributor_registered(env, address.clone(), name.clone());
+
+    Ok(())
+}
+
+/// Add an address to the approved reviewer allowlist. Admin only.
+pub fn approve_reviewer(
+    env: &Env,
+    admin: &Address,
+    reviewer: &Address,
+) -> Result<(), ContractError> {
+    require_global_admin(env, admin)?;
+
+    let mut allowlist = Storage::get_reviewer_allowlist(env);
+
+    if allowlist.contains(reviewer.clone()) {
+        return Ok(());
+    }
+
+    allowlist.push_back(reviewer.clone());
+    Storage::set_reviewer_allowlist(env, &allowlist);
+
+    Events::emit_reviewer_approved(env, reviewer.clone(), admin.clone());
+
+    Ok(())
+}
+
+/// Remove an address from the approved reviewer allowlist. Admin only.
+pub fn revoke_reviewer(
+    env: &Env,
+    admin: &Address,
+    reviewer: &Address,
+) -> Result<(), ContractError> {
+    require_global_admin(env, admin)?;
+
+    let allowlist = Storage::get_reviewer_allowlist(env);
+    let mut new_list: Vec<Address> = Vec::new(env);
+    let mut found = false;
+
+    for addr in allowlist.iter() {
+        if addr == *reviewer {
+            found = true;
+        } else {
+            new_list.push_back(addr);
+        }
+    }
+
+    if !found {
+        return Err(ContractError::InvalidInput);
+    }
+
+    Storage::set_reviewer_allowlist(env, &new_list);
+
+    Events::emit_reviewer_revoked(env, reviewer.clone(), admin.clone());
+
+    Ok(())
+}
+
+/// Check if an address is on the approved reviewer allowlist.
+pub fn is_approved_reviewer(env: &Env, address: &Address) -> bool {
+    let allowlist = Storage::get_reviewer_allowlist(env);
+    allowlist.contains(address.clone())
+}
+
+/// Paginated list of all registered contributor addresses.
+pub fn get_contributors_page(env: &Env, offset: u32, limit: u32) -> Vec<RegistryEntry> {
+    let index = Storage::get_contributor_index(env);
+    let total = index.len();
+    let effective_limit = if limit > MAX_PAGE_SIZE { MAX_PAGE_SIZE } else { limit };
+    let mut result: Vec<RegistryEntry> = Vec::new(env);
+
+    let mut i = offset;
+    while i < total && i - offset < effective_limit {
+        if let Some(entry) = index.get(i) {
+            result.push_back(entry);
+        }
+        i += 1;
+    }
+
+    result
+}
+
+/// Total count of registered contributors.
+pub fn contributor_count(env: &Env) -> u32 {
+    Storage::get_contributor_index(env).len()
+}
+
+/// Deactivate a contributor entry (soft-delete). Admin only.
+pub fn deactivate(
+    env: &Env,
+    admin: &Address,
+    address: &Address,
+) -> Result<(), ContractError> {
+    require_global_admin(env, admin)?;
+
+    let index = Storage::get_contributor_index(env);
+    let mut new_index: Vec<RegistryEntry> = Vec::new(env);
+    let mut found = false;
+
+    for mut entry in index.iter() {
+        if entry.address == *address {
+            entry.is_active = false;
+            found = true;
+        }
+        new_index.push_back(entry);
+    }
+
+    if !found {
+        return Err(ContractError::InvalidInput);
+    }
+
+    Storage::set_contributor_index(env, &new_index);
+
+    Ok(())
+}
+
+fn require_global_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
+    let admin = Storage::get_global_admin(env).ok_or(ContractError::Unauthorized)?;
+    if admin != *caller {
+        return Err(ContractError::Unauthorized);
+    }
+    Ok(())
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -1,4 +1,7 @@
-use crate::types::{ContractError, ContributorProfile, EscrowState, Grant, Milestone};
+use crate::types::{
+    ContractError, ContractVersion, ContributorProfile, EscrowState, Grant, MigrationRecord,
+    Milestone, RegistryEntry,
+};
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
 #[contracttype]
@@ -18,6 +21,12 @@ pub enum DataKey {
     MultisigSigners(u64),
     ReleaseApproval(u64, Address),
     ReviewerReputation(Address),
+    // Contract version tracking (#527)
+    ContractVersion,
+    MigrationLog,
+    // Global registry (#520)
+    ContributorIndex,
+    ReviewerAllowlist,
 }
 
 pub struct Storage;
@@ -183,5 +192,58 @@ impl Storage {
 
     pub fn get_identity_oracle(env: &Env) -> Option<Address> {
         env.storage().persistent().get(&DataKey::IdentityOracle)
+    }
+
+    // ── Contract Version (#527) ───────────────────────────────────────
+
+    pub fn get_contract_version(env: &Env) -> Option<ContractVersion> {
+        env.storage().persistent().get(&DataKey::ContractVersion)
+    }
+
+    pub fn set_contract_version(env: &Env, version: &ContractVersion) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ContractVersion, version);
+    }
+
+    pub fn get_migration_log(env: &Env) -> Vec<MigrationRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MigrationLog)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn set_migration_log(env: &Env, log: &Vec<MigrationRecord>) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::MigrationLog, log);
+    }
+
+    // ── Global Registry (#520) ────────────────────────────────────────
+
+    pub fn get_contributor_index(env: &Env) -> Vec<RegistryEntry> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ContributorIndex)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn set_contributor_index(env: &Env, index: &Vec<RegistryEntry>) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ContributorIndex, index);
+    }
+
+    pub fn get_reviewer_allowlist(env: &Env) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReviewerAllowlist)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn set_reviewer_allowlist(env: &Env, list: &Vec<Address>) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ReviewerAllowlist, list);
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -1,5 +1,43 @@
 use soroban_sdk::{contracterror, contracttype, Address, Map, String, Vec};
 
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MigrationRecord {
+    pub from_version: u32,
+    pub to_version: u32,
+    pub run_by: Address,
+    pub run_at: u64,
+    pub success: bool,
+    pub notes: String,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContractVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+    pub deployed_at: u64,
+    pub deployer: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegistryEntry {
+    pub address: Address,
+    pub registered_at: u64,
+    pub is_active: bool,
+    pub entry_type: RegistryEntryType,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum RegistryEntryType {
+    Contributor = 0,
+    Reviewer = 1,
+}
+
 /// Contract error types
 #[contracterror]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_initialize_is_idempotent.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_initialize_is_idempotent.1.json
@@ -1,0 +1,205 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ContractVersion"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "deployed_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "deployer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "major"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "minor"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "patch"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_initialize_sets_version_1_0_0.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_initialize_sets_version_1_0_0.1.json
@@ -1,0 +1,165 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ContractVersion"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "deployed_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "deployer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "major"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "minor"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "patch"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_idempotent_noop_when_already_at_target.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_idempotent_noop_when_already_at_target.1.json
@@ -1,0 +1,475 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_global_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "run_migration",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deployed_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deployer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "major"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "minor"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "patch"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "run_migration",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deployed_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deployer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "major"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "minor"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "patch"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ContractVersion"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "deployed_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "deployer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "major"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "minor"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "patch"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "MigrationLog"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "map": [
+                      {
+                        "key": {
+                          "symbol": "from_version"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "notes"
+                        },
+                        "val": {
+                          "string": "migrated schema from v1 to v2"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "run_at"
+                        },
+                        "val": {
+                          "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "run_by"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "success"
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "to_version"
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "4837995959683129791"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_state_continuity_contributor_survives_upgrade.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_state_continuity_contributor_survives_upgrade.1.json
@@ -1,0 +1,597 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_global_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "contributor_register",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "string": "Alice"
+                },
+                {
+                  "string": "Rust developer"
+                },
+                {
+                  "vec": []
+                },
+                {
+                  "string": "https://github.com/alice"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "run_migration",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deployed_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deployer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "major"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "minor"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "patch"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ContractVersion"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "deployed_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "deployer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "major"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "minor"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "patch"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Contributor"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bio"
+                    },
+                    "val": {
+                      "string": "Rust developer"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "contributor"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "github_url"
+                    },
+                    "val": {
+                      "string": "https://github.com/alice"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grants_count"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "Alice"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registration_timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "skills"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_earned"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ContributorIndex"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "map": [
+                      {
+                        "key": {
+                          "symbol": "address"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "entry_type"
+                        },
+                        "val": {
+                          "u32": 0
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "is_active"
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "registered_at"
+                        },
+                        "val": {
+                          "u64": "0"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "MigrationLog"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "map": [
+                      {
+                        "key": {
+                          "symbol": "from_version"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "notes"
+                        },
+                        "val": {
+                          "string": "migrated schema from v1 to v2"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "run_at"
+                        },
+                        "val": {
+                          "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "run_by"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "success"
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "to_version"
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "4837995959683129791"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_unauthorized_when_not_admin.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_unauthorized_when_not_admin.1.json
@@ -1,0 +1,231 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_global_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ContractVersion"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "deployed_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "deployer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "major"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "minor"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "patch"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_updates_stored_version.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_updates_stored_version.1.json
@@ -1,0 +1,391 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_global_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "run_migration",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deployed_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deployer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "major"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "minor"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "patch"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ContractVersion"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "deployed_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "deployer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "major"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "minor"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "patch"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "MigrationLog"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "map": [
+                      {
+                        "key": {
+                          "symbol": "from_version"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "notes"
+                        },
+                        "val": {
+                          "string": "migrated schema from v1 to v2"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "run_at"
+                        },
+                        "val": {
+                          "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "run_by"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "success"
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "to_version"
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_v1_to_v2_records_history.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test_migration_v1_to_v2_records_history.1.json
@@ -1,0 +1,391 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "initialize",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_global_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "run_migration",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deployed_at"
+                      },
+                      "val": {
+                        "u64": "0"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deployer"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "major"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "minor"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "patch"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ContractVersion"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "deployed_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "deployer"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "major"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "minor"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "patch"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "MigrationLog"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "map": [
+                      {
+                        "key": {
+                          "symbol": "from_version"
+                        },
+                        "val": {
+                          "u32": 1
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "notes"
+                        },
+                        "val": {
+                          "string": "migrated schema from v1 to v2"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "run_at"
+                        },
+                        "val": {
+                          "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "run_by"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "success"
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "to_version"
+                        },
+                        "val": {
+                          "u32": 2
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "1033654523790656264"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/stellargrant-contracts/contracts/stellar-grants/tests/migration_test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/tests/migration_test.rs
@@ -1,0 +1,181 @@
+use soroban_sdk::{
+    testutils::{Address as TestAddress, Ledger},
+    Address, Env, String, Vec,
+};
+use stellar_grants::{ContractVersion, StellarGrantsContractClient};
+
+fn setup(env: &Env) -> (StellarGrantsContractClient<'_>, Address) {
+    let contract_id = env.register_contract(None, stellar_grants::StellarGrantsContract);
+    let client = StellarGrantsContractClient::new(env, &contract_id);
+    let deployer = <Address as TestAddress>::generate(env);
+    (client, deployer)
+}
+
+/// Helper: build a ContractVersion value.
+fn make_version(env: &Env, major: u32, minor: u32, patch: u32, deployer: &Address) -> ContractVersion {
+    ContractVersion {
+        major,
+        minor,
+        patch,
+        deployed_at: env.ledger().timestamp(),
+        deployer: deployer.clone(),
+    }
+}
+
+#[test]
+fn test_initialize_sets_version_1_0_0() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, deployer) = setup(&env);
+
+    client.initialize(&deployer);
+
+    let version = client.get_contract_version().expect("version should be set after initialize");
+    assert_eq!(version.major, 1);
+    assert_eq!(version.minor, 0);
+    assert_eq!(version.patch, 0);
+    assert_eq!(version.deployer, deployer);
+}
+
+#[test]
+fn test_initialize_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, deployer) = setup(&env);
+
+    // First call sets the version
+    client.initialize(&deployer);
+    let v1 = client.get_contract_version().unwrap();
+
+    // Second call is a no-op; version unchanged
+    let other = <Address as TestAddress>::generate(&env);
+    client.initialize(&other);
+    let v2 = client.get_contract_version().unwrap();
+
+    assert_eq!(v1.major, v2.major);
+    assert_eq!(v1.minor, v2.minor);
+    assert_eq!(v1.patch, v2.patch);
+    assert_eq!(v1.deployer, deployer);
+}
+
+#[test]
+fn test_migration_v1_to_v2_records_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, deployer) = setup(&env);
+
+    client.initialize(&deployer);
+    client.set_global_admin(&deployer, &deployer);
+
+    let target = make_version(&env, 2, 0, 0, &deployer);
+    let record = client.run_migration(&deployer, &target);
+
+    assert!(record.success);
+    assert_eq!(record.from_version, 1);
+    assert_eq!(record.to_version, 2);
+
+    let history = client.migration_history();
+    assert_eq!(history.len(), 1);
+    let logged = history.get(0).unwrap();
+    assert_eq!(logged.from_version, 1);
+    assert_eq!(logged.to_version, 2);
+    assert!(logged.success);
+}
+
+#[test]
+fn test_migration_updates_stored_version() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, deployer) = setup(&env);
+
+    client.initialize(&deployer);
+    client.set_global_admin(&deployer, &deployer);
+
+    let target = make_version(&env, 2, 1, 0, &deployer);
+    client.run_migration(&deployer, &target);
+
+    let version = client.get_contract_version().unwrap();
+    assert_eq!(version.major, 2);
+    assert_eq!(version.minor, 1);
+    assert_eq!(version.patch, 0);
+}
+
+#[test]
+fn test_migration_idempotent_noop_when_already_at_target() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, deployer) = setup(&env);
+
+    client.initialize(&deployer);
+    client.set_global_admin(&deployer, &deployer);
+
+    // Migrate to v2
+    let target = make_version(&env, 2, 0, 0, &deployer);
+    client.run_migration(&deployer, &target);
+    assert_eq!(client.migration_history().len(), 1);
+
+    // Run the same migration again — idempotent no-op
+    let target2 = make_version(&env, 2, 0, 0, &deployer);
+    let record = client.run_migration(&deployer, &target2);
+    assert!(record.success);
+    assert_eq!(
+        record.notes,
+        String::from_str(&env, "no-op: already at target version")
+    );
+
+    // History must not grow for no-ops
+    assert_eq!(client.migration_history().len(), 1);
+}
+
+#[test]
+fn test_migration_state_continuity_contributor_survives_upgrade() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, deployer) = setup(&env);
+
+    client.initialize(&deployer);
+    client.set_global_admin(&deployer, &deployer);
+
+    // Register a contributor under v1 to establish pre-migration state
+    let contributor = <Address as TestAddress>::generate(&env);
+    client.contributor_register(
+        &contributor,
+        &String::from_str(&env, "Alice"),
+        &String::from_str(&env, "Rust developer"),
+        &Vec::new(&env),
+        &String::from_str(&env, "https://github.com/alice"),
+    );
+
+    let pre_migration_count = client.contributor_count();
+    assert_eq!(pre_migration_count, 1);
+
+    // Run migration to v2
+    let target = make_version(&env, 2, 0, 0, &deployer);
+    let record = client.run_migration(&deployer, &target);
+    assert!(record.success);
+
+    // Contributor registry must survive the migration (state continuity)
+    let post_migration_count = client.contributor_count();
+    assert_eq!(post_migration_count, 1, "contributor count must be unchanged after migration");
+
+    // Version is correctly updated
+    let new_version = client.get_contract_version().unwrap();
+    assert_eq!(new_version.major, 2);
+}
+
+#[test]
+fn test_migration_unauthorized_when_not_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, deployer) = setup(&env);
+
+    client.initialize(&deployer);
+    // Set a different admin
+    let admin = <Address as TestAddress>::generate(&env);
+    client.set_global_admin(&deployer, &admin);
+
+    // deployer is no longer the admin; migration should fail
+    let target = make_version(&env, 2, 0, 0, &deployer);
+    let result = client.try_run_migration(&deployer, &target);
+    assert!(result.is_err());
+}

--- a/stellargrant-contracts/pr.md
+++ b/stellargrant-contracts/pr.md
@@ -1,0 +1,41 @@
+## Summary
+
+Implements four interconnected protocol improvements to the StellarGrant Soroban smart contract:
+
+- **#513 — Voting & Quorum Logic Module**: Extracts milestone approval voting from `lib.rs` into a standalone `governance.rs` module with `cast_vote`, `quorum_reached`, `approval_percentage`, and `finalize_milestone`. `lib.rs::milestone_vote` now delegates entirely to `governance::cast_vote`. Includes unit tests for quorum edge cases (0 reviewers, single reviewer, exact 50%, 51%, all-reject path).
+
+- **#520 — Global Contributor & Reviewer Registry**: Adds `registry.rs` with a protocol-wide contributor index and reviewer allowlist. Introduces `RegistryEntry` / `RegistryEntryType` types, `DataKey::ContributorIndex` / `DataKey::ReviewerAllowlist` storage keys, and new events `ReviewerApproved` / `ReviewerRevoked`. `lib.rs::contributor_register` now also writes to the global index. New public API: `get_contributors_page`, `contributor_count`, `is_approved_reviewer`, `approve_reviewer`, `revoke_reviewer`.
+
+- **#525 — Protocol-Wide Compile-Time Constants**: Adds `constants.rs` with named constants for financial limits, governance parameters, timelock/ledger timing, string length caps, pagination, reputation, and milestone bounds. Magic numbers in `lib.rs` replaced with `constants::MAX_MILESTONES_PER_GRANT`, `constants::MAX_TITLE_LEN`, `constants::MAX_BIO_LEN`, and `constants::MAX_BATCH_SIZE`. Compile-time assertion tests verify key invariants.
+
+- **#527 — Contract Upgrade & State Migration Framework**: Adds `migration.rs` providing `get_version`, `initialize_version`, `run_migration`, and `migration_history`. `ContractVersion` and `MigrationRecord` types added to `types.rs`; `DataKey::ContractVersion` and `DataKey::MigrationLog` added to `storage.rs`; `ContractMigrated` event added to `events.rs`. `lib.rs::initialize` now records the initial version (v1.0.0). `run_migration` is idempotent and dispatches to versioned migration functions (`migrate_v1_to_v2` placeholder). New public API: `get_contract_version`, `run_migration`, `migration_history`.
+
+## Files changed
+
+| File | Action |
+|---|---|
+| `src/constants.rs` | Created — compile-time constants (#525) |
+| `src/governance.rs` | Created — voting/quorum module (#513) |
+| `src/registry.rs` | Created — contributor & reviewer registry (#520) |
+| `src/migration.rs` | Created — version migration framework (#527) |
+| `src/types.rs` | Modified — added `MigrationRecord`, `ContractVersion`, `RegistryEntry`, `RegistryEntryType` |
+| `src/storage.rs` | Modified — added 4 new `DataKey` variants and 8 new storage accessors |
+| `src/events.rs` | Modified — added `ContractMigrated`, `ReviewerApproved`, `ReviewerRevoked` |
+| `src/lib.rs` | Modified — wired all new modules, replaced magic numbers, exposed new entry points |
+| `tests/migration_test.rs` | Created — 7 end-to-end migration tests |
+
+## Test plan
+
+- [x] All 22 existing unit tests continue to pass (`cargo test --lib`)
+- [x] 7 new migration integration tests pass (`cargo test --test migration_test`)
+- [x] 6 compile-time assertion tests in `constants::tests` pass
+- [x] 9 quorum/percentage unit tests in `governance::tests` pass
+- [x] Contract builds cleanly with no errors (`cargo build -p stellar-grants`)
+- [ ] Verify `test_milestone_dispute`, `test_delegate_voting`, and `test_reputation_and_dispute_fee` suites (these reference contract methods not yet implemented and were failing before this PR)
+
+## Breaking changes
+
+- `initialize(Env)` → `initialize(Env, Address)` — deployer address now required; recorded as the initial version's deployer.
+- `num_milestones` cap tightened from 100 → `MAX_MILESTONES_PER_GRANT` (20) per spec.
+- Milestone batch size cap tightened from 20 → `MAX_BATCH_SIZE` (10) per spec.
+- `contributor_register` no longer emits `contributor_registered` directly — the event is now emitted by `registry::register_contributor` to keep the registry self-contained.


### PR DESCRIPTION
## Summary

Implements four interconnected protocol improvements to the StellarGrant Soroban smart contract:

closes #513 
closes #520 
closes #525 
closes #527 

- **#513 — Voting & Quorum Logic Module**: Extracts milestone approval voting from `lib.rs` into a standalone `governance.rs` module with `cast_vote`, `quorum_reached`, `approval_percentage`, and `finalize_milestone`. `lib.rs::milestone_vote` now delegates entirely to `governance::cast_vote`. Includes unit tests for quorum edge cases (0 reviewers, single reviewer, exact 50%, 51%, all-reject path).

- **#520 — Global Contributor & Reviewer Registry**: Adds `registry.rs` with a protocol-wide contributor index and reviewer allowlist. Introduces `RegistryEntry` / `RegistryEntryType` types, `DataKey::ContributorIndex` / `DataKey::ReviewerAllowlist` storage keys, and new events `ReviewerApproved` / `ReviewerRevoked`. `lib.rs::contributor_register` now also writes to the global index. New public API: `get_contributors_page`, `contributor_count`, `is_approved_reviewer`, `approve_reviewer`, `revoke_reviewer`.

- **#525 — Protocol-Wide Compile-Time Constants**: Adds `constants.rs` with named constants for financial limits, governance parameters, timelock/ledger timing, string length caps, pagination, reputation, and milestone bounds. Magic numbers in `lib.rs` replaced with `constants::MAX_MILESTONES_PER_GRANT`, `constants::MAX_TITLE_LEN`, `constants::MAX_BIO_LEN`, and `constants::MAX_BATCH_SIZE`. Compile-time assertion tests verify key invariants.

- **#527 — Contract Upgrade & State Migration Framework**: Adds `migration.rs` providing `get_version`, `initialize_version`, `run_migration`, and `migration_history`. `ContractVersion` and `MigrationRecord` types added to `types.rs`; `DataKey::ContractVersion` and `DataKey::MigrationLog` added to `storage.rs`; `ContractMigrated` event added to `events.rs`. `lib.rs::initialize` now records the initial version (v1.0.0). `run_migration` is idempotent and dispatches to versioned migration functions (`migrate_v1_to_v2` placeholder). New public API: `get_contract_version`, `run_migration`, `migration_history`.

## Files changed

| File | Action |
|---|---|
| `src/constants.rs` | Created — compile-time constants (#525) |
| `src/governance.rs` | Created — voting/quorum module (#513) |
| `src/registry.rs` | Created — contributor & reviewer registry (#520) |
| `src/migration.rs` | Created — version migration framework (#527) |
| `src/types.rs` | Modified — added `MigrationRecord`, `ContractVersion`, `RegistryEntry`, `RegistryEntryType` |
| `src/storage.rs` | Modified — added 4 new `DataKey` variants and 8 new storage accessors |
| `src/events.rs` | Modified — added `ContractMigrated`, `ReviewerApproved`, `ReviewerRevoked` |
| `src/lib.rs` | Modified — wired all new modules, replaced magic numbers, exposed new entry points |
| `tests/migration_test.rs` | Created — 7 end-to-end migration tests |

## Test plan

- [x] All 22 existing unit tests continue to pass (`cargo test --lib`)
- [x] 7 new migration integration tests pass (`cargo test --test migration_test`)
- [x] 6 compile-time assertion tests in `constants::tests` pass
- [x] 9 quorum/percentage unit tests in `governance::tests` pass
- [x] Contract builds cleanly with no errors (`cargo build -p stellar-grants`)
- [ ] Verify `test_milestone_dispute`, `test_delegate_voting`, and `test_reputation_and_dispute_fee` suites (these reference contract methods not yet implemented and were failing before this PR)

## Breaking changes

- `initialize(Env)` → `initialize(Env, Address)` — deployer address now required; recorded as the initial version's deployer.
- `num_milestones` cap tightened from 100 → `MAX_MILESTONES_PER_GRANT` (20) per spec.
- Milestone batch size cap tightened from 20 → `MAX_BATCH_SIZE` (10) per spec.
- `contributor_register` no longer emits `contributor_registered` directly — the event is now emitted by `registry::register_contributor` to keep the registry self-contained.
