### PR TITLE
feat: escrow extraction, M-of-N multisig, protocol metrics, KYC compliance

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/audit.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/audit.rs
@@ -30,6 +30,7 @@ pub fn get_log(env: &Env, grant_id: u64) -> Vec<AuditEntry> {
 }
 
 /// Return the last N entries from the audit log.
+#[allow(dead_code)]
 pub fn get_recent(env: &Env, grant_id: u64, n: u32) -> Vec<AuditEntry> {
     let log = Storage::get_audit_log(env, grant_id);
     let len = log.len();
@@ -37,7 +38,7 @@ pub fn get_recent(env: &Env, grant_id: u64, n: u32) -> Vec<AuditEntry> {
         return Vec::new(env);
     }
 
-    let start = if len > n { len - n } else { 0 };
+    let start = len.saturating_sub(n);
     let mut result = Vec::new(env);
     for i in start..len {
         result.push_back(log.get(i).unwrap());
@@ -46,6 +47,7 @@ pub fn get_recent(env: &Env, grant_id: u64, n: u32) -> Vec<AuditEntry> {
 }
 
 /// Return the count of audit entries for a grant.
+#[allow(dead_code)]
 pub fn log_length(env: &Env, grant_id: u64) -> u32 {
     Storage::get_audit_log(env, grant_id).len()
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/compliance.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/compliance.rs
@@ -1,0 +1,133 @@
+use soroban_sdk::{Address, Env, String};
+
+use crate::errors::ContractError;
+use crate::events::{ComplianceAttested, ComplianceRevoked};
+use crate::storage::Storage;
+use crate::types::{ComplianceAttestation, ComplianceLevel, ComplianceStatus};
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Register a trusted compliance verifier address. Admin only.
+pub fn set_verifier(env: &Env, admin: &Address, verifier: &Address) -> Result<(), ContractError> {
+    if Storage::get_global_admin(env) != Some(admin.clone()) {
+        return Err(ContractError::Unauthorized);
+    }
+    Storage::set_compliance_verifier(env, verifier);
+    Ok(())
+}
+
+/// A trusted verifier attests the compliance status of a subject address.
+/// No personal data is stored — only status, level, jurisdiction code, and timestamps.
+pub fn attest(
+    env: &Env,
+    verifier: &Address,
+    subject: &Address,
+    status: ComplianceStatus,
+    level: ComplianceLevel,
+    expires_at: u64,
+    jurisdiction: String,
+) -> Result<(), ContractError> {
+    let registered_verifier =
+        Storage::get_compliance_verifier(env).ok_or(ContractError::VerifierNotSet)?;
+    if *verifier != registered_verifier {
+        return Err(ContractError::NotVerifier);
+    }
+
+    let now = env.ledger().timestamp();
+    let level_u32 = level.clone() as u32;
+
+    let attestation = ComplianceAttestation {
+        subject: subject.clone(),
+        status,
+        level,
+        attested_by: verifier.clone(),
+        attested_at: now,
+        expires_at,
+        jurisdiction,
+    };
+    Storage::set_compliance_attestation(env, &attestation);
+
+    ComplianceAttested {
+        subject: subject.clone(),
+        attested_by: verifier.clone(),
+        level: level_u32,
+        expires_at,
+        timestamp: now,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Revoke a compliance attestation. Verifier or admin only.
+pub fn revoke(env: &Env, revoker: &Address, subject: &Address) -> Result<(), ContractError> {
+    let is_admin = Storage::get_global_admin(env) == Some(revoker.clone());
+    let is_verifier = Storage::get_compliance_verifier(env) == Some(revoker.clone());
+    if !is_admin && !is_verifier {
+        return Err(ContractError::Unauthorized);
+    }
+
+    Storage::remove_compliance_attestation(env, subject);
+
+    ComplianceRevoked {
+        subject: subject.clone(),
+        revoked_by: revoker.clone(),
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Return the compliance attestation for an address.
+pub fn get_attestation(env: &Env, address: &Address) -> Option<ComplianceAttestation> {
+    Storage::get_compliance_attestation(env, address)
+}
+
+/// Check if an address meets the required compliance level.
+/// Returns Err if not compliant, expired, or rejected.
+pub fn require_compliant(
+    env: &Env,
+    address: &Address,
+    required_level: ComplianceLevel,
+) -> Result<(), ContractError> {
+    // ComplianceLevel::None means no check required.
+    if matches!(required_level, ComplianceLevel::None) {
+        return Ok(());
+    }
+
+    let attestation = Storage::get_compliance_attestation(env, address)
+        .ok_or(ContractError::ComplianceNotVerified)?;
+
+    if !is_valid(env, &attestation) {
+        return Err(ContractError::ComplianceCheckFailed);
+    }
+
+    if matches!(attestation.status, ComplianceStatus::Rejected) {
+        return Err(ContractError::ComplianceCheckFailed);
+    }
+
+    if !matches!(attestation.status, ComplianceStatus::Approved) {
+        return Err(ContractError::ComplianceNotVerified);
+    }
+
+    let attestation_level = attestation.level.clone() as u32;
+    let required_level_u32 = required_level as u32;
+    if attestation_level < required_level_u32 {
+        return Err(ContractError::ComplianceCheckFailed);
+    }
+
+    Ok(())
+}
+
+/// Check if an attestation is still valid (not expired).
+pub fn is_valid(env: &Env, attestation: &ComplianceAttestation) -> bool {
+    let now = env.ledger().timestamp();
+    if attestation.expires_at > 0 && now > attestation.expires_at {
+        return false;
+    }
+    !matches!(
+        attestation.status,
+        ComplianceStatus::Expired | ComplianceStatus::Rejected
+    )
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/config.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/config.rs
@@ -13,6 +13,7 @@ pub fn default_config() -> ProtocolConfig {
         dispute_window_ledgers: 17280,
         max_grant_title_len: 128,
         max_grant_desc_len: 1024,
+        multisig_threshold: 0,
     }
 }
 

--- a/stellargrant-contracts/contracts/stellar-grants/src/constants.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/constants.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 // ── Financial ────────────────────────────────────────────────────────────────
 pub const BASIS_POINTS_SCALE: u32 = 10_000;
 pub const DEFAULT_PROTOCOL_FEE_BPS: u32 = 100; // 1%

--- a/stellargrant-contracts/contracts/stellar-grants/src/dispute.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/dispute.rs
@@ -160,11 +160,7 @@ pub fn resolve_dispute(
                             .ok_or(ContractError::InvalidInput)?
                     };
                     if share > 0 {
-                        tok_client.transfer(
-                            &env.current_contract_address(),
-                            &fund.funder,
-                            &share,
-                        );
+                        tok_client.transfer(&env.current_contract_address(), &fund.funder, &share);
                         distributed = distributed.saturating_add(share);
                     }
                 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/errors.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/errors.rs
@@ -49,4 +49,19 @@ pub enum ContractError {
     HookNotFound = 39,
     HookLimitExceeded = 40,
     HookAlreadyInactive = 41,
+    // Escrow (#529)
+    EscrowLocked = 42,
+    EscrowAlreadyOpen = 43,
+    EscrowNotFound = 44,
+    // Multisig (#530)
+    ProposalNotFound = 45,
+    ProposalExpired = 46,
+    ProposalAlreadyExecuted = 47,
+    ThresholdNotMet = 48,
+    NotAProposalSigner = 49,
+    // Compliance (#548)
+    ComplianceNotVerified = 50,
+    ComplianceCheckFailed = 51,
+    VerifierNotSet = 52,
+    NotVerifier = 53,
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/escrow.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/escrow.rs
@@ -1,0 +1,288 @@
+use soroban_sdk::{token, Address, Env};
+
+use crate::errors::ContractError;
+use crate::storage::Storage;
+use crate::types::{EscrowAccount, FunderLedger, GrantFund};
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn load_account(env: &Env, grant_id: u64) -> Result<EscrowAccount, ContractError> {
+    Storage::get_escrow_account(env, grant_id).ok_or(ContractError::EscrowNotFound)
+}
+
+fn proportional_share(funder_net: i128, total_net: i128, total_balance: i128) -> i128 {
+    if total_net == 0 || total_balance == 0 {
+        return 0;
+    }
+    funder_net
+        .saturating_mul(total_balance)
+        .checked_div(total_net)
+        .unwrap_or(0)
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Initialize an escrow account for a grant. Called once on grant creation.
+pub fn open(
+    env: &Env,
+    grant_id: u64,
+    owner: &Address,
+    token: &Address,
+) -> Result<(), ContractError> {
+    if Storage::get_escrow_account(env, grant_id).is_some() {
+        return Err(ContractError::EscrowAlreadyOpen);
+    }
+    let account = EscrowAccount {
+        owner: owner.clone(),
+        token: token.clone(),
+        balance: 0,
+        total_deposited: 0,
+        total_released: 0,
+        locked: false,
+    };
+    Storage::set_escrow_account(env, grant_id, &account);
+    Ok(())
+}
+
+/// Deposit funds from a funder into the grant's escrow.
+pub fn deposit(
+    env: &Env,
+    grant_id: u64,
+    funder: &Address,
+    amount: i128,
+) -> Result<(), ContractError> {
+    if amount <= 0 {
+        return Err(ContractError::ZeroAmount);
+    }
+
+    let mut account = load_account(env, grant_id)?;
+    let token_client = token::Client::new(env, &account.token);
+    token_client.transfer(funder, env.current_contract_address(), &amount);
+
+    account.balance = account
+        .balance
+        .checked_add(amount)
+        .ok_or(ContractError::InvalidInput)?;
+    account.total_deposited = account
+        .total_deposited
+        .checked_add(amount)
+        .ok_or(ContractError::InvalidInput)?;
+    Storage::set_escrow_account(env, grant_id, &account);
+
+    // Update FunderLedger.
+    let mut ledger = Storage::get_funder_ledger(env, grant_id, funder).unwrap_or(FunderLedger {
+        funder: funder.clone(),
+        contributed: 0,
+        refunded: 0,
+        last_contribution_at: 0,
+    });
+    ledger.contributed = ledger
+        .contributed
+        .checked_add(amount)
+        .ok_or(ContractError::InvalidInput)?;
+    ledger.last_contribution_at = env.ledger().timestamp();
+    Storage::set_funder_ledger(env, grant_id, funder, &ledger);
+
+    // Track funder address in the list.
+    let mut funders = Storage::get_escrow_funders_list(env, grant_id);
+    if !funders.contains(funder.clone()) {
+        funders.push_back(funder.clone());
+        Storage::set_escrow_funders_list(env, grant_id, &funders);
+    }
+
+    // Mirror onto Grant struct for backward-compatible queries.
+    let mut grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    grant.escrow_balance = account.balance;
+    let mut funder_found = false;
+    for i in 0..grant.funders.len() {
+        let mut entry = grant.funders.get(i).unwrap();
+        if entry.funder == *funder {
+            entry.amount = entry
+                .amount
+                .checked_add(amount)
+                .ok_or(ContractError::InvalidInput)?;
+            grant.funders.set(i, entry);
+            funder_found = true;
+            break;
+        }
+    }
+    if !funder_found {
+        grant.funders.push_back(GrantFund {
+            funder: funder.clone(),
+            amount,
+        });
+    }
+    Storage::set_grant(env, grant_id, &grant);
+
+    Ok(())
+}
+
+/// Release `amount` from escrow to `recipient` (milestone payout).
+pub fn release(
+    env: &Env,
+    grant_id: u64,
+    recipient: &Address,
+    amount: i128,
+) -> Result<(), ContractError> {
+    if amount <= 0 {
+        return Err(ContractError::ZeroAmount);
+    }
+
+    let mut account = load_account(env, grant_id)?;
+    if account.locked {
+        return Err(ContractError::EscrowLocked);
+    }
+    if account.balance < amount {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let token_client = token::Client::new(env, &account.token);
+    token_client.transfer(&env.current_contract_address(), recipient, &amount);
+
+    account.balance -= amount;
+    account.total_released = account
+        .total_released
+        .checked_add(amount)
+        .ok_or(ContractError::InvalidInput)?;
+    Storage::set_escrow_account(env, grant_id, &account);
+
+    if let Some(mut grant) = Storage::get_grant(env, grant_id) {
+        grant.escrow_balance = account.balance;
+        Storage::set_grant(env, grant_id, &grant);
+    }
+
+    Ok(())
+}
+
+/// Refund remaining contribution from escrow back to a specific funder.
+pub fn refund(env: &Env, grant_id: u64, funder: &Address) -> Result<i128, ContractError> {
+    let mut ledger = Storage::get_funder_ledger(env, grant_id, funder)
+        .ok_or(ContractError::NoRefundableAmount)?;
+
+    let refundable = ledger.contributed.saturating_sub(ledger.refunded);
+    if refundable <= 0 {
+        return Err(ContractError::NoRefundableAmount);
+    }
+
+    let mut account = load_account(env, grant_id)?;
+    let actual_refund = refundable.min(account.balance);
+    if actual_refund <= 0 {
+        return Err(ContractError::NoRefundableAmount);
+    }
+
+    let token_client = token::Client::new(env, &account.token);
+    token_client.transfer(&env.current_contract_address(), funder, &actual_refund);
+
+    account.balance -= actual_refund;
+    Storage::set_escrow_account(env, grant_id, &account);
+
+    ledger.refunded = ledger
+        .refunded
+        .checked_add(actual_refund)
+        .ok_or(ContractError::InvalidInput)?;
+    Storage::set_funder_ledger(env, grant_id, funder, &ledger);
+
+    if let Some(mut grant) = Storage::get_grant(env, grant_id) {
+        grant.escrow_balance = account.balance;
+        Storage::set_grant(env, grant_id, &grant);
+    }
+
+    Ok(actual_refund)
+}
+
+/// Refund all remaining escrow balance proportionally to all funders.
+pub fn refund_all(env: &Env, grant_id: u64) -> Result<(), ContractError> {
+    let mut account = load_account(env, grant_id)?;
+    let total_balance = account.balance;
+    if total_balance == 0 {
+        return Ok(());
+    }
+
+    let funders = Storage::get_escrow_funders_list(env, grant_id);
+    if funders.is_empty() {
+        return Ok(());
+    }
+
+    let token_client = token::Client::new(env, &account.token);
+
+    // Compute total net contributions for proportion denominator.
+    let mut total_net: i128 = 0;
+    for addr in funders.iter() {
+        if let Some(l) = Storage::get_funder_ledger(env, grant_id, &addr) {
+            total_net += l.contributed.saturating_sub(l.refunded);
+        }
+    }
+
+    let funders_len = funders.len();
+    let mut distributed: i128 = 0;
+
+    for (i, addr) in funders.iter().enumerate() {
+        let ledger_opt = Storage::get_funder_ledger(env, grant_id, &addr);
+        let net = ledger_opt
+            .as_ref()
+            .map(|l| l.contributed.saturating_sub(l.refunded))
+            .unwrap_or(0);
+
+        if net <= 0 {
+            continue;
+        }
+
+        let is_last = (i as u32) + 1 == funders_len;
+        let refund_amount = if is_last {
+            total_balance - distributed
+        } else {
+            proportional_share(net, total_net, total_balance)
+        };
+
+        if refund_amount > 0 {
+            token_client.transfer(&env.current_contract_address(), &addr, &refund_amount);
+            distributed += refund_amount;
+
+            if let Some(mut ledger) = ledger_opt {
+                ledger.refunded = ledger.refunded.saturating_add(refund_amount);
+                Storage::set_funder_ledger(env, grant_id, &addr, &ledger);
+            }
+        }
+    }
+
+    account.balance = 0;
+    Storage::set_escrow_account(env, grant_id, &account);
+
+    if let Some(mut grant) = Storage::get_grant(env, grant_id) {
+        grant.escrow_balance = 0;
+        Storage::set_grant(env, grant_id, &grant);
+    }
+
+    Ok(())
+}
+
+/// Lock escrow during a dispute (blocks release but not deposit).
+pub fn lock(env: &Env, grant_id: u64) -> Result<(), ContractError> {
+    let mut account = load_account(env, grant_id)?;
+    account.locked = true;
+    Storage::set_escrow_account(env, grant_id, &account);
+    Ok(())
+}
+
+/// Unlock escrow after dispute resolution.
+pub fn unlock(env: &Env, grant_id: u64) -> Result<(), ContractError> {
+    let mut account = load_account(env, grant_id)?;
+    account.locked = false;
+    Storage::set_escrow_account(env, grant_id, &account);
+    Ok(())
+}
+
+/// Return current escrow account state.
+pub fn get_account(env: &Env, grant_id: u64) -> Result<EscrowAccount, ContractError> {
+    load_account(env, grant_id)
+}
+
+/// Return funder ledger for a specific contributor.
+pub fn get_funder_ledger(env: &Env, grant_id: u64, funder: &Address) -> Option<FunderLedger> {
+    Storage::get_funder_ledger(env, grant_id, funder)
+}
+
+/// Thin wrapper for non-escrow token transfers (e.g. reviewer staking).
+pub fn transfer_token(env: &Env, token: &Address, from: &Address, to: &Address, amount: i128) {
+    token::Client::new(env, token).transfer(from, to, &amount);
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -462,12 +462,7 @@ impl Events {
 
     // ── Issue #514: Dispute emit methods ──────────────────────────────────────
 
-    pub fn emit_dispute_raised(
-        env: &Env,
-        grant_id: u64,
-        milestone_idx: u32,
-        raised_by: Address,
-    ) {
+    pub fn emit_dispute_raised(env: &Env, grant_id: u64, milestone_idx: u32, raised_by: Address) {
         let event = DisputeRaised {
             grant_id,
             milestone_idx,
@@ -477,12 +472,7 @@ impl Events {
         event.publish(env);
     }
 
-    pub fn emit_arbiter_assigned(
-        env: &Env,
-        grant_id: u64,
-        milestone_idx: u32,
-        arbiter: Address,
-    ) {
+    pub fn emit_arbiter_assigned(env: &Env, grant_id: u64, milestone_idx: u32, arbiter: Address) {
         let event = ArbiterAssigned {
             grant_id,
             milestone_idx,
@@ -580,4 +570,55 @@ impl Events {
         };
         event.publish(env);
     }
+}
+
+// ── Issue #530: Multisig events ───────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultisigProposalCreated {
+    pub proposal_id: u32,
+    pub grant_id: u64,
+    pub created_by: Address,
+    pub threshold: u32,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultisigSigned {
+    pub proposal_id: u32,
+    pub signer: Address,
+    pub approved: bool,
+    pub total_weight_signed: u32,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultisigExecuted {
+    pub proposal_id: u32,
+    pub grant_id: u64,
+    pub executed_by: Address,
+    pub timestamp: u64,
+}
+
+// ── Issue #548: Compliance events ─────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ComplianceAttested {
+    pub subject: Address,
+    pub attested_by: Address,
+    pub level: u32,
+    pub expires_at: u64,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ComplianceRevoked {
+    pub subject: Address,
+    pub revoked_by: Address,
+    pub timestamp: u64,
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/fees.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/fees.rs
@@ -4,6 +4,7 @@ use crate::events::Events;
 use crate::storage::Storage;
 use crate::types::ContractError;
 
+#[allow(dead_code)]
 fn basis_points_of(amount: i128, bps: u32) -> Result<i128, ContractError> {
     amount
         .checked_mul(bps as i128)
@@ -12,6 +13,7 @@ fn basis_points_of(amount: i128, bps: u32) -> Result<i128, ContractError> {
         .ok_or(ContractError::InvalidInput)
 }
 
+#[allow(dead_code)]
 pub fn compute_fee(gross: i128, fee_bps: u32) -> Result<i128, ContractError> {
     if fee_bps == 0 || gross <= 0 {
         return Ok(0);
@@ -19,6 +21,7 @@ pub fn compute_fee(gross: i128, fee_bps: u32) -> Result<i128, ContractError> {
     basis_points_of(gross, fee_bps)
 }
 
+#[allow(dead_code)]
 pub fn deduct_and_transfer(
     env: &Env,
     gross: i128,
@@ -45,15 +48,14 @@ pub fn deduct_and_transfer(
         treasury.clone(),
     );
 
-    gross
-        .checked_sub(fee)
-        .ok_or(ContractError::InvalidInput)
+    gross.checked_sub(fee).ok_or(ContractError::InvalidInput)
 }
 
 pub fn total_fees_collected(env: &Env, token: &Address) -> i128 {
     Storage::get_fees_collected(env, token)
 }
 
+#[allow(dead_code)]
 pub fn set_treasury(env: &Env, admin: &Address, treasury: &Address) -> Result<(), ContractError> {
     if Storage::get_global_admin(env) != Some(admin.clone()) {
         return Err(ContractError::Unauthorized);
@@ -62,6 +64,7 @@ pub fn set_treasury(env: &Env, admin: &Address, treasury: &Address) -> Result<()
     Ok(())
 }
 
+#[allow(dead_code)]
 pub fn get_treasury(env: &Env) -> Result<Address, ContractError> {
     Storage::get_treasury(env).ok_or(ContractError::InvalidInput)
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/governance.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/governance.rs
@@ -6,6 +6,7 @@ use crate::quadratic;
 use crate::storage::Storage;
 use crate::types::{ContractError, Grant, Milestone, MilestoneState, VotingMechanism};
 
+#[allow(dead_code)]
 pub struct VoteResult {
     pub approved: bool,
     pub quorum_reached: bool,
@@ -39,9 +40,23 @@ pub fn cast_vote(
         };
         if quorum {
             let approved = quadratic::is_approved_qv(env, grant.id, milestone.idx);
-            finalize_milestone(milestone, &VoteResult { approved, quorum_reached: true, approval_pct: for_v });
+            finalize_milestone(
+                milestone,
+                &VoteResult {
+                    approved,
+                    quorum_reached: true,
+                    approval_pct: for_v,
+                },
+            );
         }
-        Events::milestone_voted(env, grant.id, milestone.idx, reviewer.clone(), approve, reason);
+        Events::milestone_voted(
+            env,
+            grant.id,
+            milestone.idx,
+            reviewer.clone(),
+            approve,
+            reason,
+        );
         return Ok(result);
     }
 

--- a/stellargrant-contracts/contracts/stellar-grants/src/hooks.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/hooks.rs
@@ -106,17 +106,13 @@ pub fn trigger(env: &Env, event: HookEvent, payload: Bytes) -> Vec<HookCallResul
         }
 
         // Use try_invoke_contract to avoid propagating failures
-        let args: Vec<Val> = vec![
-            env,
-            event_u32.into(),
-            payload.clone().into(),
-        ];
-        type HookResult = Result<Result<Val, soroban_sdk::ConversionError>, Result<soroban_sdk::Error, InvokeError>>;
-        let result: HookResult = env.try_invoke_contract(
-            &hook.target_contract,
-            &Symbol::new(env, "on_hook"),
-            args,
-        );
+        let args: Vec<Val> = vec![env, event_u32.into(), payload.clone().into()];
+        type HookResult = Result<
+            Result<Val, soroban_sdk::ConversionError>,
+            Result<soroban_sdk::Error, InvokeError>,
+        >;
+        let result: HookResult =
+            env.try_invoke_contract(&hook.target_contract, &Symbol::new(env, "on_hook"), args);
 
         let success = matches!(result, Ok(Ok(_)));
         let error_code: Option<u32> = if success { None } else { Some(1) };

--- a/stellargrant-contracts/contracts/stellar-grants/src/insurance.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/insurance.rs
@@ -1,6 +1,8 @@
 use soroban_sdk::{contractevent, token, Address, Env, String};
 
-use crate::constants::{BASIS_POINTS_SCALE, DEFAULT_INSURANCE_DURATION_LEDGERS, DEFAULT_INSURANCE_PREMIUM_RATE_BPS};
+use crate::constants::{
+    BASIS_POINTS_SCALE, DEFAULT_INSURANCE_DURATION_LEDGERS, DEFAULT_INSURANCE_PREMIUM_RATE_BPS,
+};
 use crate::errors::ContractError;
 use crate::storage::Storage;
 use crate::types::{InsuranceClaim, InsuranceClaimStatus, InsurancePolicy};
@@ -66,7 +68,7 @@ pub fn purchase_policy(
 
     if premium > 0 {
         let token_client = token::Client::new(env, token);
-        token_client.transfer(policyholder, &env.current_contract_address(), &premium);
+        token_client.transfer(policyholder, env.current_contract_address(), &premium);
     }
 
     // Add premium to pool
@@ -207,7 +209,11 @@ pub fn approve_claim(
     Storage::set_insurance_claim(env, &claim);
 
     let token_client = token::Client::new(env, &policy.token);
-    token_client.transfer(&env.current_contract_address(), &claim.claimant, &actual_payout);
+    token_client.transfer(
+        &env.current_contract_address(),
+        &claim.claimant,
+        &actual_payout,
+    );
 
     ClaimApproved {
         claim_id,
@@ -269,8 +275,9 @@ mod tests {
         let admin = Address::generate(&env);
         let policyholder = Address::generate(&env);
         let token_admin = Address::generate(&env);
-        let token_contract =
-            env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+        let token_contract = env
+            .register_stellar_asset_contract_v2(token_admin.clone())
+            .address();
         let stellar_asset = StellarAssetClient::new(&env, &token_contract);
         stellar_asset.mint(&policyholder, &10_000_000);
         (env, admin, policyholder, token_contract)

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -1,17 +1,21 @@
 #![no_std]
 #![allow(clippy::too_many_arguments)]
 mod audit;
+mod compliance;
 mod config;
 mod constants;
 mod dispute;
 mod emergency;
 mod errors;
+mod escrow;
 mod events;
 mod fees;
 mod governance;
 mod hooks;
 mod insurance;
+mod metrics;
 mod migration;
+mod multisig;
 mod oracle;
 mod quadratic;
 mod reentrancy;
@@ -25,15 +29,17 @@ pub use errors::ContractError;
 pub use events::Events;
 pub use storage::Storage;
 pub use types::{
-    AuditAction, AuditEntry, ContractVersion, Dispute, DisputeStatus, EscrowLifecycleState,
-    EscrowMode, EscrowState, FeeRecord, Grant, GrantFund, GrantStatus, HookCallResult, HookEvent,
+    AuditAction, AuditEntry, ComplianceAttestation, ComplianceLevel, ComplianceStatus,
+    ContractVersion, Dispute, DisputeStatus, EscrowAccount, EscrowLifecycleState, EscrowMode,
+    EscrowState, FeeRecord, FunderLedger, Grant, GrantFund, GrantStatus, HookCallResult, HookEvent,
     HookRegistration, InsuranceClaim, InsurancePolicy, MigrationRecord, Milestone, MilestoneState,
-    MilestoneSubmission, OracleConfig, PauseRecord, PaymentStream, PriceQuote, ProtocolConfig,
-    QuadraticVoteRecord, RegistryEntry, RegistryEntryType, ReputationTier, VoiceCredits,
-    VotingMechanism,
+    MilestoneSubmission, MultisigProposal, MultisigSigner, OracleConfig, PauseRecord,
+    PaymentStream, PriceQuote, ProtocolConfig, ProtocolMetrics, QuadraticVoteRecord, RegistryEntry,
+    RegistryEntryType, ReputationTier, SignatureStatus, TokenMetric, VoiceCredits, VotingMechanism,
 };
 
-use soroban_sdk::{contract, contractimpl, token, Address, Bytes, Env, String, Vec};
+use metrics::MetricField;
+use soroban_sdk::{contract, contractimpl, Address, Bytes, Env, String, Vec};
 
 #[contract]
 pub struct StellarGrantsContract;
@@ -108,7 +114,7 @@ impl StellarGrantsContract {
             owner: owner.clone(),
             title: title.clone(),
             description,
-            token,
+            token: token.clone(),
             status: GrantStatus::Active,
             total_amount,
             milestone_amount,
@@ -119,6 +125,7 @@ impl StellarGrantsContract {
             funders: soroban_sdk::Vec::new(&env),
             reason: None,
             timestamp: env.ledger().timestamp(),
+            require_compliance: None,
         };
 
         Storage::set_grant(&env, grant_id, &grant);
@@ -134,6 +141,8 @@ impl StellarGrantsContract {
         );
         Storage::set_multisig_signers(&env, grant_id, &soroban_sdk::Vec::new(&env));
 
+        escrow::open(&env, grant_id, &owner, &token)?;
+
         Events::emit_grant_created(&env, grant_id, owner.clone(), title, total_amount);
 
         audit::log(
@@ -144,6 +153,9 @@ impl StellarGrantsContract {
             None,
             Some(total_amount),
         );
+
+        metrics::increment(&env, MetricField::GrantsCreated, 1);
+        metrics::increment(&env, MetricField::GrantsActive, 1);
 
         if hooks::has_hooks(&env, HookEvent::GrantCreated) {
             hooks::trigger(&env, HookEvent::GrantCreated, Bytes::new(&env));
@@ -237,6 +249,8 @@ impl StellarGrantsContract {
         // Register in global index and emit contributor_registered event
         registry::register_contributor(&env, &contributor, &name)?;
 
+        metrics::increment(&env, MetricField::ContributorsRegistered, 1);
+
         Ok(())
     }
 
@@ -259,8 +273,7 @@ impl StellarGrantsContract {
     ) -> Result<(), ContractError> {
         caller.require_auth();
         reentrancy::with_non_reentrant(&env, || {
-            let mut grant =
-                Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+            let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
 
             let caller_is_owner = grant.owner == caller;
             let caller_is_admin = Storage::get_global_admin(&env) == Some(caller.clone());
@@ -278,51 +291,11 @@ impl StellarGrantsContract {
 
             let total_refundable = grant.escrow_balance;
             if total_refundable > 0 {
-                let mut total_contributions: i128 = 0;
-                for fund_entry in grant.funders.iter() {
-                    total_contributions += fund_entry.amount;
-                }
-
-                if total_contributions <= 0 {
-                    return Err(ContractError::InvalidInput);
-                }
-
-                let token_client = token::Client::new(&env, &grant.token);
-                let funders_len = grant.funders.len();
-                let mut distributed = 0i128;
-
-                for i in 0..funders_len {
-                    let fund_entry = grant.funders.get(i).unwrap();
-                    let is_last = i + 1 == funders_len;
-                    let refund_amount = if is_last {
-                        total_refundable - distributed
-                    } else {
-                        let amount = fund_entry
-                            .amount
-                            .checked_mul(total_refundable)
-                            .ok_or(ContractError::InvalidInput)?
-                            .checked_div(total_contributions)
-                            .ok_or(ContractError::InvalidInput)?;
-                        distributed += amount;
-                        amount
-                    };
-
-                    if refund_amount > 0 {
-                        token_client.transfer(
-                            &env.current_contract_address(),
-                            &fund_entry.funder,
-                            &refund_amount,
-                        );
-                        Events::emit_refund_issued(
-                            &env,
-                            grant_id,
-                            fund_entry.funder.clone(),
-                            refund_amount,
-                        );
-                    }
-                }
+                escrow::refund_all(&env, grant_id)?;
             }
 
+            let mut grant =
+                Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
             grant.status = GrantStatus::Cancelled;
             grant.escrow_balance = 0;
             grant.reason = Some(reason.clone());
@@ -340,6 +313,11 @@ impl StellarGrantsContract {
                 None,
                 Some(total_refundable),
             );
+
+            metrics::increment(&env, MetricField::GrantsCancelled, 1);
+            if total_refundable > 0 {
+                metrics::record_token_refund(&env, &grant.token, total_refundable);
+            }
 
             Ok(())
         })
@@ -439,9 +417,14 @@ impl StellarGrantsContract {
     }
 
     fn finalize_grant_release(env: &Env, grant_id: u64) -> Result<(), ContractError> {
-        let mut grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
         if grant.status != GrantStatus::Active {
             return Err(ContractError::InvalidState);
+        }
+
+        // Compliance gate: if the grant requires KYC, check the owner/contributor.
+        if let Some(ref required_level) = grant.require_compliance {
+            compliance::require_compliant(env, &grant.owner, required_level.clone())?;
         }
 
         let total_paid =
@@ -450,54 +433,16 @@ impl StellarGrantsContract {
             return Err(ContractError::InvalidInput);
         }
         let remaining_balance = grant.escrow_balance - total_paid;
-        let token_client = token::Client::new(env, &grant.token);
 
         if total_paid > 0 {
-            token_client.transfer(&env.current_contract_address(), &grant.owner, &total_paid);
+            escrow::release(env, grant_id, &grant.owner, total_paid)?;
         }
-
         if remaining_balance > 0 {
-            let mut total_contributions: i128 = 0;
-            for fund_entry in grant.funders.iter() {
-                total_contributions += fund_entry.amount;
-            }
-
-            if total_contributions > 0 {
-                let funders_len = grant.funders.len();
-                let mut distributed = 0i128;
-                for i in 0..funders_len {
-                    let fund_entry = grant.funders.get(i).unwrap();
-                    let is_last = i + 1 == funders_len;
-                    let refund_amount = if is_last {
-                        remaining_balance - distributed
-                    } else {
-                        let amount = fund_entry
-                            .amount
-                            .checked_mul(remaining_balance)
-                            .ok_or(ContractError::InvalidInput)?
-                            .checked_div(total_contributions)
-                            .ok_or(ContractError::InvalidInput)?;
-                        distributed += amount;
-                        amount
-                    };
-
-                    if refund_amount > 0 {
-                        token_client.transfer(
-                            &env.current_contract_address(),
-                            &fund_entry.funder,
-                            &refund_amount,
-                        );
-                        Events::emit_final_refund(
-                            env,
-                            grant_id,
-                            fund_entry.funder.clone(),
-                            refund_amount,
-                        );
-                    }
-                }
-            }
+            escrow::refund_all(env, grant_id)?;
         }
 
+        // Re-load grant after escrow mutations.
+        let mut grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
         grant.status = GrantStatus::Completed;
         grant.escrow_balance = 0;
         grant.milestones_paid_out = grant.total_milestones;
@@ -508,6 +453,9 @@ impl StellarGrantsContract {
         escrow_state.lifecycle = EscrowLifecycleState::Released;
         escrow_state.quorum_ready = true;
         Storage::set_escrow_state(env, grant_id, &escrow_state);
+
+        metrics::increment(env, MetricField::GrantsCompleted, 1);
+        metrics::update_token_locked(env, &grant.token, -total_paid);
 
         Events::emit_grant_completed(env, grant_id, total_paid, remaining_balance);
         Ok(())
@@ -557,6 +505,7 @@ impl StellarGrantsContract {
                     Some(milestone_idx),
                     Some(milestone.amount),
                 );
+                metrics::increment(&env, MetricField::MilestonesApproved, 1);
                 if hooks::has_hooks(&env, HookEvent::MilestoneApproved) {
                     hooks::trigger(&env, HookEvent::MilestoneApproved, Bytes::new(&env));
                 }
@@ -569,6 +518,7 @@ impl StellarGrantsContract {
                     Some(milestone_idx),
                     None,
                 );
+                metrics::increment(&env, MetricField::MilestonesRejected, 1);
             }
         }
 
@@ -730,44 +680,15 @@ impl StellarGrantsContract {
                 return Err(ContractError::ZeroAmount);
             }
 
-            let mut grant =
-                Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+            let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
 
             if grant.status != GrantStatus::Active {
                 return Err(ContractError::InvalidState);
             }
 
-            let token_client = token::Client::new(&env, &grant.token);
-            let contract_address = env.current_contract_address();
-            token_client.transfer(&funder, &contract_address, &amount);
+            escrow::deposit(&env, grant_id, &funder, amount)?;
 
-            grant.escrow_balance = grant
-                .escrow_balance
-                .checked_add(amount)
-                .ok_or(ContractError::InvalidInput)?;
-
-            let mut funder_found = false;
-            for i in 0..grant.funders.len() {
-                let mut fund_entry = grant.funders.get(i).unwrap();
-                if fund_entry.funder == funder {
-                    fund_entry.amount = fund_entry
-                        .amount
-                        .checked_add(amount)
-                        .ok_or(ContractError::InvalidInput)?;
-                    grant.funders.set(i, fund_entry);
-                    funder_found = true;
-                    break;
-                }
-            }
-
-            if !funder_found {
-                grant.funders.push_back(GrantFund {
-                    funder: funder.clone(),
-                    amount,
-                });
-            }
-
-            Storage::set_grant(&env, grant_id, &grant);
+            let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
 
             Events::emit_grant_funded(&env, grant_id, funder.clone(), amount, grant.escrow_balance);
 
@@ -779,6 +700,8 @@ impl StellarGrantsContract {
                 None,
                 Some(amount),
             );
+
+            metrics::update_token_locked(&env, &grant.token, amount);
 
             Ok(())
         })
@@ -919,9 +842,13 @@ impl StellarGrantsContract {
             return Err(ContractError::InsufficientStake);
         }
 
-        let contract_addr = env.current_contract_address();
-        let client = token::Client::new(&env, &grant.token);
-        client.transfer(&reviewer, &contract_addr, &amount);
+        escrow::transfer_token(
+            &env,
+            &grant.token,
+            &reviewer,
+            &env.current_contract_address(),
+            amount,
+        );
 
         let current = Storage::get_reviewer_stake(&env, grant_id, &reviewer);
         Storage::set_reviewer_stake(&env, grant_id, &reviewer, current + amount);
@@ -945,8 +872,13 @@ impl StellarGrantsContract {
         }
 
         let treasury = Storage::get_treasury(&env).ok_or(ContractError::InvalidInput)?;
-        let client = token::Client::new(&env, &grant.token);
-        client.transfer(&env.current_contract_address(), &treasury, &stake);
+        escrow::transfer_token(
+            &env,
+            &grant.token,
+            &env.current_contract_address(),
+            &treasury,
+            stake,
+        );
 
         Storage::set_reviewer_stake(&env, grant_id, &reviewer, 0);
 
@@ -967,8 +899,13 @@ impl StellarGrantsContract {
             return Err(ContractError::StakeNotFound);
         }
 
-        let client = token::Client::new(&env, &grant.token);
-        client.transfer(&env.current_contract_address(), &reviewer, &stake);
+        escrow::transfer_token(
+            &env,
+            &grant.token,
+            &env.current_contract_address(),
+            &reviewer,
+            stake,
+        );
 
         Storage::set_reviewer_stake(&env, grant_id, &reviewer, 0);
 
@@ -1036,46 +973,18 @@ impl StellarGrantsContract {
                 return Err(ContractError::ZeroAmount);
             }
 
-            let mut grant =
-                Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+            let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
 
             if grant.status != GrantStatus::Active {
                 return Err(ContractError::InvalidState);
             }
 
-            let contract_addr = env.current_contract_address();
-            let client = token::Client::new(&env, &grant.token);
-            client.transfer(&funder, &contract_addr, &amount);
+            escrow::deposit(&env, grant_id, &funder, amount)?;
 
-            grant.escrow_balance = grant
-                .escrow_balance
-                .checked_add(amount)
-                .ok_or(ContractError::InvalidInput)?;
-
-            let mut found = false;
-            let mut new_funders = soroban_sdk::Vec::new(&env);
-            for f in grant.funders.iter() {
-                if f.funder == funder {
-                    new_funders.push_back(GrantFund {
-                        funder: f.funder,
-                        amount: f.amount + amount,
-                    });
-                    found = true;
-                } else {
-                    new_funders.push_back(f);
-                }
-            }
-            if !found {
-                new_funders.push_back(GrantFund {
-                    funder: funder.clone(),
-                    amount,
-                });
-            }
-            grant.funders = new_funders;
-
-            Storage::set_grant(&env, grant_id, &grant);
+            let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
 
             Events::emit_grant_funded(&env, grant_id, funder.clone(), amount, grant.escrow_balance);
+            metrics::update_token_locked(&env, &grant.token, amount);
         }
 
         Ok(())
@@ -1184,11 +1093,7 @@ impl StellarGrantsContract {
     }
 
     /// Return all QV vote records for a milestone.
-    pub fn get_qv_votes(
-        env: Env,
-        grant_id: u64,
-        milestone_idx: u32,
-    ) -> Vec<QuadraticVoteRecord> {
+    pub fn get_qv_votes(env: Env, grant_id: u64, milestone_idx: u32) -> Vec<QuadraticVoteRecord> {
         quadratic::get_qv_votes(&env, grant_id, milestone_idx)
     }
 
@@ -1310,6 +1215,7 @@ impl StellarGrantsContract {
         emergency::require_not_paused(&env)?;
         let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
         dispute::raise_dispute(&env, &grant, milestone_idx, &caller, reason)?;
+        metrics::increment(&env, MetricField::DisputesRaised, 1);
         Ok(())
     }
 
@@ -1357,6 +1263,7 @@ impl StellarGrantsContract {
             .ok_or(ContractError::InvalidState)?;
         let outcome = dispute::resolve_dispute(&env, &mut grant, &mut d)?;
         Storage::set_grant(&env, grant_id, &grant);
+        metrics::increment(&env, MetricField::DisputesResolved, 1);
         Ok(outcome)
     }
 
@@ -1372,11 +1279,7 @@ impl StellarGrantsContract {
         dispute::cancel_dispute(&env, &mut d, &caller)
     }
 
-    pub fn get_dispute_record(
-        env: Env,
-        grant_id: u64,
-        milestone_idx: u32,
-    ) -> Option<Dispute> {
+    pub fn get_dispute_record(env: Env, grant_id: u64, milestone_idx: u32) -> Option<Dispute> {
         Storage::get_dispute(&env, grant_id, milestone_idx)
     }
 
@@ -1399,6 +1302,205 @@ impl StellarGrantsContract {
 
     pub fn get_fees_collected(env: Env, token: Address) -> i128 {
         fees::total_fees_collected(&env, &token)
+    }
+
+    // ── Issue #529: Escrow Module ─────────────────────────────────────────────
+
+    /// Return the escrow account state for a grant.
+    pub fn get_escrow_account(env: Env, grant_id: u64) -> Result<EscrowAccount, ContractError> {
+        escrow::get_account(&env, grant_id)
+    }
+
+    /// Return the funder ledger for a contributor in a grant.
+    pub fn get_funder_ledger(env: Env, grant_id: u64, funder: Address) -> Option<FunderLedger> {
+        escrow::get_funder_ledger(&env, grant_id, &funder)
+    }
+
+    /// Refund a specific funder's net contribution from escrow after grant ends. Funder only.
+    pub fn refund_funder(env: Env, funder: Address, grant_id: u64) -> Result<i128, ContractError> {
+        funder.require_auth();
+        let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        if grant.status == GrantStatus::Active {
+            return Err(ContractError::InvalidState);
+        }
+        escrow::refund(&env, grant_id, &funder)
+    }
+
+    /// Lock escrow for a grant (e.g., when a dispute is open). Admin only.
+    pub fn lock_escrow(env: Env, admin: Address, grant_id: u64) -> Result<(), ContractError> {
+        admin.require_auth();
+        if Storage::get_global_admin(&env) != Some(admin) {
+            return Err(ContractError::Unauthorized);
+        }
+        escrow::lock(&env, grant_id)
+    }
+
+    /// Unlock escrow for a grant after dispute resolution. Admin only.
+    pub fn unlock_escrow(env: Env, admin: Address, grant_id: u64) -> Result<(), ContractError> {
+        admin.require_auth();
+        if Storage::get_global_admin(&env) != Some(admin) {
+            return Err(ContractError::Unauthorized);
+        }
+        escrow::unlock(&env, grant_id)
+    }
+
+    /// Expire a stale multisig proposal past its TTL. Anyone can call.
+    pub fn expire_multisig_proposal(env: Env, proposal_id: u32) -> Result<(), ContractError> {
+        multisig::expire_proposal(&env, proposal_id)
+    }
+
+    // ── Issue #530: Multisig Fund Release ─────────────────────────────────────
+
+    /// Create a multisig proposal for a grant action. Grant owner or admin only.
+    pub fn create_multisig_proposal(
+        env: Env,
+        creator: Address,
+        grant_id: u64,
+        action_payload: Bytes,
+        signers: Vec<Address>,
+        threshold: u32,
+        ttl_ledgers: u32,
+    ) -> Result<u32, ContractError> {
+        creator.require_auth();
+        let grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        let is_owner = grant.owner == creator;
+        let is_admin = Storage::get_global_admin(&env) == Some(creator.clone());
+        if !is_owner && !is_admin {
+            return Err(ContractError::Unauthorized);
+        }
+        multisig::create_proposal(
+            &env,
+            &creator,
+            grant_id,
+            action_payload,
+            signers,
+            threshold,
+            ttl_ledgers,
+        )
+    }
+
+    /// Sign (or veto) a multisig proposal.
+    pub fn sign_proposal(
+        env: Env,
+        signer: Address,
+        proposal_id: u32,
+        approve: bool,
+    ) -> Result<u32, ContractError> {
+        signer.require_auth();
+        multisig::sign(&env, &signer, proposal_id, approve)
+    }
+
+    /// Execute a multisig proposal once threshold is met.
+    /// For GrantWithdraw proposals, triggers the grant release.
+    pub fn execute_multisig_proposal(
+        env: Env,
+        caller: Address,
+        proposal_id: u32,
+    ) -> Result<Bytes, ContractError> {
+        caller.require_auth();
+        let payload = multisig::execute(&env, &caller, proposal_id)?;
+        // Dispatch GrantWithdraw if payload encodes a grant_id.
+        if let Some(grant_id) = multisig::decode_grant_withdraw(&payload) {
+            Self::finalize_grant_release(&env, grant_id)?;
+        }
+        Ok(payload)
+    }
+
+    /// Return a multisig proposal by id.
+    pub fn get_multisig_proposal(
+        env: Env,
+        proposal_id: u32,
+    ) -> Result<MultisigProposal, ContractError> {
+        multisig::get_proposal(&env, proposal_id)
+    }
+
+    /// Helper to encode a GrantWithdraw action payload from a grant_id.
+    pub fn encode_grant_withdraw_payload(env: Env, grant_id: u64) -> Bytes {
+        multisig::encode_grant_withdraw(&env, grant_id)
+    }
+
+    // ── Issue #540: Protocol Metrics ──────────────────────────────────────────
+
+    /// Return the aggregated protocol-wide metrics snapshot.
+    pub fn get_protocol_metrics(env: Env) -> ProtocolMetrics {
+        metrics::get_metrics(&env)
+    }
+
+    /// Return token-specific locked/paid/refunded totals.
+    pub fn get_token_metrics(env: Env, token: Address) -> TokenMetric {
+        metrics::get_token_metrics(&env, &token)
+    }
+
+    /// Reset all protocol metrics. Admin only (for testnet/migration use).
+    pub fn reset_metrics(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin.require_auth();
+        metrics::reset(&env, &admin)
+    }
+
+    // ── Issue #548: KYC/AML Compliance ────────────────────────────────────────
+
+    /// Register the trusted compliance verifier. Admin only.
+    pub fn set_compliance_verifier(
+        env: Env,
+        admin: Address,
+        verifier: Address,
+    ) -> Result<(), ContractError> {
+        admin.require_auth();
+        compliance::set_verifier(&env, &admin, &verifier)
+    }
+
+    /// Trusted verifier attests compliance for a subject address.
+    pub fn attest_compliance(
+        env: Env,
+        verifier: Address,
+        subject: Address,
+        status: ComplianceStatus,
+        level: ComplianceLevel,
+        expires_at: u64,
+        jurisdiction: String,
+    ) -> Result<(), ContractError> {
+        verifier.require_auth();
+        compliance::attest(
+            &env,
+            &verifier,
+            &subject,
+            status,
+            level,
+            expires_at,
+            jurisdiction,
+        )
+    }
+
+    /// Revoke a compliance attestation. Verifier or admin only.
+    pub fn revoke_compliance(
+        env: Env,
+        revoker: Address,
+        subject: Address,
+    ) -> Result<(), ContractError> {
+        revoker.require_auth();
+        compliance::revoke(&env, &revoker, &subject)
+    }
+
+    /// Return the compliance attestation for an address.
+    pub fn get_compliance_attestation(env: Env, address: Address) -> Option<ComplianceAttestation> {
+        compliance::get_attestation(&env, &address)
+    }
+
+    /// Enable compliance requirement for an existing grant. Owner only.
+    pub fn set_grant_compliance_level(
+        env: Env,
+        owner: Address,
+        grant_id: u64,
+        level: ComplianceLevel,
+    ) -> Result<(), ContractError> {
+        owner.require_auth();
+        let mut grant = Storage::get_grant(&env, grant_id).ok_or(ContractError::GrantNotFound)?;
+        if grant.owner != owner {
+            return Err(ContractError::Unauthorized);
+        }
+        grant.require_compliance = Some(level);
+        Storage::set_grant(&env, grant_id, &grant);
+        Ok(())
     }
 
     // ── Issue #524: Price Oracle Integration ─────────────────────────────────

--- a/stellargrant-contracts/contracts/stellar-grants/src/metrics.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/metrics.rs
@@ -1,0 +1,146 @@
+use soroban_sdk::{Address, Env};
+
+use crate::errors::ContractError;
+use crate::storage::Storage;
+use crate::types::{ProtocolMetrics, TokenMetric};
+
+// ── Metric field selector ─────────────────────────────────────────────────────
+
+/// Internal enum for selecting which counter to increment.
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub enum MetricField {
+    GrantsCreated,
+    GrantsActive,
+    GrantsCompleted,
+    GrantsCancelled,
+    MilestonesApproved,
+    MilestonesRejected,
+    MilestonesPaid,
+    ContributorsRegistered,
+    DisputesRaised,
+    DisputesResolved,
+    BountiesCreated,
+    BountiesAwarded,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn default_metrics(env: &Env) -> ProtocolMetrics {
+    ProtocolMetrics {
+        total_grants_created: 0,
+        total_grants_active: 0,
+        total_grants_completed: 0,
+        total_grants_cancelled: 0,
+        total_milestones_approved: 0,
+        total_milestones_rejected: 0,
+        total_milestones_paid: 0,
+        total_contributors_registered: 0,
+        total_disputes_raised: 0,
+        total_disputes_resolved: 0,
+        total_bounties_created: 0,
+        total_bounties_awarded: 0,
+        last_updated: env.ledger().timestamp(),
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Return the current protocol metrics snapshot.
+pub fn get_metrics(env: &Env) -> ProtocolMetrics {
+    Storage::get_protocol_metrics(env).unwrap_or_else(|| default_metrics(env))
+}
+
+/// Return token-specific financial metrics for a given token.
+pub fn get_token_metrics(env: &Env, token: &Address) -> TokenMetric {
+    Storage::get_token_metrics(env, token).unwrap_or(TokenMetric {
+        token: token.clone(),
+        total_locked: 0,
+        total_paid_out: 0,
+        total_refunded: 0,
+    })
+}
+
+/// Increment a specific metric counter by `delta`. Infallible — never panics.
+pub fn increment(env: &Env, field: MetricField, delta: u32) {
+    let mut m = get_metrics(env);
+    match field {
+        MetricField::GrantsCreated => {
+            m.total_grants_created = m.total_grants_created.saturating_add(delta);
+        }
+        MetricField::GrantsActive => {
+            m.total_grants_active = m.total_grants_active.saturating_add(delta);
+        }
+        MetricField::GrantsCompleted => {
+            m.total_grants_completed = m.total_grants_completed.saturating_add(delta);
+            m.total_grants_active = m.total_grants_active.saturating_sub(delta);
+        }
+        MetricField::GrantsCancelled => {
+            m.total_grants_cancelled = m.total_grants_cancelled.saturating_add(delta);
+            m.total_grants_active = m.total_grants_active.saturating_sub(delta);
+        }
+        MetricField::MilestonesApproved => {
+            m.total_milestones_approved = m.total_milestones_approved.saturating_add(delta);
+        }
+        MetricField::MilestonesRejected => {
+            m.total_milestones_rejected = m.total_milestones_rejected.saturating_add(delta);
+        }
+        MetricField::MilestonesPaid => {
+            m.total_milestones_paid = m.total_milestones_paid.saturating_add(delta);
+        }
+        MetricField::ContributorsRegistered => {
+            m.total_contributors_registered = m.total_contributors_registered.saturating_add(delta);
+        }
+        MetricField::DisputesRaised => {
+            m.total_disputes_raised = m.total_disputes_raised.saturating_add(delta);
+        }
+        MetricField::DisputesResolved => {
+            m.total_disputes_resolved = m.total_disputes_resolved.saturating_add(delta);
+        }
+        MetricField::BountiesCreated => {
+            m.total_bounties_created = m.total_bounties_created.saturating_add(delta);
+        }
+        MetricField::BountiesAwarded => {
+            m.total_bounties_awarded = m.total_bounties_awarded.saturating_add(delta);
+        }
+    }
+    m.last_updated = env.ledger().timestamp();
+    Storage::set_protocol_metrics(env, &m);
+}
+
+/// Update token locked amount (positive = deposit, negative = release/refund).
+/// Uses saturating arithmetic — never panics.
+pub fn update_token_locked(env: &Env, token: &Address, delta: i128) {
+    let mut tm = get_token_metrics(env, token);
+    if delta > 0 {
+        tm.total_locked = tm.total_locked.saturating_add(delta);
+    } else {
+        let decrease = delta.saturating_abs();
+        if decrease > tm.total_locked {
+            // Released more than locked (shouldn't happen in normal flow, but safe).
+            tm.total_paid_out = tm.total_paid_out.saturating_add(decrease - tm.total_locked);
+            tm.total_locked = 0;
+        } else {
+            tm.total_locked = tm.total_locked.saturating_sub(decrease);
+            tm.total_paid_out = tm.total_paid_out.saturating_add(decrease);
+        }
+    }
+    Storage::set_token_metrics(env, &tm);
+}
+
+/// Track a refund in token metrics.
+pub fn record_token_refund(env: &Env, token: &Address, amount: i128) {
+    let mut tm = get_token_metrics(env, token);
+    tm.total_locked = tm.total_locked.saturating_sub(amount);
+    tm.total_refunded = tm.total_refunded.saturating_add(amount);
+    Storage::set_token_metrics(env, &tm);
+}
+
+/// Reset all protocol metrics to zero. Admin only (for testnet/migration use).
+pub fn reset(env: &Env, admin: &Address) -> Result<(), ContractError> {
+    if Storage::get_global_admin(env) != Some(admin.clone()) {
+        return Err(ContractError::Unauthorized);
+    }
+    Storage::set_protocol_metrics(env, &default_metrics(env));
+    Ok(())
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/multisig.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/multisig.rs
@@ -1,0 +1,205 @@
+use soroban_sdk::{Address, Bytes, Env, Vec};
+
+use crate::errors::ContractError;
+use crate::events::{MultisigExecuted, MultisigProposalCreated, MultisigSigned};
+use crate::storage::Storage;
+use crate::types::{MultisigProposal, MultisigSigner, SignatureStatus};
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Create a new multisig proposal for a grant action. Grant owner or admin only.
+pub fn create_proposal(
+    env: &Env,
+    creator: &Address,
+    grant_id: u64,
+    action_payload: Bytes,
+    signer_addresses: Vec<Address>,
+    threshold: u32,
+    ttl_ledgers: u32,
+) -> Result<u32, ContractError> {
+    if signer_addresses.is_empty() || threshold == 0 {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let mut signers: Vec<MultisigSigner> = Vec::new(env);
+    for addr in signer_addresses.iter() {
+        signers.push_back(MultisigSigner {
+            address: addr,
+            weight: 1,
+            status: SignatureStatus::Pending,
+            signed_at: None,
+        });
+    }
+
+    let now = env.ledger().timestamp();
+    let expired_at = now.saturating_add(ttl_ledgers as u64);
+
+    let proposal_id = Storage::next_multisig_proposal_id(env);
+    let proposal = MultisigProposal {
+        id: proposal_id,
+        grant_id,
+        action_payload,
+        signers,
+        threshold,
+        total_weight_signed: 0,
+        executed: false,
+        expired_at,
+        created_by: creator.clone(),
+        created_at: now,
+    };
+
+    Storage::set_multisig_proposal(env, &proposal);
+
+    MultisigProposalCreated {
+        proposal_id,
+        grant_id,
+        created_by: creator.clone(),
+        threshold,
+        timestamp: now,
+    }
+    .publish(env);
+
+    Ok(proposal_id)
+}
+
+/// A registered signer adds their signature (approve) or veto (reject).
+/// Returns updated total_weight_signed.
+pub fn sign(
+    env: &Env,
+    signer: &Address,
+    proposal_id: u32,
+    approve: bool,
+) -> Result<u32, ContractError> {
+    let mut proposal =
+        Storage::get_multisig_proposal(env, proposal_id).ok_or(ContractError::ProposalNotFound)?;
+
+    if proposal.executed {
+        return Err(ContractError::ProposalAlreadyExecuted);
+    }
+    if env.ledger().timestamp() > proposal.expired_at {
+        return Err(ContractError::ProposalExpired);
+    }
+
+    let mut found = false;
+    for i in 0..proposal.signers.len() {
+        let mut s = proposal.signers.get(i).unwrap();
+        if s.address == *signer {
+            found = true;
+            if s.status != SignatureStatus::Pending {
+                // Already signed or rejected — idempotent reject of re-sign.
+                return Ok(proposal.total_weight_signed);
+            }
+            if approve {
+                s.status = SignatureStatus::Signed;
+                s.signed_at = Some(env.ledger().timestamp());
+                proposal.total_weight_signed =
+                    proposal.total_weight_signed.saturating_add(s.weight);
+            } else {
+                s.status = SignatureStatus::Rejected;
+                s.signed_at = Some(env.ledger().timestamp());
+            }
+            proposal.signers.set(i, s);
+            break;
+        }
+    }
+
+    if !found {
+        return Err(ContractError::NotAProposalSigner);
+    }
+
+    let total_weight = proposal.total_weight_signed;
+    Storage::set_multisig_proposal(env, &proposal);
+
+    MultisigSigned {
+        proposal_id,
+        signer: signer.clone(),
+        approved: approve,
+        total_weight_signed: total_weight,
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+
+    Ok(total_weight)
+}
+
+/// Execute the proposal if threshold is met and TTL has not expired.
+/// Returns action_payload for dispatch.
+pub fn execute(env: &Env, caller: &Address, proposal_id: u32) -> Result<Bytes, ContractError> {
+    let mut proposal =
+        Storage::get_multisig_proposal(env, proposal_id).ok_or(ContractError::ProposalNotFound)?;
+
+    if proposal.executed {
+        return Err(ContractError::ProposalAlreadyExecuted);
+    }
+    if env.ledger().timestamp() > proposal.expired_at {
+        return Err(ContractError::ProposalExpired);
+    }
+    if !is_threshold_met(&proposal) {
+        return Err(ContractError::ThresholdNotMet);
+    }
+
+    proposal.executed = true;
+    let payload = proposal.action_payload.clone();
+    let grant_id = proposal.grant_id;
+    Storage::set_multisig_proposal(env, &proposal);
+
+    MultisigExecuted {
+        proposal_id,
+        grant_id,
+        executed_by: caller.clone(),
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+
+    Ok(payload)
+}
+
+/// Check whether a proposal has reached its signing threshold.
+pub fn is_threshold_met(proposal: &MultisigProposal) -> bool {
+    proposal.total_weight_signed >= proposal.threshold
+}
+
+/// Return a proposal by id.
+pub fn get_proposal(env: &Env, proposal_id: u32) -> Result<MultisigProposal, ContractError> {
+    Storage::get_multisig_proposal(env, proposal_id).ok_or(ContractError::ProposalNotFound)
+}
+
+/// Mark a proposal expired if its TTL has passed. Anyone can call.
+pub fn expire_proposal(env: &Env, proposal_id: u32) -> Result<(), ContractError> {
+    let proposal =
+        Storage::get_multisig_proposal(env, proposal_id).ok_or(ContractError::ProposalNotFound)?;
+
+    if proposal.executed {
+        return Err(ContractError::ProposalAlreadyExecuted);
+    }
+    if env.ledger().timestamp() <= proposal.expired_at {
+        return Err(ContractError::InvalidState);
+    }
+
+    // Proposal is expired; no state change needed beyond the TTL check in execute/sign.
+    Ok(())
+}
+
+// ── Action payload encoding helpers ──────────────────────────────────────────
+
+/// Encode a grant_id as an 8-byte big-endian payload (GrantWithdraw action).
+pub fn encode_grant_withdraw(env: &Env, grant_id: u64) -> Bytes {
+    let bytes = grant_id.to_be_bytes();
+    let mut payload = Bytes::new(env);
+    for b in bytes.iter() {
+        payload.push_back(*b);
+    }
+    payload
+}
+
+/// Decode a grant_id from an 8-byte big-endian payload.
+pub fn decode_grant_withdraw(payload: &Bytes) -> Option<u64> {
+    if payload.len() < 8 {
+        return None;
+    }
+    let mut bytes = [0u8; 8];
+    for (i, byte) in bytes.iter_mut().enumerate() {
+        *byte = payload.get(i as u32)?;
+    }
+    Some(u64::from_be_bytes(bytes))
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/oracle.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/oracle.rs
@@ -42,11 +42,7 @@ fn fetch_oracle_price(
     let mut args: Vec<Val> = Vec::new(env);
     args.push_back(token.clone().into_val(env));
 
-    let result: Option<(i128, u64)> = env.invoke_contract(
-        oracle,
-        &Symbol::new(env, "price"),
-        args,
-    );
+    let result: Option<(i128, u64)> = env.invoke_contract(oracle, &Symbol::new(env, "price"), args);
 
     result.ok_or(ContractError::InvalidInput)
 }
@@ -131,7 +127,11 @@ pub fn convert_amount(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{contract, contractimpl, contracttype, testutils::{Address as _, Ledger}, Address, Env};
+    use soroban_sdk::{
+        contract, contractimpl, contracttype,
+        testutils::{Address as _, Ledger},
+        Address, Env,
+    };
 
     #[contracttype]
     #[derive(Clone)]
@@ -220,7 +220,10 @@ mod tests {
         oracle_client.set_price(&base_token, &PRICE_SCALE, &100);
 
         env.ledger().set_timestamp(10_000);
-        assert_eq!(get_price(&env, &base_token), Err(ContractError::InvalidInput));
+        assert_eq!(
+            get_price(&env, &base_token),
+            Err(ContractError::InvalidInput)
+        );
     }
 
     #[test]

--- a/stellargrant-contracts/contracts/stellar-grants/src/quadratic.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/quadratic.rs
@@ -41,8 +41,8 @@ pub fn cast_qv_vote(
         return Err(ContractError::InvalidInput);
     }
 
-    let mut credits = Storage::get_voice_credits(env, voter, grant_id)
-        .ok_or(ContractError::VoterNotAllocated)?;
+    let mut credits =
+        Storage::get_voice_credits(env, voter, grant_id).ok_or(ContractError::VoterNotAllocated)?;
 
     let cost = credit_cost(votes);
     let available = credits.total_credits.saturating_sub(credits.spent_credits);
@@ -148,8 +148,8 @@ mod tests {
         allocate_credits(&env, &alice, 1, 100).unwrap();
         allocate_credits(&env, &bob, 1, 100).unwrap();
         allocate_credits(&env, &carol, 1, 100).unwrap();
-        cast_qv_vote(&env, &alice, 1, 0, 3, true).unwrap();  // 3 for
-        cast_qv_vote(&env, &bob, 1, 0, 2, true).unwrap();    // 2 for
+        cast_qv_vote(&env, &alice, 1, 0, 3, true).unwrap(); // 3 for
+        cast_qv_vote(&env, &bob, 1, 0, 2, true).unwrap(); // 2 for
         cast_qv_vote(&env, &carol, 1, 0, 4, false).unwrap(); // 4 against
         let (for_v, against_v) = tally_votes(&env, 1, 0);
         assert_eq!(for_v, 5);

--- a/stellargrant-contracts/contracts/stellar-grants/src/registry.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/registry.rs
@@ -121,6 +121,7 @@ pub fn contributor_count(env: &Env) -> u32 {
 }
 
 /// Deactivate a contributor entry (soft-delete). Admin only.
+#[allow(dead_code)]
 pub fn deactivate(env: &Env, admin: &Address, address: &Address) -> Result<(), ContractError> {
     require_global_admin(env, admin)?;
 

--- a/stellargrant-contracts/contracts/stellar-grants/src/reputation.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/reputation.rs
@@ -73,6 +73,7 @@ pub fn record_completion(
     Ok(new_score)
 }
 
+#[allow(dead_code)]
 pub fn record_rejection(
     env: &Env,
     grant_id: u64,
@@ -96,6 +97,7 @@ pub fn record_rejection(
     Ok(new_score)
 }
 
+#[allow(dead_code)]
 pub fn tier_from_score(score: u32) -> ReputationTier {
     match score {
         0..=99 => ReputationTier::Unranked,

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -1,8 +1,9 @@
 use crate::types::{
-    AuditEntry, ContractError, ContractVersion, ContributorProfile, Dispute, EscrowState, Grant,
-    HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy, MigrationRecord, Milestone,
-    PauseRecord, PaymentStream, ProtocolConfig, QuadraticVoteRecord, RegistryEntry, OracleConfig,
-    VoiceCredits, VotingMechanism,
+    AuditEntry, ComplianceAttestation, ContractError, ContractVersion, ContributorProfile, Dispute,
+    EscrowAccount, EscrowState, FunderLedger, Grant, HookEvent, HookRegistration, InsuranceClaim,
+    InsurancePolicy, MigrationRecord, Milestone, MultisigProposal, OracleConfig, PauseRecord,
+    PaymentStream, ProtocolConfig, ProtocolMetrics, QuadraticVoteRecord, RegistryEntry,
+    TokenMetric, VoiceCredits, VotingMechanism,
 };
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
@@ -58,6 +59,19 @@ pub enum DataKey {
     FeesCollected(Address),
     // Issue #524: price oracle configuration
     OracleConfig,
+    // Issue #529: escrow module
+    EscrowAccount(u64),
+    FunderContribution(u64, Address),
+    EscrowFundersList(u64),
+    // Issue #530: multisig module
+    MultisigProposal(u32),
+    MultisigProposalCounter,
+    // Issue #540: protocol metrics
+    ProtocolMetrics,
+    TokenMetrics(Address),
+    // Issue #548: compliance module
+    ComplianceAttestation(Address),
+    ComplianceVerifier,
 }
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 100_000;
@@ -328,9 +342,7 @@ impl Storage {
     }
 
     pub fn set_is_paused(env: &Env, paused: bool) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::IsPaused, &paused);
+        env.storage().persistent().set(&DataKey::IsPaused, &paused);
     }
 
     pub fn get_pause_history(env: &Env) -> Vec<PauseRecord> {
@@ -371,16 +383,12 @@ impl Storage {
             .get(&DataKey::StreamCounter)
             .unwrap_or(0);
         id += 1;
-        env.storage()
-            .persistent()
-            .set(&DataKey::StreamCounter, &id);
+        env.storage().persistent().set(&DataKey::StreamCounter, &id);
         id
     }
 
     pub fn get_stream(env: &Env, stream_id: u32) -> Option<PaymentStream> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Stream(stream_id))
+        env.storage().persistent().get(&DataKey::Stream(stream_id))
     }
 
     pub fn set_stream(env: &Env, stream: &PaymentStream) {
@@ -595,45 +603,132 @@ impl Storage {
         Self::bump_persistent_ttl(env, &key);
     }
 
-    // ── Emergency pause storage ───────────────────────────────────────────────
+    // ── Issue #529: Escrow Module ─────────────────────────────────────────────
 
-    pub fn get_is_paused(env: &Env) -> bool {
-        env.storage()
-            .persistent()
-            .get(&DataKey::IsPaused)
-            .unwrap_or(false)
-    }
-
-    pub fn set_is_paused(env: &Env, val: bool) {
-        env.storage().persistent().set(&DataKey::IsPaused, &val);
-    }
-
-    pub fn get_pause_history(env: &Env) -> soroban_sdk::Vec<PauseRecord> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::PauseHistory)
-            .unwrap_or_else(|| soroban_sdk::Vec::new(env))
-    }
-
-    pub fn append_pause_record(env: &Env, record: &PauseRecord) {
-        let mut history = Self::get_pause_history(env);
-        history.push_back(record.clone());
-        env.storage()
-            .persistent()
-            .set(&DataKey::PauseHistory, &history);
-    }
-
-    pub fn set_latest_pause_unpaused_at(env: &Env, timestamp: u64) {
-        let mut history = Self::get_pause_history(env);
-        let len = history.len();
-        if len == 0 {
-            return;
+    pub fn get_escrow_account(env: &Env, grant_id: u64) -> Option<EscrowAccount> {
+        let key = DataKey::EscrowAccount(grant_id);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
         }
-        let mut last = history.get(len - 1).unwrap();
-        last.unpaused_at = Some(timestamp);
-        history.set(len - 1, last);
+        v
+    }
+
+    pub fn set_escrow_account(env: &Env, grant_id: u64, account: &EscrowAccount) {
+        let key = DataKey::EscrowAccount(grant_id);
+        env.storage().persistent().set(&key, account);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_funder_ledger(env: &Env, grant_id: u64, funder: &Address) -> Option<FunderLedger> {
         env.storage()
             .persistent()
-            .set(&DataKey::PauseHistory, &history);
+            .get(&DataKey::FunderContribution(grant_id, funder.clone()))
+    }
+
+    pub fn set_funder_ledger(env: &Env, grant_id: u64, funder: &Address, ledger: &FunderLedger) {
+        let key = DataKey::FunderContribution(grant_id, funder.clone());
+        env.storage().persistent().set(&key, ledger);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_escrow_funders_list(env: &Env, grant_id: u64) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::EscrowFundersList(grant_id))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn set_escrow_funders_list(env: &Env, grant_id: u64, list: &Vec<Address>) {
+        let key = DataKey::EscrowFundersList(grant_id);
+        env.storage().persistent().set(&key, list);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #530: Multisig Module ───────────────────────────────────────────
+
+    pub fn next_multisig_proposal_id(env: &Env) -> u32 {
+        let mut id: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MultisigProposalCounter)
+            .unwrap_or(0);
+        id += 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::MultisigProposalCounter, &id);
+        id
+    }
+
+    pub fn get_multisig_proposal(env: &Env, proposal_id: u32) -> Option<MultisigProposal> {
+        let key = DataKey::MultisigProposal(proposal_id);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_multisig_proposal(env: &Env, proposal: &MultisigProposal) {
+        let key = DataKey::MultisigProposal(proposal.id);
+        env.storage().persistent().set(&key, proposal);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #540: Protocol Metrics ──────────────────────────────────────────
+
+    pub fn get_protocol_metrics(env: &Env) -> Option<ProtocolMetrics> {
+        env.storage().persistent().get(&DataKey::ProtocolMetrics)
+    }
+
+    pub fn set_protocol_metrics(env: &Env, metrics: &ProtocolMetrics) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ProtocolMetrics, metrics);
+    }
+
+    pub fn get_token_metrics(env: &Env, token: &Address) -> Option<TokenMetric> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::TokenMetrics(token.clone()))
+    }
+
+    pub fn set_token_metrics(env: &Env, metrics: &TokenMetric) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::TokenMetrics(metrics.token.clone()), metrics);
+    }
+
+    // ── Issue #548: Compliance Module ─────────────────────────────────────────
+
+    pub fn get_compliance_attestation(
+        env: &Env,
+        address: &Address,
+    ) -> Option<ComplianceAttestation> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ComplianceAttestation(address.clone()))
+    }
+
+    pub fn set_compliance_attestation(env: &Env, attestation: &ComplianceAttestation) {
+        let key = DataKey::ComplianceAttestation(attestation.subject.clone());
+        env.storage().persistent().set(&key, attestation);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn remove_compliance_attestation(env: &Env, address: &Address) {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ComplianceAttestation(address.clone()));
+    }
+
+    pub fn get_compliance_verifier(env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::ComplianceVerifier)
+    }
+
+    pub fn set_compliance_verifier(env: &Env, verifier: &Address) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ComplianceVerifier, verifier);
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/streaming.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/streaming.rs
@@ -79,7 +79,7 @@ pub fn create_stream(
         .ok_or(ContractError::InvalidInput)?;
 
     let token_client = token::Client::new(env, token);
-    token_client.transfer(sender, &env.current_contract_address(), &deposited);
+    token_client.transfer(sender, env.current_contract_address(), &deposited);
 
     let stream_id = Storage::next_stream_id(env);
     let stream = PaymentStream {
@@ -307,8 +307,9 @@ mod tests {
         let sender = Address::generate(&env);
         let recipient = Address::generate(&env);
         let token_admin = Address::generate(&env);
-        let token_contract =
-            env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+        let token_contract = env
+            .register_stellar_asset_contract_v2(token_admin.clone())
+            .address();
         let stellar_asset = StellarAssetClient::new(&env, &token_contract);
         stellar_asset.mint(&sender, &10_000_000);
         let _ = admin;
@@ -318,8 +319,7 @@ mod tests {
     #[test]
     fn test_accrual_at_midpoint_returns_50_percent() {
         let (env, sender, recipient, token, _) = setup();
-        let stream_id =
-            create_stream(&env, &sender, &recipient, 1, &token, 100, 100).unwrap();
+        let stream_id = create_stream(&env, &sender, &recipient, 1, &token, 100, 100).unwrap();
         // Advance to midpoint
         env.ledger().with_mut(|li| li.sequence_number += 50);
         let stream = Storage::get_stream(&env, stream_id).unwrap();
@@ -330,8 +330,7 @@ mod tests {
     #[test]
     fn test_double_withdraw_returns_zero_second_time() {
         let (env, sender, recipient, token, _) = setup();
-        let stream_id =
-            create_stream(&env, &sender, &recipient, 1, &token, 100, 100).unwrap();
+        let stream_id = create_stream(&env, &sender, &recipient, 1, &token, 100, 100).unwrap();
         env.ledger().with_mut(|li| li.sequence_number += 50);
         let first = withdraw_stream(&env, &recipient, stream_id).unwrap();
         assert!(first > 0);
@@ -342,20 +341,17 @@ mod tests {
     #[test]
     fn test_cancel_returns_correct_split() {
         let (env, sender, recipient, token, _) = setup();
-        let stream_id =
-            create_stream(&env, &sender, &recipient, 1, &token, 100, 100).unwrap();
+        let stream_id = create_stream(&env, &sender, &recipient, 1, &token, 100, 100).unwrap();
         env.ledger().with_mut(|li| li.sequence_number += 30);
-        let (sender_refund, recipient_payout) =
-            cancel_stream(&env, &sender, stream_id).unwrap();
+        let (sender_refund, recipient_payout) = cancel_stream(&env, &sender, stream_id).unwrap();
         assert_eq!(recipient_payout, 3_000); // 30 * 100
-        assert_eq!(sender_refund, 7_000);    // 70 * 100
+        assert_eq!(sender_refund, 7_000); // 70 * 100
     }
 
     #[test]
     fn test_pause_resume_maintains_end_ledger() {
         let (env, sender, recipient, token, _) = setup();
-        let stream_id =
-            create_stream(&env, &sender, &recipient, 1, &token, 1, 100).unwrap();
+        let stream_id = create_stream(&env, &sender, &recipient, 1, &token, 1, 100).unwrap();
         let stream_before = Storage::get_stream(&env, stream_id).unwrap();
         let original_end = stream_before.end_ledger;
 

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -101,6 +101,7 @@ pub struct Grant {
     pub funders: Vec<GrantFund>,
     pub reason: Option<String>,
     pub timestamp: u64,
+    pub require_compliance: Option<ComplianceLevel>,
 }
 
 #[contracttype]
@@ -327,8 +328,8 @@ pub struct HookCallResult {
 }
 
 /// Opaque byte payload passed to hook callbacks.
+#[allow(dead_code)]
 pub type HookPayload = Bytes;
-
 
 // ── Issue #514: Dispute Resolution Module ────────────────────────────────────
 
@@ -384,6 +385,8 @@ pub struct ProtocolConfig {
     pub dispute_window_ledgers: u32,
     pub max_grant_title_len: u32,
     pub max_grant_desc_len: u32,
+    /// Grants with total_amount above this threshold require multisig release (0 = disabled).
+    pub multisig_threshold: i128,
 }
 
 // ── Issue #517: Protocol Fee Collection ──────────────────────────────────────
@@ -417,4 +420,123 @@ pub struct PriceQuote {
     pub price_in_base: i128,
     pub fetched_at: u64,
     pub is_stale: bool,
+}
+
+// ── Issue #529: Escrow Module ─────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EscrowAccount {
+    pub owner: Address,
+    pub token: Address,
+    pub balance: i128,
+    pub total_deposited: i128,
+    pub total_released: i128,
+    /// True when a dispute is open; blocks release but not deposit.
+    pub locked: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FunderLedger {
+    pub funder: Address,
+    pub contributed: i128,
+    pub refunded: i128,
+    pub last_contribution_at: u64,
+}
+
+// ── Issue #530: M-of-N Multi-Signature Fund Release ───────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SignatureStatus {
+    Pending = 0,
+    Signed = 1,
+    Rejected = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultisigSigner {
+    pub address: Address,
+    pub weight: u32,
+    pub status: SignatureStatus,
+    pub signed_at: Option<u64>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultisigProposal {
+    pub id: u32,
+    pub grant_id: u64,
+    pub action_payload: Bytes,
+    pub signers: Vec<MultisigSigner>,
+    pub threshold: u32,
+    pub total_weight_signed: u32,
+    pub executed: bool,
+    pub expired_at: u64,
+    pub created_by: Address,
+    pub created_at: u64,
+}
+
+// ── Issue #540: Protocol-Wide On-Chain Metrics ────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TokenMetric {
+    pub token: Address,
+    pub total_locked: i128,
+    pub total_paid_out: i128,
+    pub total_refunded: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProtocolMetrics {
+    pub total_grants_created: u32,
+    pub total_grants_active: u32,
+    pub total_grants_completed: u32,
+    pub total_grants_cancelled: u32,
+    pub total_milestones_approved: u32,
+    pub total_milestones_rejected: u32,
+    pub total_milestones_paid: u32,
+    pub total_contributors_registered: u32,
+    pub total_disputes_raised: u32,
+    pub total_disputes_resolved: u32,
+    pub total_bounties_created: u32,
+    pub total_bounties_awarded: u32,
+    pub last_updated: u64,
+}
+
+// ── Issue #548: KYC/AML Compliance Integration Hooks ─────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ComplianceStatus {
+    Unverified = 0,
+    Pending = 1,
+    Approved = 2,
+    Rejected = 3,
+    Expired = 4,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ComplianceLevel {
+    None = 0,
+    Basic = 1,
+    Standard = 2,
+    Enhanced = 3,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ComplianceAttestation {
+    pub subject: Address,
+    pub status: ComplianceStatus,
+    pub level: ComplianceLevel,
+    pub attested_by: Address,
+    pub attested_at: u64,
+    pub expires_at: u64,
+    pub jurisdiction: String,
 }


### PR DESCRIPTION
## Summary

This PR implements four protocol enhancements tracked in issues #529, #530, #540, and #548.

---

### #529 — Escrow Module Extraction

Extracts all token transfer logic out of `lib.rs` into a new standalone `escrow.rs` module, making token custody an explicit first-class concern.

- `EscrowAccount` tracks per-grant balance, total deposited, total released, and lock state
- `FunderLedger` tracks per-funder contributed and refunded amounts with timestamps
- `escrow::deposit` / `release` / `refund` / `refund_all` handle all token movement; `lib.rs` no longer calls `token::Client` directly
- `refund_all` distributes remaining balance proportionally by net contribution (saturating math)
- `EscrowFundersList` storage key keeps an ordered list of funders for iteration
- New entry points: `get_escrow_account`, `get_funder_ledger`, `refund_funder`, `lock_escrow`, `unlock_escrow`

---

### #530 — M-of-N Multi-Signature Fund Release

New `multisig.rs` module implementing weighted threshold signing for grant actions.

- `MultisigProposal` stores signers with individual weights, TTL, and execution state
- `create_proposal` → `sign` → `execute` lifecycle; execution requires `total_weight_signed >= threshold`
- Action payload is an opaque `Bytes` blob; `encode_grant_withdraw` / `decode_grant_withdraw` helpers encode a `u64` grant_id in 8-byte big-endian for `GrantWithdraw` proposals
- Proposals are time-bound; `expire_proposal` can be called by anyone once TTL passes
- Emits `MultisigProposalCreated`, `MultisigSigned`, `MultisigExecuted` events
- New entry points: `create_multisig_proposal`, `sign_proposal`, `execute_multisig_proposal`, `get_multisig_proposal`, `expire_multisig_proposal`, `encode_grant_withdraw_payload`

---

### #540 — Aggregated Protocol-Wide On-Chain Metrics

New `metrics.rs` module providing a queryable snapshot of protocol activity.

- `ProtocolMetrics` struct with 12 counters: grants created/active/completed/cancelled, milestones approved/rejected/paid, contributors registered, disputes raised/resolved, bounties created/awarded
- `TokenMetric` tracks per-token total locked, paid out, and refunded amounts
- All arithmetic is saturating — the module never panics
- `increment(env, MetricField, delta)` is wired into `grant_create`, `grant_fund`, `milestone_vote`, `contributor_register`, `dispute_raise`, `dispute_resolve`
- `update_token_locked` / `record_token_refund` called from escrow operations
- New entry points: `get_protocol_metrics`, `get_token_metrics`, `reset_metrics`

---

### #548 — KYC/AML Compliance Integration Hooks

New `compliance.rs` module providing verifier-gated attestations as a grant-level compliance gate.

- `ComplianceAttestation` stores subject, status, level, attesting verifier, timestamps, expiry, and jurisdiction
- `ComplianceLevel` enum: `None` (ungated) / `Basic` / `Standard` / `Enhanced`
- Only the registered verifier address can call `attest` or `revoke` (prevents self-attestation)
- `require_compliant` returns `Ok(())` immediately for `ComplianceLevel::None`, so existing grants are unaffected
- `is_valid` checks attestation status and expiry against `env.ledger().timestamp()`
- `finalize_grant_release` calls `compliance::require_compliant` before releasing funds when `grant.require_compliance` is set
- Emits `ComplianceAttested` and `ComplianceRevoked` events
- New entry points: `set_compliance_verifier`, `attest_compliance`, `revoke_compliance`, `get_compliance_attestation`, `set_grant_compliance_level`

---

### Pre-existing bug fix

Removed a duplicate function block in `storage.rs` where `get_is_paused`, `set_is_paused`, `get_pause_history`, `append_pause_record`, and `set_latest_pause_unpaused_at` were defined twice, causing compile errors on the main branch.

---

## CI

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --lib --target wasm32v1-none -- -D warnings` ✅
- `cargo check --workspace --target wasm32v1-none` ✅

Closes #529
Closes #530
Closes #540
Closes #548