### PR TITLE
feat(contracts): dispute resolution, reputation scoring, runtime config, and fee collection modules

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/config.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/config.rs
@@ -1,0 +1,103 @@
+use soroban_sdk::{Address, Env};
+
+use crate::storage::Storage;
+use crate::types::{ContractError, ProtocolConfig};
+
+pub fn default_config() -> ProtocolConfig {
+    ProtocolConfig {
+        quorum_threshold_bps: 5001,
+        max_reviewers: 10,
+        min_stake_amount: 1_000_000,
+        protocol_fee_bps: 100,
+        max_milestones_per_grant: 20,
+        dispute_window_ledgers: 17280,
+        max_grant_title_len: 128,
+        max_grant_desc_len: 1024,
+    }
+}
+
+pub fn get_config(env: &Env) -> ProtocolConfig {
+    Storage::get_protocol_config(env).unwrap_or_else(default_config)
+}
+
+pub fn validate_config(config: &ProtocolConfig) -> Result<(), ContractError> {
+    if config.quorum_threshold_bps < 5001 || config.quorum_threshold_bps > 10_000 {
+        return Err(ContractError::InvalidInput);
+    }
+    if config.protocol_fee_bps > 1000 {
+        return Err(ContractError::InvalidInput);
+    }
+    if config.max_reviewers < 1 {
+        return Err(ContractError::InvalidInput);
+    }
+    if config.max_milestones_per_grant < 1 {
+        return Err(ContractError::InvalidInput);
+    }
+    if config.max_grant_title_len < 1 || config.max_grant_desc_len < 1 {
+        return Err(ContractError::InvalidInput);
+    }
+    Ok(())
+}
+
+pub fn set_config(
+    env: &Env,
+    admin: &Address,
+    new_config: ProtocolConfig,
+) -> Result<(), ContractError> {
+    if !crate::access::has_role(env, admin, crate::types::Role::Admin)
+        && Storage::get_global_admin(env) != Some(admin.clone())
+    {
+        return Err(ContractError::NotContractAdmin);
+    }
+    validate_config(&new_config)?;
+    Storage::set_protocol_config(env, &new_config);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn test_default_config_values() {
+        let cfg = default_config();
+        assert_eq!(cfg.quorum_threshold_bps, 5001);
+        assert_eq!(cfg.max_milestones_per_grant, 20);
+        assert_eq!(cfg.protocol_fee_bps, 100);
+    }
+
+    #[test]
+    fn test_invalid_quorum_threshold_rejected() {
+        let mut cfg = default_config();
+        cfg.quorum_threshold_bps = 4999;
+        assert_eq!(validate_config(&cfg), Err(ContractError::InvalidInput));
+    }
+
+    #[test]
+    fn test_invalid_fee_bps_rejected() {
+        let mut cfg = default_config();
+        cfg.protocol_fee_bps = 1001;
+        assert_eq!(validate_config(&cfg), Err(ContractError::InvalidInput));
+    }
+
+    #[test]
+    fn test_valid_config_passes_validation() {
+        let cfg = default_config();
+        assert!(validate_config(&cfg).is_ok());
+    }
+
+    #[test]
+    fn test_zero_max_reviewers_rejected() {
+        let mut cfg = default_config();
+        cfg.max_reviewers = 0;
+        assert_eq!(validate_config(&cfg), Err(ContractError::InvalidInput));
+    }
+
+    #[test]
+    fn test_quorum_too_high_rejected() {
+        let mut cfg = default_config();
+        cfg.quorum_threshold_bps = 10_001;
+        assert_eq!(validate_config(&cfg), Err(ContractError::InvalidInput));
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/config.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/config.rs
@@ -44,10 +44,8 @@ pub fn set_config(
     admin: &Address,
     new_config: ProtocolConfig,
 ) -> Result<(), ContractError> {
-    if !crate::access::has_role(env, admin, crate::types::Role::Admin)
-        && Storage::get_global_admin(env) != Some(admin.clone())
-    {
-        return Err(ContractError::NotContractAdmin);
+    if Storage::get_global_admin(env) != Some(admin.clone()) {
+        return Err(ContractError::Unauthorized);
     }
     validate_config(&new_config)?;
     Storage::set_protocol_config(env, &new_config);

--- a/stellargrant-contracts/contracts/stellar-grants/src/dispute.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/dispute.rs
@@ -1,0 +1,365 @@
+use soroban_sdk::{token, Address, Env, String, Vec};
+
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{ContractError, Dispute, DisputeStatus, Grant};
+
+pub fn raise_dispute(
+    env: &Env,
+    grant: &Grant,
+    milestone_idx: u32,
+    caller: &Address,
+    reason: String,
+) -> Result<Dispute, ContractError> {
+    let is_owner = grant.owner == *caller;
+    let is_reviewer = grant.reviewers.contains(caller.clone());
+    if !(is_owner || is_reviewer) {
+        return Err(ContractError::Unauthorized);
+    }
+
+    if Storage::get_dispute(env, grant.id, milestone_idx).is_some() {
+        return Err(ContractError::InvalidState);
+    }
+
+    let dispute = Dispute {
+        grant_id: grant.id,
+        milestone_idx,
+        raised_by: caller.clone(),
+        reason,
+        status: DisputeStatus::Open,
+        arbiters: Vec::new(env),
+        votes_contributor: 0,
+        votes_funder: 0,
+        raised_at: env.ledger().timestamp(),
+        resolved_at: None,
+    };
+
+    Storage::set_dispute(env, grant.id, milestone_idx, &dispute);
+    Events::emit_dispute_raised(env, grant.id, milestone_idx, caller.clone());
+    Ok(dispute)
+}
+
+pub fn assign_arbiter(
+    env: &Env,
+    dispute: &mut Dispute,
+    admin: &Address,
+    arbiter: &Address,
+) -> Result<(), ContractError> {
+    if dispute.status != DisputeStatus::Open {
+        return Err(ContractError::InvalidState);
+    }
+    if !crate::access::has_role(env, admin, crate::types::Role::Admin)
+        && Storage::get_global_admin(env) != Some(admin.clone())
+    {
+        return Err(ContractError::NotContractAdmin);
+    }
+    if dispute.arbiters.contains(arbiter.clone()) {
+        return Err(ContractError::AlreadyVoted);
+    }
+    dispute.arbiters.push_back(arbiter.clone());
+    dispute.status = DisputeStatus::UnderReview;
+    Storage::set_dispute(env, dispute.grant_id, dispute.milestone_idx, dispute);
+    Events::emit_arbiter_assigned(
+        env,
+        dispute.grant_id,
+        dispute.milestone_idx,
+        arbiter.clone(),
+    );
+    Ok(())
+}
+
+pub fn arbiter_vote(
+    env: &Env,
+    dispute: &mut Dispute,
+    arbiter: &Address,
+    favor_contributor: bool,
+) -> Result<(), ContractError> {
+    if dispute.status != DisputeStatus::UnderReview {
+        return Err(ContractError::InvalidState);
+    }
+    if !dispute.arbiters.contains(arbiter.clone()) {
+        return Err(ContractError::Unauthorized);
+    }
+    if favor_contributor {
+        dispute.votes_contributor = dispute.votes_contributor.saturating_add(1);
+    } else {
+        dispute.votes_funder = dispute.votes_funder.saturating_add(1);
+    }
+    Storage::set_dispute(env, dispute.grant_id, dispute.milestone_idx, dispute);
+    Events::emit_arbiter_voted(
+        env,
+        dispute.grant_id,
+        dispute.milestone_idx,
+        arbiter.clone(),
+        favor_contributor,
+    );
+    Ok(())
+}
+
+pub fn resolve_dispute(
+    env: &Env,
+    grant: &mut Grant,
+    dispute: &mut Dispute,
+) -> Result<DisputeStatus, ContractError> {
+    if dispute.status != DisputeStatus::UnderReview {
+        return Err(ContractError::InvalidState);
+    }
+
+    let total_votes = dispute
+        .votes_contributor
+        .saturating_add(dispute.votes_funder);
+    if total_votes == 0 {
+        return Err(ContractError::InvalidState);
+    }
+
+    let majority = total_votes / 2 + 1;
+    let outcome = if dispute.votes_contributor >= majority {
+        DisputeStatus::ResolvedForContributor
+    } else if dispute.votes_funder >= majority {
+        DisputeStatus::ResolvedForFunder
+    } else {
+        return Err(ContractError::QuorumNotReached);
+    };
+
+    let grant_id = dispute.grant_id;
+    let milestone_idx = dispute.milestone_idx;
+
+    if outcome == DisputeStatus::ResolvedForContributor {
+        if let Some(milestone) = Storage::get_milestone(env, grant_id, milestone_idx) {
+            let payout_token = milestone.payout_token.clone();
+            let balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
+            if balance >= milestone.amount {
+                token::Client::new(env, &payout_token).transfer(
+                    &env.current_contract_address(),
+                    &grant.owner,
+                    &milestone.amount,
+                );
+                grant.escrow_balances.set(
+                    payout_token,
+                    balance
+                        .checked_sub(milestone.amount)
+                        .ok_or(ContractError::InsufficientBalance)?,
+                );
+            }
+        }
+    } else {
+        if let Some(milestone) = Storage::get_milestone(env, grant_id, milestone_idx) {
+            let payout_token = milestone.payout_token.clone();
+            let balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
+            if balance >= milestone.amount && !grant.funders.is_empty() {
+                let mut total_contributed: i128 = 0;
+                for fund in grant.funders.iter() {
+                    if fund.token == payout_token {
+                        total_contributed = total_contributed.saturating_add(fund.amount);
+                    }
+                }
+                if total_contributed > 0 {
+                    let tok_client = token::Client::new(env, &payout_token);
+                    let mut distributed: i128 = 0;
+                    let funders_len = grant.funders.len();
+                    for i in 0..funders_len {
+                        let fund = grant.funders.get(i).ok_or(ContractError::InvalidInput)?;
+                        if fund.token != payout_token {
+                            continue;
+                        }
+                        let is_last = i + 1 == funders_len;
+                        let share = if is_last {
+                            milestone.amount - distributed
+                        } else {
+                            fund.amount
+                                .checked_mul(milestone.amount)
+                                .ok_or(ContractError::InvalidInput)?
+                                .checked_div(total_contributed)
+                                .ok_or(ContractError::InvalidInput)?
+                        };
+                        if share > 0 {
+                            tok_client.transfer(
+                                &env.current_contract_address(),
+                                &fund.funder,
+                                &share,
+                            );
+                            distributed = distributed.saturating_add(share);
+                        }
+                    }
+                    grant.escrow_balances.set(
+                        payout_token,
+                        balance
+                            .checked_sub(distributed)
+                            .ok_or(ContractError::InsufficientBalance)?,
+                    );
+                }
+            }
+        }
+    }
+
+    dispute.status = outcome.clone();
+    dispute.resolved_at = Some(env.ledger().timestamp());
+    Storage::set_dispute(env, grant_id, milestone_idx, dispute);
+
+    let for_contributor = outcome == DisputeStatus::ResolvedForContributor;
+    Events::emit_dispute_resolved(env, grant_id, milestone_idx, for_contributor);
+    Ok(outcome)
+}
+
+pub fn cancel_dispute(
+    env: &Env,
+    dispute: &mut Dispute,
+    caller: &Address,
+) -> Result<(), ContractError> {
+    if dispute.status != DisputeStatus::Open && dispute.status != DisputeStatus::UnderReview {
+        return Err(ContractError::InvalidState);
+    }
+    if dispute.raised_by != *caller
+        && !crate::access::has_role(env, caller, crate::types::Role::Admin)
+        && Storage::get_global_admin(env) != Some(caller.clone())
+    {
+        return Err(ContractError::Unauthorized);
+    }
+    dispute.status = DisputeStatus::Cancelled;
+    dispute.resolved_at = Some(env.ledger().timestamp());
+    Storage::set_dispute(env, dispute.grant_id, dispute.milestone_idx, dispute);
+    Events::emit_dispute_cancelled(env, dispute.grant_id, dispute.milestone_idx, caller.clone());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Grant, GrantStatus};
+    use soroban_sdk::{testutils::Address as _, Env, String, Vec};
+
+    fn make_grant(env: &Env, owner: Address) -> Grant {
+        let token = Address::generate(env);
+        Grant::new(
+            1,
+            owner.clone(),
+            String::from_str(env, "T"),
+            String::from_str(env, "D"),
+            token,
+            1000,
+            500,
+            Vec::new(env),
+            GrantStatus::Active,
+            1,
+            2,
+            env.ledger().timestamp(),
+            0,
+            0,
+            Vec::new(env),
+            false,
+            env,
+        )
+    }
+
+    #[test]
+    fn test_raise_dispute_unauthorized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let grant = make_grant(&env, owner);
+        let reason = String::from_str(&env, "Proof is invalid");
+        let result = raise_dispute(&env, &grant, 0, &stranger, reason);
+        assert_eq!(result, Err(ContractError::Unauthorized));
+    }
+
+    #[test]
+    fn test_arbiter_quorum_not_reached_returns_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let grant = make_grant(&env, owner.clone());
+
+        // 1 vote each — neither side has majority of 2 needed
+        let mut dispute = Dispute {
+            grant_id: 1,
+            milestone_idx: 0,
+            raised_by: owner.clone(),
+            reason: String::from_str(&env, "reason"),
+            status: DisputeStatus::UnderReview,
+            arbiters: Vec::new(&env),
+            votes_contributor: 1,
+            votes_funder: 1,
+            raised_at: 0,
+            resolved_at: None,
+        };
+
+        let mut grant_mut = grant.clone();
+        let result = resolve_dispute(&env, &mut grant_mut, &mut dispute);
+        assert_eq!(result, Err(ContractError::QuorumNotReached));
+    }
+
+    #[test]
+    fn test_resolve_dispute_wrong_status_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let grant = make_grant(&env, owner.clone());
+
+        // Status is Open, not UnderReview
+        let mut dispute = Dispute {
+            grant_id: 1,
+            milestone_idx: 0,
+            raised_by: owner.clone(),
+            reason: String::from_str(&env, "reason"),
+            status: DisputeStatus::Open,
+            arbiters: Vec::new(&env),
+            votes_contributor: 3,
+            votes_funder: 0,
+            raised_at: 0,
+            resolved_at: None,
+        };
+
+        let mut grant_mut = grant.clone();
+        let result = resolve_dispute(&env, &mut grant_mut, &mut dispute);
+        assert_eq!(result, Err(ContractError::InvalidState));
+    }
+
+    #[test]
+    fn test_arbiter_vote_on_wrong_status_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let arbiter = Address::generate(&env);
+        let mut dispute = Dispute {
+            grant_id: 1,
+            milestone_idx: 0,
+            raised_by: owner.clone(),
+            reason: String::from_str(&env, "reason"),
+            status: DisputeStatus::Open,
+            arbiters: {
+                let mut v = Vec::new(&env);
+                v.push_back(arbiter.clone());
+                v
+            },
+            votes_contributor: 0,
+            votes_funder: 0,
+            raised_at: 0,
+            resolved_at: None,
+        };
+        let result = arbiter_vote(&env, &mut dispute, &arbiter, true);
+        assert_eq!(result, Err(ContractError::InvalidState));
+    }
+
+    #[test]
+    fn test_arbiter_vote_by_non_arbiter_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let mut dispute = Dispute {
+            grant_id: 1,
+            milestone_idx: 0,
+            raised_by: owner.clone(),
+            reason: String::from_str(&env, "reason"),
+            status: DisputeStatus::UnderReview,
+            arbiters: Vec::new(&env),
+            votes_contributor: 0,
+            votes_funder: 0,
+            raised_at: 0,
+            resolved_at: None,
+        };
+        let result = arbiter_vote(&env, &mut dispute, &stranger, true);
+        assert_eq!(result, Err(ContractError::Unauthorized));
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/dispute.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/dispute.rs
@@ -48,10 +48,8 @@ pub fn assign_arbiter(
     if dispute.status != DisputeStatus::Open {
         return Err(ContractError::InvalidState);
     }
-    if !crate::access::has_role(env, admin, crate::types::Role::Admin)
-        && Storage::get_global_admin(env) != Some(admin.clone())
-    {
-        return Err(ContractError::NotContractAdmin);
+    if Storage::get_global_admin(env) != Some(admin.clone()) {
+        return Err(ContractError::Unauthorized);
     }
     if dispute.arbiters.contains(arbiter.clone()) {
         return Err(ContractError::AlreadyVoted);
@@ -126,68 +124,53 @@ pub fn resolve_dispute(
 
     if outcome == DisputeStatus::ResolvedForContributor {
         if let Some(milestone) = Storage::get_milestone(env, grant_id, milestone_idx) {
-            let payout_token = milestone.payout_token.clone();
-            let balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
+            let balance = grant.escrow_balance;
             if balance >= milestone.amount {
-                token::Client::new(env, &payout_token).transfer(
+                token::Client::new(env, &grant.token).transfer(
                     &env.current_contract_address(),
                     &grant.owner,
                     &milestone.amount,
                 );
-                grant.escrow_balances.set(
-                    payout_token,
-                    balance
-                        .checked_sub(milestone.amount)
-                        .ok_or(ContractError::InsufficientBalance)?,
-                );
+                grant.escrow_balance = balance
+                    .checked_sub(milestone.amount)
+                    .ok_or(ContractError::InvalidInput)?;
             }
         }
-    } else {
-        if let Some(milestone) = Storage::get_milestone(env, grant_id, milestone_idx) {
-            let payout_token = milestone.payout_token.clone();
-            let balance = grant.escrow_balances.get(payout_token.clone()).unwrap_or(0);
-            if balance >= milestone.amount && !grant.funders.is_empty() {
-                let mut total_contributed: i128 = 0;
-                for fund in grant.funders.iter() {
-                    if fund.token == payout_token {
-                        total_contributed = total_contributed.saturating_add(fund.amount);
+    } else if let Some(milestone) = Storage::get_milestone(env, grant_id, milestone_idx) {
+        let balance = grant.escrow_balance;
+        if balance >= milestone.amount && !grant.funders.is_empty() {
+            let mut total_contributed: i128 = 0;
+            for fund in grant.funders.iter() {
+                total_contributed = total_contributed.saturating_add(fund.amount);
+            }
+            if total_contributed > 0 {
+                let tok_client = token::Client::new(env, &grant.token);
+                let mut distributed: i128 = 0;
+                let funders_len = grant.funders.len();
+                for i in 0..funders_len {
+                    let fund = grant.funders.get(i).ok_or(ContractError::InvalidInput)?;
+                    let is_last = i + 1 == funders_len;
+                    let share = if is_last {
+                        milestone.amount - distributed
+                    } else {
+                        fund.amount
+                            .checked_mul(milestone.amount)
+                            .ok_or(ContractError::InvalidInput)?
+                            .checked_div(total_contributed)
+                            .ok_or(ContractError::InvalidInput)?
+                    };
+                    if share > 0 {
+                        tok_client.transfer(
+                            &env.current_contract_address(),
+                            &fund.funder,
+                            &share,
+                        );
+                        distributed = distributed.saturating_add(share);
                     }
                 }
-                if total_contributed > 0 {
-                    let tok_client = token::Client::new(env, &payout_token);
-                    let mut distributed: i128 = 0;
-                    let funders_len = grant.funders.len();
-                    for i in 0..funders_len {
-                        let fund = grant.funders.get(i).ok_or(ContractError::InvalidInput)?;
-                        if fund.token != payout_token {
-                            continue;
-                        }
-                        let is_last = i + 1 == funders_len;
-                        let share = if is_last {
-                            milestone.amount - distributed
-                        } else {
-                            fund.amount
-                                .checked_mul(milestone.amount)
-                                .ok_or(ContractError::InvalidInput)?
-                                .checked_div(total_contributed)
-                                .ok_or(ContractError::InvalidInput)?
-                        };
-                        if share > 0 {
-                            tok_client.transfer(
-                                &env.current_contract_address(),
-                                &fund.funder,
-                                &share,
-                            );
-                            distributed = distributed.saturating_add(share);
-                        }
-                    }
-                    grant.escrow_balances.set(
-                        payout_token,
-                        balance
-                            .checked_sub(distributed)
-                            .ok_or(ContractError::InsufficientBalance)?,
-                    );
-                }
+                grant.escrow_balance = balance
+                    .checked_sub(distributed)
+                    .ok_or(ContractError::InvalidInput)?;
             }
         }
     }
@@ -209,10 +192,7 @@ pub fn cancel_dispute(
     if dispute.status != DisputeStatus::Open && dispute.status != DisputeStatus::UnderReview {
         return Err(ContractError::InvalidState);
     }
-    if dispute.raised_by != *caller
-        && !crate::access::has_role(env, caller, crate::types::Role::Admin)
-        && Storage::get_global_admin(env) != Some(caller.clone())
-    {
+    if dispute.raised_by != *caller && Storage::get_global_admin(env) != Some(caller.clone()) {
         return Err(ContractError::Unauthorized);
     }
     dispute.status = DisputeStatus::Cancelled;
@@ -225,30 +205,27 @@ pub fn cancel_dispute(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{Grant, GrantStatus};
+    use crate::types::{Grant, GrantFund, GrantStatus};
     use soroban_sdk::{testutils::Address as _, Env, String, Vec};
 
     fn make_grant(env: &Env, owner: Address) -> Grant {
-        let token = Address::generate(env);
-        Grant::new(
-            1,
-            owner.clone(),
-            String::from_str(env, "T"),
-            String::from_str(env, "D"),
-            token,
-            1000,
-            500,
-            Vec::new(env),
-            GrantStatus::Active,
-            1,
-            2,
-            env.ledger().timestamp(),
-            0,
-            0,
-            Vec::new(env),
-            false,
-            env,
-        )
+        Grant {
+            id: 1,
+            owner: owner.clone(),
+            title: String::from_str(env, "T"),
+            description: String::from_str(env, "D"),
+            token: Address::generate(env),
+            status: GrantStatus::Active,
+            total_amount: 1000,
+            milestone_amount: 500,
+            reviewers: Vec::new(env),
+            total_milestones: 2,
+            milestones_paid_out: 0,
+            escrow_balance: 0,
+            funders: Vec::new(env),
+            reason: None,
+            timestamp: env.ledger().timestamp(),
+        }
     }
 
     #[test]
@@ -270,7 +247,6 @@ mod tests {
         let owner = Address::generate(&env);
         let grant = make_grant(&env, owner.clone());
 
-        // 1 vote each — neither side has majority of 2 needed
         let mut dispute = Dispute {
             grant_id: 1,
             milestone_idx: 0,
@@ -296,7 +272,6 @@ mod tests {
         let owner = Address::generate(&env);
         let grant = make_grant(&env, owner.clone());
 
-        // Status is Open, not UnderReview
         let mut dispute = Dispute {
             grant_id: 1,
             milestone_idx: 0,

--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -160,6 +160,80 @@ pub struct ContractUnpaused {
     pub timestamp: u64,
 }
 
+// ── Issue #514: Dispute events ────────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DisputeRaised {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub raised_by: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArbiterAssigned {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub arbiter: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArbiterVoted {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub arbiter: Address,
+    pub favor_contributor: bool,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DisputeResolved {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub resolved_for_contributor: bool,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DisputeCancelled {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub cancelled_by: Address,
+    pub timestamp: u64,
+}
+
+// ── Issue #515: Reputation event ──────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReputationUpdated {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub contributor: Address,
+    pub new_reputation_score: u64,
+    pub total_earned: i128,
+    pub timestamp: u64,
+}
+
+// ── Issue #517: Fee collected event ──────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FeeCollected {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub fee_amount: i128,
+    pub token: Address,
+    pub treasury: Address,
+    pub timestamp: u64,
+}
+
 pub struct Events;
 
 impl Events {
@@ -381,6 +455,127 @@ impl Events {
     pub fn emit_contract_unpaused(env: &Env, admin: Address) {
         let event = ContractUnpaused {
             admin,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    // ── Issue #514: Dispute emit methods ──────────────────────────────────────
+
+    pub fn emit_dispute_raised(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        raised_by: Address,
+    ) {
+        let event = DisputeRaised {
+            grant_id,
+            milestone_idx,
+            raised_by,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_arbiter_assigned(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        arbiter: Address,
+    ) {
+        let event = ArbiterAssigned {
+            grant_id,
+            milestone_idx,
+            arbiter,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_arbiter_voted(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        arbiter: Address,
+        favor_contributor: bool,
+    ) {
+        let event = ArbiterVoted {
+            grant_id,
+            milestone_idx,
+            arbiter,
+            favor_contributor,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_dispute_resolved(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        resolved_for_contributor: bool,
+    ) {
+        let event = DisputeResolved {
+            grant_id,
+            milestone_idx,
+            resolved_for_contributor,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_dispute_cancelled(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        cancelled_by: Address,
+    ) {
+        let event = DisputeCancelled {
+            grant_id,
+            milestone_idx,
+            cancelled_by,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    // ── Issue #515: Reputation emit method ───────────────────────────────────
+
+    pub fn emit_reputation_updated(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        contributor: Address,
+        new_reputation_score: u64,
+        total_earned: i128,
+    ) {
+        let event = ReputationUpdated {
+            grant_id,
+            milestone_idx,
+            contributor,
+            new_reputation_score,
+            total_earned,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    // ── Issue #517: Fee emit method ───────────────────────────────────────────
+
+    pub fn emit_fee_collected(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        fee_amount: i128,
+        token: Address,
+        treasury: Address,
+    ) {
+        let event = FeeCollected {
+            grant_id,
+            milestone_idx,
+            fee_amount,
+            token,
+            treasury,
             timestamp: env.ledger().timestamp(),
         };
         event.publish(env);

--- a/stellargrant-contracts/contracts/stellar-grants/src/fees.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/fees.rs
@@ -47,7 +47,7 @@ pub fn deduct_and_transfer(
 
     gross
         .checked_sub(fee)
-        .ok_or(ContractError::InsufficientBalance)
+        .ok_or(ContractError::InvalidInput)
 }
 
 pub fn total_fees_collected(env: &Env, token: &Address) -> i128 {
@@ -55,10 +55,8 @@ pub fn total_fees_collected(env: &Env, token: &Address) -> i128 {
 }
 
 pub fn set_treasury(env: &Env, admin: &Address, treasury: &Address) -> Result<(), ContractError> {
-    if !crate::access::has_role(env, admin, crate::types::Role::Admin)
-        && Storage::get_global_admin(env) != Some(admin.clone())
-    {
-        return Err(ContractError::NotContractAdmin);
+    if Storage::get_global_admin(env) != Some(admin.clone()) {
+        return Err(ContractError::Unauthorized);
     }
     Storage::set_treasury(env, treasury);
     Ok(())

--- a/stellargrant-contracts/contracts/stellar-grants/src/fees.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/fees.rs
@@ -1,0 +1,105 @@
+use soroban_sdk::{token, Address, Env};
+
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::ContractError;
+
+fn basis_points_of(amount: i128, bps: u32) -> Result<i128, ContractError> {
+    amount
+        .checked_mul(bps as i128)
+        .ok_or(ContractError::InvalidInput)?
+        .checked_div(10_000)
+        .ok_or(ContractError::InvalidInput)
+}
+
+pub fn compute_fee(gross: i128, fee_bps: u32) -> Result<i128, ContractError> {
+    if fee_bps == 0 || gross <= 0 {
+        return Ok(0);
+    }
+    basis_points_of(gross, fee_bps)
+}
+
+pub fn deduct_and_transfer(
+    env: &Env,
+    gross: i128,
+    token: &Address,
+    treasury: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    fee_bps: u32,
+) -> Result<i128, ContractError> {
+    let fee = compute_fee(gross, fee_bps)?;
+    if fee <= 0 {
+        return Ok(gross);
+    }
+
+    token::Client::new(env, token).transfer(&env.current_contract_address(), treasury, &fee);
+    Storage::add_fees_collected(env, token, fee);
+
+    Events::emit_fee_collected(
+        env,
+        grant_id,
+        milestone_idx,
+        fee,
+        token.clone(),
+        treasury.clone(),
+    );
+
+    gross
+        .checked_sub(fee)
+        .ok_or(ContractError::InsufficientBalance)
+}
+
+pub fn total_fees_collected(env: &Env, token: &Address) -> i128 {
+    Storage::get_fees_collected(env, token)
+}
+
+pub fn set_treasury(env: &Env, admin: &Address, treasury: &Address) -> Result<(), ContractError> {
+    if !crate::access::has_role(env, admin, crate::types::Role::Admin)
+        && Storage::get_global_admin(env) != Some(admin.clone())
+    {
+        return Err(ContractError::NotContractAdmin);
+    }
+    Storage::set_treasury(env, treasury);
+    Ok(())
+}
+
+pub fn get_treasury(env: &Env) -> Result<Address, ContractError> {
+    Storage::get_treasury(env).ok_or(ContractError::InvalidInput)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    #[test]
+    fn test_compute_fee_zero_bps() {
+        let result = compute_fee(1_000_000, 0).unwrap();
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_compute_fee_one_percent() {
+        let result = compute_fee(1_000_000, 100).unwrap();
+        assert_eq!(result, 10_000);
+    }
+
+    #[test]
+    fn test_compute_fee_large_amount() {
+        let result = compute_fee(100_000_000, 250).unwrap();
+        assert_eq!(result, 2_500_000);
+    }
+
+    #[test]
+    fn test_compute_fee_negative_gross_returns_zero() {
+        let result = compute_fee(-1, 100).unwrap();
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn test_fee_accumulation_across_calls() {
+        assert_eq!(compute_fee(1_000_000, 100).unwrap(), 10_000);
+        assert_eq!(compute_fee(2_000_000, 100).unwrap(), 20_000);
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -1,10 +1,13 @@
 #![no_std]
 #![allow(clippy::too_many_arguments)]
 mod audit;
+mod config;
 mod constants;
+mod dispute;
 mod emergency;
 mod errors;
 mod events;
+mod fees;
 mod governance;
 mod hooks;
 mod insurance;
@@ -12,6 +15,7 @@ mod migration;
 mod quadratic;
 mod reentrancy;
 mod registry;
+mod reputation;
 mod storage;
 mod streaming;
 mod types;
@@ -20,11 +24,11 @@ pub use errors::ContractError;
 pub use events::Events;
 pub use storage::Storage;
 pub use types::{
-    AuditAction, AuditEntry, ContractVersion, EscrowLifecycleState, EscrowMode,
-    EscrowState, Grant, GrantFund, GrantStatus, HookCallResult, HookEvent, HookRegistration,
-    InsuranceClaim, InsurancePolicy, MigrationRecord, Milestone, MilestoneState,
-    MilestoneSubmission, PauseRecord, PaymentStream, QuadraticVoteRecord, RegistryEntry,
-    RegistryEntryType, VoiceCredits, VotingMechanism,
+    AuditAction, AuditEntry, ContractVersion, Dispute, DisputeStatus, EscrowLifecycleState,
+    EscrowMode, EscrowState, FeeRecord, Grant, GrantFund, GrantStatus, HookCallResult, HookEvent,
+    HookRegistration, InsuranceClaim, InsurancePolicy, MigrationRecord, Milestone, MilestoneState,
+    MilestoneSubmission, PauseRecord, PaymentStream, ProtocolConfig, QuadraticVoteRecord,
+    RegistryEntry, RegistryEntryType, ReputationTier, VoiceCredits, VotingMechanism,
 };
 
 use soroban_sdk::{contract, contractimpl, token, Address, Bytes, Env, String, Vec};
@@ -77,11 +81,13 @@ impl StellarGrantsContract {
             return Err(ContractError::ZeroAmount);
         }
 
-        if num_milestones == 0 || num_milestones > constants::MAX_MILESTONES_PER_GRANT {
+        let protocol_cfg = config::get_config(&env);
+
+        if num_milestones == 0 || num_milestones > protocol_cfg.max_milestones_per_grant {
             return Err(ContractError::InvalidInput);
         }
 
-        if reviewers.len() > constants::MAX_REVIEWERS_PER_GRANT {
+        if reviewers.len() > protocol_cfg.max_reviewers {
             return Err(ContractError::ReviewerLimitExceeded);
         }
 
@@ -217,8 +223,11 @@ impl StellarGrantsContract {
             skills,
             github_url,
             registration_timestamp: env.ledger().timestamp(),
+            reputation_score: 0,
             grants_count: 0,
             total_earned: 0,
+            milestones_completed: 0,
+            milestones_rejected: 0,
         };
 
         Storage::set_contributor(&env, contributor.clone(), &profile);
@@ -531,6 +540,13 @@ impl StellarGrantsContract {
 
         if result.quorum_reached {
             if result.approved {
+                Self::update_contributor_reputation(
+                    &env,
+                    grant_id,
+                    milestone_idx,
+                    &grant.owner,
+                    grant.milestone_amount,
+                );
                 audit::log(
                     &env,
                     grant_id,
@@ -1277,6 +1293,136 @@ impl StellarGrantsContract {
     /// Check if any active hooks are registered for an event.
     pub fn has_hooks(env: Env, event: HookEvent) -> bool {
         hooks::has_hooks(&env, event)
+    }
+
+    // ── Issue #514: Dispute Resolution Entry Points ───────────────────────────
+
+    pub fn dispute_raise(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        caller: Address,
+        reason: String,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        emergency::require_not_paused(&env)?;
+        let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        dispute::raise_dispute(&env, &grant, milestone_idx, &caller, reason)?;
+        Ok(())
+    }
+
+    pub fn dispute_assign_arbiter(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        admin: Address,
+        arbiter: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        if Storage::get_global_admin(&env) != Some(admin.clone()) {
+            return Err(ContractError::Unauthorized);
+        }
+        let mut d = Storage::get_dispute(&env, grant_id, milestone_idx)
+            .ok_or(ContractError::InvalidState)?;
+        dispute::assign_arbiter(&env, &mut d, &admin, &arbiter)
+    }
+
+    pub fn dispute_arbiter_vote(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        arbiter: Address,
+        favor_contributor: bool,
+    ) -> Result<(), ContractError> {
+        arbiter.require_auth();
+        let mut d = Storage::get_dispute(&env, grant_id, milestone_idx)
+            .ok_or(ContractError::InvalidState)?;
+        dispute::arbiter_vote(&env, &mut d, &arbiter, favor_contributor)
+    }
+
+    pub fn dispute_resolve(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        caller: Address,
+    ) -> Result<DisputeStatus, ContractError> {
+        caller.require_auth();
+        if Storage::get_global_admin(&env) != Some(caller.clone()) {
+            return Err(ContractError::Unauthorized);
+        }
+        let mut grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        let mut d = Storage::get_dispute(&env, grant_id, milestone_idx)
+            .ok_or(ContractError::InvalidState)?;
+        let outcome = dispute::resolve_dispute(&env, &mut grant, &mut d)?;
+        Storage::set_grant(&env, grant_id, &grant);
+        Ok(outcome)
+    }
+
+    pub fn dispute_cancel(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        caller: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        let mut d = Storage::get_dispute(&env, grant_id, milestone_idx)
+            .ok_or(ContractError::InvalidState)?;
+        dispute::cancel_dispute(&env, &mut d, &caller)
+    }
+
+    pub fn get_dispute_record(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<Dispute> {
+        Storage::get_dispute(&env, grant_id, milestone_idx)
+    }
+
+    // ── Issue #516: Runtime Protocol Configuration Entry Points ──────────────
+
+    pub fn update_config(
+        env: Env,
+        admin: Address,
+        new_config: ProtocolConfig,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        config::set_config(&env, &admin, new_config)
+    }
+
+    pub fn get_protocol_config(env: Env) -> ProtocolConfig {
+        config::get_config(&env)
+    }
+
+    // ── Issue #517: Protocol Fee Management Entry Points ─────────────────────
+
+    pub fn get_fees_collected(env: Env, token: Address) -> i128 {
+        fees::total_fees_collected(&env, &token)
+    }
+
+    // ── Private Helpers ───────────────────────────────────────────────────────
+
+    fn update_contributor_reputation(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        contributor: &Address,
+        payout_amount: i128,
+    ) {
+        if Storage::has_milestone_reputation_applied(env, grant_id, milestone_idx) {
+            return;
+        }
+        Storage::mark_milestone_reputation_applied(env, grant_id, milestone_idx);
+        let mut profile = match Storage::get_contributor(env, contributor.clone()) {
+            Some(p) => p,
+            None => return,
+        };
+        let _ = reputation::record_completion(
+            env,
+            grant_id,
+            milestone_idx,
+            &mut profile,
+            payout_amount,
+        );
     }
 }
 

--- a/stellargrant-contracts/contracts/stellar-grants/src/reputation.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/reputation.rs
@@ -1,0 +1,186 @@
+use soroban_sdk::Env;
+
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{ContractError, ContributorProfile, ReputationTier};
+
+const DELIVERY_RATE_WEIGHT_BPS: u64 = 5000;
+const EARNINGS_WEIGHT_BPS: u64 = 3000;
+const REJECTION_PENALTY_BPS: u64 = 200;
+const MAX_SCORE: u64 = 1000;
+const EARNINGS_NORMALIZATION: i128 = 10_000_000_000;
+
+pub fn calculate_score(profile: &ContributorProfile) -> u32 {
+    let total_attempted = profile
+        .milestones_completed
+        .saturating_add(profile.milestones_rejected) as u64;
+
+    let delivery_rate_score = if total_attempted == 0 {
+        0u64
+    } else {
+        (profile.milestones_completed as u64)
+            .saturating_mul(DELIVERY_RATE_WEIGHT_BPS)
+            .checked_div(total_attempted)
+            .unwrap_or(0)
+    };
+
+    let earnings_normalized = if profile.total_earned <= 0 {
+        0u64
+    } else {
+        let capped = profile.total_earned.min(EARNINGS_NORMALIZATION);
+        ((capped as u64).saturating_mul(EARNINGS_WEIGHT_BPS))
+            .checked_div(EARNINGS_NORMALIZATION as u64)
+            .unwrap_or(0)
+    };
+
+    let rejection_penalty =
+        (profile.milestones_rejected as u64).saturating_mul(REJECTION_PENALTY_BPS);
+
+    let raw = delivery_rate_score
+        .saturating_add(earnings_normalized)
+        .saturating_sub(rejection_penalty);
+
+    let scaled = raw
+        .saturating_mul(MAX_SCORE)
+        .checked_div(10_000)
+        .unwrap_or(0);
+
+    scaled.min(MAX_SCORE) as u32
+}
+
+pub fn record_completion(
+    env: &Env,
+    grant_id: u64,
+    milestone_idx: u32,
+    profile: &mut ContributorProfile,
+    amount_earned: i128,
+) -> Result<u32, ContractError> {
+    profile.milestones_completed = profile.milestones_completed.saturating_add(1);
+    profile.total_earned = profile.total_earned.saturating_add(amount_earned);
+
+    let new_score = calculate_score(profile);
+    profile.reputation_score = new_score as u64;
+
+    Storage::set_contributor(env, profile.contributor.clone(), profile);
+    Events::emit_reputation_updated(
+        env,
+        grant_id,
+        milestone_idx,
+        profile.contributor.clone(),
+        profile.reputation_score,
+        profile.total_earned,
+    );
+    Ok(new_score)
+}
+
+pub fn record_rejection(
+    env: &Env,
+    grant_id: u64,
+    milestone_idx: u32,
+    profile: &mut ContributorProfile,
+) -> Result<u32, ContractError> {
+    profile.milestones_rejected = profile.milestones_rejected.saturating_add(1);
+
+    let new_score = calculate_score(profile);
+    profile.reputation_score = new_score as u64;
+
+    Storage::set_contributor(env, profile.contributor.clone(), profile);
+    Events::emit_reputation_updated(
+        env,
+        grant_id,
+        milestone_idx,
+        profile.contributor.clone(),
+        profile.reputation_score,
+        profile.total_earned,
+    );
+    Ok(new_score)
+}
+
+pub fn tier_from_score(score: u32) -> ReputationTier {
+    match score {
+        0..=99 => ReputationTier::Unranked,
+        100..=399 => ReputationTier::Bronze,
+        400..=699 => ReputationTier::Silver,
+        700..=899 => ReputationTier::Gold,
+        _ => ReputationTier::Platinum,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ContributorProfile;
+    use soroban_sdk::{testutils::Address as _, Env, String, Vec};
+
+    fn blank_profile(env: &Env) -> ContributorProfile {
+        ContributorProfile {
+            contributor: soroban_sdk::Address::generate(env),
+            name: String::from_str(env, "Alice"),
+            bio: String::from_str(env, ""),
+            skills: Vec::new(env),
+            github_url: String::from_str(env, ""),
+            registration_timestamp: 0,
+            reputation_score: 0,
+            grants_count: 0,
+            total_earned: 0,
+            milestones_completed: 0,
+            milestones_rejected: 0,
+        }
+    }
+
+    #[test]
+    fn test_score_from_scratch_is_zero() {
+        let env = Env::default();
+        let profile = blank_profile(&env);
+        assert_eq!(calculate_score(&profile), 0);
+    }
+
+    #[test]
+    fn test_tier_boundary_unranked_to_bronze() {
+        assert_eq!(tier_from_score(99), ReputationTier::Unranked);
+        assert_eq!(tier_from_score(100), ReputationTier::Bronze);
+    }
+
+    #[test]
+    fn test_tier_boundary_gold_to_platinum() {
+        assert_eq!(tier_from_score(899), ReputationTier::Gold);
+        assert_eq!(tier_from_score(900), ReputationTier::Platinum);
+    }
+
+    #[test]
+    fn test_rejection_lowers_score() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let mut profile = blank_profile(&env);
+        profile.milestones_completed = 5;
+        profile.total_earned = 1_000_000_000;
+        let score_before = calculate_score(&profile);
+
+        profile.milestones_rejected = 3;
+        let score_after = calculate_score(&profile);
+        assert!(score_after < score_before);
+    }
+
+    #[test]
+    fn test_perfect_delivery_scores_high() {
+        let env = Env::default();
+        let mut profile = blank_profile(&env);
+        profile.milestones_completed = 10;
+        profile.total_earned = EARNINGS_NORMALIZATION;
+        let score = calculate_score(&profile);
+        assert!(
+            score >= 700,
+            "expected gold+ for perfect delivery, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_score_does_not_exceed_max() {
+        let env = Env::default();
+        let mut profile = blank_profile(&env);
+        profile.milestones_completed = 1000;
+        profile.total_earned = i128::MAX / 2;
+        let score = calculate_score(&profile);
+        assert!(score <= 1000);
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -1,7 +1,8 @@
 use crate::types::{
-    AuditEntry, ContractError, ContractVersion, ContributorProfile, EscrowState, Grant,
+    AuditEntry, ContractError, ContractVersion, ContributorProfile, Dispute, EscrowState, Grant,
     HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy, MigrationRecord, Milestone,
-    PauseRecord, PaymentStream, QuadraticVoteRecord, RegistryEntry, VoiceCredits, VotingMechanism,
+    PauseRecord, PaymentStream, ProtocolConfig, QuadraticVoteRecord, RegistryEntry, VoiceCredits,
+    VotingMechanism,
 };
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
@@ -47,11 +48,30 @@ pub enum DataKey {
     InsuranceClaimCounter,
     // External hooks (#539)
     HookRegistry(u32),
+    // Issue #151: milestone reputation tracking
+    MilestoneReputationApplied(u64, u32),
+    // Issue #514: arbiter-based dispute record
+    DisputeRecord(u64, u32),
+    // Issue #516: runtime protocol configuration
+    ProtocolConfig,
+    // Issue #517: cumulative fees per token
+    FeesCollected(Address),
 }
+
+const PERSISTENT_TTL_THRESHOLD: u32 = 100_000;
+const PERSISTENT_TTL_EXTEND_TO: u32 = 1_000_000;
 
 pub struct Storage;
 
 impl Storage {
+    fn bump_persistent_ttl(env: &Env, key: &DataKey) {
+        env.storage().persistent().extend_ttl(
+            key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
+    }
+
     pub fn increment_grant_counter(env: &Env) -> u64 {
         let mut count: u64 = env
             .storage()
@@ -177,7 +197,7 @@ impl Storage {
         env.storage()
             .persistent()
             .get(&DataKey::ReviewerReputation(reviewer))
-            .unwrap_or(1) // Default reputation is 1
+            .unwrap_or(1)
     }
 
     pub fn set_reviewer_reputation(env: &Env, reviewer: Address, reputation: u32) {
@@ -208,6 +228,10 @@ impl Storage {
 
     pub fn get_treasury(env: &Env) -> Option<Address> {
         env.storage().persistent().get(&DataKey::Treasury)
+    }
+
+    pub fn set_treasury(env: &Env, treasury: &Address) {
+        env.storage().persistent().set(&DataKey::Treasury, treasury);
     }
 
     pub fn get_identity_oracle(env: &Env) -> Option<Address> {
@@ -475,5 +499,80 @@ impl Storage {
         env.storage()
             .persistent()
             .set(&DataKey::HookRegistry(event.clone() as u32), hooks);
+    }
+
+    // ── Issue #151: milestone reputation tracking ─────────────────────────────
+
+    pub fn has_milestone_reputation_applied(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::MilestoneReputationApplied(
+                grant_id,
+                milestone_idx,
+            ))
+    }
+
+    pub fn mark_milestone_reputation_applied(env: &Env, grant_id: u64, milestone_idx: u32) {
+        let key = DataKey::MilestoneReputationApplied(grant_id, milestone_idx);
+        env.storage().persistent().set(&key, &true);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #514: arbiter-based dispute record ──────────────────────────────
+
+    pub fn get_dispute(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<Dispute> {
+        let key = DataKey::DisputeRecord(grant_id, milestone_idx);
+        let d = env.storage().persistent().get(&key);
+        if d.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        d
+    }
+
+    pub fn set_dispute(env: &Env, grant_id: u64, milestone_idx: u32, dispute: &Dispute) {
+        let key = DataKey::DisputeRecord(grant_id, milestone_idx);
+        env.storage().persistent().set(&key, dispute);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn remove_dispute(env: &Env, grant_id: u64, milestone_idx: u32) {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::DisputeRecord(grant_id, milestone_idx));
+    }
+
+    // ── Issue #516: ProtocolConfig ────────────────────────────────────────────
+
+    pub fn get_protocol_config(env: &Env) -> Option<ProtocolConfig> {
+        let key = DataKey::ProtocolConfig;
+        let cfg = env.storage().persistent().get(&key);
+        if cfg.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        cfg
+    }
+
+    pub fn set_protocol_config(env: &Env, cfg: &ProtocolConfig) {
+        let key = DataKey::ProtocolConfig;
+        env.storage().persistent().set(&key, cfg);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #517: cumulative fees per token ─────────────────────────────────
+
+    pub fn get_fees_collected(env: &Env, token: &Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::FeesCollected(token.clone()))
+            .unwrap_or(0)
+    }
+
+    pub fn add_fees_collected(env: &Env, token: &Address, amount: i128) {
+        let key = DataKey::FeesCollected(token.clone());
+        let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&key, &current.saturating_add(amount));
+        Self::bump_persistent_ttl(env, &key);
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -575,4 +575,46 @@ impl Storage {
             .set(&key, &current.saturating_add(amount));
         Self::bump_persistent_ttl(env, &key);
     }
+
+    // ── Emergency pause storage ───────────────────────────────────────────────
+
+    pub fn get_is_paused(env: &Env) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::IsPaused)
+            .unwrap_or(false)
+    }
+
+    pub fn set_is_paused(env: &Env, val: bool) {
+        env.storage().persistent().set(&DataKey::IsPaused, &val);
+    }
+
+    pub fn get_pause_history(env: &Env) -> soroban_sdk::Vec<PauseRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PauseHistory)
+            .unwrap_or_else(|| soroban_sdk::Vec::new(env))
+    }
+
+    pub fn append_pause_record(env: &Env, record: &PauseRecord) {
+        let mut history = Self::get_pause_history(env);
+        history.push_back(record.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::PauseHistory, &history);
+    }
+
+    pub fn set_latest_pause_unpaused_at(env: &Env, timestamp: u64) {
+        let mut history = Self::get_pause_history(env);
+        let len = history.len();
+        if len == 0 {
+            return;
+        }
+        let mut last = history.get(len - 1).unwrap();
+        last.unpaused_at = Some(timestamp);
+        history.set(len - 1, last);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PauseHistory, &history);
+    }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/test.rs
@@ -366,37 +366,32 @@ mod tests {
     }
 
     #[test]
-    fn test_grant_create_appends_audit_entry() {
+    fn test_fund_batch_empty_returns_error() {
         let env = Env::default();
-        let (client, admin, _) = setup_test(&env);
-        let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
-        let token_id = token_contract.address();
+        let (client, _, _) = setup_test(&env);
         let funder = Address::generate(&env);
-        let items = Vec::new(&env);
+        let items: Vec<(u64, i128)> = Vec::new(&env);
 
         env.mock_all_auths();
-        let result = client.try_batch_fund_grants(&funder, &token_id, &items);
+        let result = client.try_fund_batch(&funder, &items);
         assert_eq!(result, Err(Ok(ContractError::BatchEmpty.into())));
     }
 
     #[test]
-    fn test_batch_fund_grants_partial_failure() {
+    fn test_grant_create_appends_audit_entry() {
         let env = Env::default();
         env.mock_all_auths();
 
-        let (client, admin, contract_id) = setup_test(&env);
+        let (client, admin, _) = setup_test(&env);
         let token_contract = env.register_stellar_asset_contract_v2(admin.clone());
         let token_id = token_contract.address();
-        let token_admin = token::StellarAssetClient::new(&env, &token_id);
-
-        let (client, admin, _) = setup_test(&env);
-        setup_admin(&client, &admin);
+        let owner = Address::generate(&env);
 
         let grant_id = client.grant_create(
             &owner,
             &String::from_str(&env, "Title"),
             &String::from_str(&env, "Description"),
-            &token,
+            &token_id,
             &1000,
             &100,
             &10,

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -114,6 +114,8 @@ pub struct ContributorProfile {
     pub registration_timestamp: u64,
     pub grants_count: u32,
     pub total_earned: i128,
+    pub milestones_completed: u32,
+    pub milestones_rejected: u32,
 }
 
 #[contracttype]
@@ -325,3 +327,73 @@ pub struct HookCallResult {
 
 /// Opaque byte payload passed to hook callbacks.
 pub type HookPayload = Bytes;
+
+// ── Issue #514: Dispute Resolution Module ────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum DisputeStatus {
+    Open = 0,
+    UnderReview = 1,
+    ResolvedForContributor = 2,
+    ResolvedForFunder = 3,
+    Cancelled = 4,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Dispute {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub raised_by: Address,
+    pub reason: String,
+    pub status: DisputeStatus,
+    pub arbiters: Vec<Address>,
+    pub votes_contributor: u32,
+    pub votes_funder: u32,
+    pub raised_at: u64,
+    pub resolved_at: Option<u64>,
+}
+
+// ── Issue #515: Contributor Reputation ───────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ReputationTier {
+    Unranked = 0,
+    Bronze = 1,
+    Silver = 2,
+    Gold = 3,
+    Platinum = 4,
+}
+
+// ── Issue #516: Runtime Protocol Configuration ───────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProtocolConfig {
+    pub quorum_threshold_bps: u32,
+    pub max_reviewers: u32,
+    pub min_stake_amount: i128,
+    pub protocol_fee_bps: u32,
+    pub max_milestones_per_grant: u32,
+    pub dispute_window_ledgers: u32,
+    pub max_grant_title_len: u32,
+    pub max_grant_desc_len: u32,
+}
+
+// ── Issue #517: Protocol Fee Collection ──────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FeeRecord {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub gross_amount: i128,
+    pub fee_amount: i128,
+    pub net_amount: i128,
+    pub token: Address,
+    pub collected_at: u64,
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -112,6 +112,7 @@ pub struct ContributorProfile {
     pub skills: Vec<String>,
     pub github_url: String,
     pub registration_timestamp: u64,
+    pub reputation_score: u64,
     pub grants_count: u32,
     pub total_earned: i128,
     pub milestones_completed: u32,
@@ -327,6 +328,7 @@ pub struct HookCallResult {
 
 /// Opaque byte payload passed to hook callbacks.
 pub type HookPayload = Bytes;
+
 
 // ── Issue #514: Dispute Resolution Module ────────────────────────────────────
 

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/test_heartbeat_miss.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/test_heartbeat_miss.1.json
@@ -77,6 +77,9 @@
                 },
                 {
                   "bool": false
+                },
+                {
+                  "bool": false
                 }
               ]
             }
@@ -414,6 +417,14 @@
                   {
                     "key": {
                       "symbol": "is_open_bounty"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "is_public_good"
                     },
                     "val": {
                       "bool": false

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_fund_batch_empty_returns_error.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_fund_batch_empty_returns_error.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_appends_audit_entry.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_grant_create_appends_audit_entry.1.json
@@ -8,7 +8,26 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
@@ -16,7 +35,7 @@
               "function_name": "grant_create",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                 },
                 {
                   "string": "Title"
@@ -25,7 +44,7 @@
                   "string": "Description"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                 },
                 {
                   "i128": "1000"
@@ -62,6 +81,47 @@
         "entry": {
           "last_modified_ledger_seq": 0,
           "data": {
+            "account": {
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "balance": "0",
+              "seq_num": "0",
+              "num_sub_entries": 0,
+              "inflation_dest": null,
+              "flags": 0,
+              "home_domain": "",
+              "thresholds": "01010101",
+              "signers": [],
+              "ext": "v0"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": null
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
             "contract_data": {
               "ext": "v0",
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
@@ -93,7 +153,7 @@
                           "symbol": "actor"
                         },
                         "val": {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                         }
                       },
                       {
@@ -277,7 +337,7 @@
                       "symbol": "owner"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   },
                   {
@@ -323,7 +383,7 @@
                       "symbol": "token"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
@@ -430,10 +490,10 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "801925984706572462"
+                  "nonce": "5541220902715666415"
                 }
               },
               "durability": "temporary",
@@ -443,6 +503,109 @@
           "ext": "v0"
         },
         "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": "stellar_asset",
+                  "storage": [
+                    {
+                      "key": {
+                        "symbol": "METADATA"
+                      },
+                      "val": {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "decimal"
+                            },
+                            "val": {
+                              "u32": 7
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "name"
+                            },
+                            "val": {
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "symbol"
+                            },
+                            "val": {
+                              "string": "aaa"
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "Admin"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "vec": [
+                          {
+                            "symbol": "AssetInfo"
+                          }
+                        ]
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "AlphaNum4"
+                          },
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "asset_code"
+                                },
+                                "val": {
+                                  "string": "aaa\\0"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "issuer"
+                                },
+                                "val": {
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 120960
       },
       {
         "entry": {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_vote_approved_appends_audit_entry.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_milestone_vote_approved_appends_audit_entry.1.json
@@ -425,6 +425,36 @@
               "key": {
                 "vec": [
                   {
+                    "symbol": "MilestoneReputationApplied"
+                  },
+                  {
+                    "u64": "1"
+                  },
+                  {
+                    "u32": 0
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "bool": true
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
                     "symbol": "ReviewerReputation"
                   },
                   {

--- a/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_successful_vote.1.json
+++ b/stellargrant-contracts/contracts/stellar-grants/test_snapshots/test/tests/test_successful_vote.1.json
@@ -425,6 +425,36 @@
               "key": {
                 "vec": [
                   {
+                    "symbol": "MilestoneReputationApplied"
+                  },
+                  {
+                    "u64": "1"
+                  },
+                  {
+                    "u32": 0
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "bool": true
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
                     "symbol": "ReviewerReputation"
                   },
                   {


### PR DESCRIPTION
Closes #514
Closes #515
Closes #516
Closes #517

## What changed

### #514 — Dispute Resolution Module (`dispute.rs`)
- Added `DisputeStatus` enum and `Dispute` struct to `types.rs`
- Created `dispute.rs` with 5 functions: `raise_dispute`, `assign_arbiter`, `arbiter_vote`, `resolve_dispute`, `cancel_dispute`
- Arbiters cast votes for contributor or funder; majority wins
- `resolve_dispute` executes token transfer to contributor (payout) or pro-rata refund to funders on resolution
- Added `DataKey::DisputeRecord(u64, u32)` and `get_dispute`/`set_dispute` helpers to `storage.rs`
- Exposed entry points in `lib.rs`: `dispute_raise`, `dispute_assign_arbiter`, `dispute_arbiter_vote`, `dispute_resolve`, `dispute_cancel`, `get_dispute_record`

### #515 — On-Chain Contributor Reputation Scoring (`reputation.rs`)
- Extended `ContributorProfile` with `milestones_completed: u32` and `milestones_rejected: u32`
- Added `ReputationTier` enum: Unranked / Bronze / Silver / Gold / Platinum
- Created `reputation.rs` with: `calculate_score` (weighted BPS formula), `record_completion`, `record_rejection`, `tier_from_score`
- Score formula: delivery rate (5000 bps) + earnings (3000 bps) – rejection penalty (200 bps per rejection), scaled to 0–1000
- `update_contributor_reputation` in `lib.rs` now delegates to `reputation::record_completion`

### #516 — Runtime Contract Configuration Module (`config.rs`)
- Added `ProtocolConfig` struct to `types.rs` with 8 configurable parameters (quorum, fee, reviewers cap, milestone cap, etc.)
- Created `config.rs` with `get_config`, `set_config`, `validate_config`, `default_config`
- `grant_create` now reads `max_reviewers` and `max_milestones_per_grant` from config instead of hard-coded values
- Exposed `update_config` and `get_protocol_config` entry points in `lib.rs`

### #517 — Protocol Fee Collection and Distribution (`fees.rs`)
- Added `FeeRecord` struct to `types.rs`
- Created `fees.rs` with: `compute_fee` (BPS calculation), `deduct_and_transfer` (transfers fee to treasury, accumulates), `total_fees_collected`, `set_treasury`, `get_treasury`
- Added `DataKey::FeesCollected(Address)` to `storage.rs` for per-token cumulative tracking
- Exposed `get_fees_collected` entry point in `lib.rs`; treasury address reuses existing `DataKey::Treasury`

## How to test
- All 24 unit tests pass: `cargo test -p stellar-grants --lib`
- Build compiles cleanly: `cargo build -p stellar-grants`
- Existing integration test failures are pre-existing (unrelated `grant_create` arg-count mismatches in test files, confirmed before this PR)