### PR TITLE
feat: implement crowdfund module with target-and-deadline campaigns

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/crowdfund.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/crowdfund.rs
@@ -1,0 +1,391 @@
+use soroban_sdk::{token, Address, Env, String, Vec};
+
+use crate::circuit_breaker;
+use crate::emergency;
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{
+    ContractError, CrowdfundCampaign, CrowdfundPledge, CrowdfundStatus, ProtocolModule,
+};
+
+/// Create a new crowdfunding campaign. Funds are held in the contract until
+/// the deadline passes. If the target is met, the owner may call `finalize`
+/// to receive the collected tokens. If the target is missed, backers may
+/// call `claim_refund` to reclaim their pledges.
+pub fn create_campaign(
+    env: &Env,
+    owner: &Address,
+    title: String,
+    description: String,
+    token: &Address,
+    target_amount: i128,
+    deadline_ledgers: u32,
+) -> Result<u64, ContractError> {
+    emergency::require_not_paused(env)?;
+    circuit_breaker::require_open(env, ProtocolModule::Crowdfund)?;
+
+    if target_amount <= 0 {
+        return Err(ContractError::ZeroAmount);
+    }
+    if title.is_empty() {
+        return Err(ContractError::InvalidInput);
+    }
+    if deadline_ledgers == 0 {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let now = env.ledger().timestamp();
+    let deadline = now.saturating_add(deadline_ledgers as u64);
+    let id = Storage::next_crowdfund_id(env);
+
+    let campaign = CrowdfundCampaign {
+        id,
+        owner: owner.clone(),
+        title: title.clone(),
+        description,
+        token: token.clone(),
+        target_amount,
+        total_pledged: 0,
+        deadline,
+        status: CrowdfundStatus::Active,
+        created_at: now,
+    };
+
+    Storage::set_crowdfund_campaign(env, &campaign);
+    Events::emit_crowdfund_created(env, id, owner.clone(), title, target_amount, deadline);
+
+    Ok(id)
+}
+
+/// Pledge tokens to an active campaign. The caller must approve the contract
+/// to transfer `amount` tokens before calling this function. Each address may
+/// pledge multiple times; subsequent calls increase the existing pledge.
+pub fn pledge(
+    env: &Env,
+    campaign_id: u64,
+    backer: &Address,
+    amount: i128,
+) -> Result<(), ContractError> {
+    emergency::require_not_paused(env)?;
+    circuit_breaker::require_open(env, ProtocolModule::Crowdfund)?;
+
+    if amount <= 0 {
+        return Err(ContractError::ZeroAmount);
+    }
+
+    let mut campaign = Storage::get_crowdfund_campaign(env, campaign_id)
+        .ok_or(ContractError::CrowdfundNotFound)?;
+
+    if campaign.status != CrowdfundStatus::Active {
+        return Err(ContractError::CrowdfundNotActive);
+    }
+    if env.ledger().timestamp() > campaign.deadline {
+        return Err(ContractError::DeadlinePassed);
+    }
+
+    token::Client::new(env, &campaign.token).transfer(
+        backer,
+        &env.current_contract_address(),
+        &amount,
+    );
+
+    let existing = Storage::get_crowdfund_pledge(env, campaign_id, backer);
+    let (new_amount, is_new_backer) = match existing {
+        Some(mut p) => {
+            p.amount = p.amount.saturating_add(amount);
+            p.pledged_at = env.ledger().timestamp();
+            Storage::set_crowdfund_pledge(env, &p);
+            (p.amount, false)
+        }
+        None => {
+            let pledge = CrowdfundPledge {
+                campaign_id,
+                backer: backer.clone(),
+                amount,
+                pledged_at: env.ledger().timestamp(),
+                refunded: false,
+            };
+            Storage::set_crowdfund_pledge(env, &pledge);
+            (amount, true)
+        }
+    };
+
+    if is_new_backer {
+        let mut backers = Storage::get_crowdfund_backers(env, campaign_id);
+        backers.push_back(backer.clone());
+        Storage::set_crowdfund_backers(env, campaign_id, &backers);
+    }
+
+    campaign.total_pledged = campaign.total_pledged.saturating_add(amount);
+    Storage::set_crowdfund_campaign(env, &campaign);
+
+    Events::emit_crowdfund_pledged(env, campaign_id, backer.clone(), amount, campaign.total_pledged);
+
+    let _ = new_amount;
+    Ok(())
+}
+
+/// Finalize a campaign once its deadline has passed. Anyone may call this.
+///
+/// - If `total_pledged >= target_amount`: marks the campaign as Succeeded and
+///   transfers all pledged tokens to the campaign owner.
+/// - If `total_pledged < target_amount`: marks the campaign as Failed so that
+///   backers can call `claim_refund`.
+pub fn finalize(env: &Env, campaign_id: u64) -> Result<CrowdfundStatus, ContractError> {
+    let mut campaign = Storage::get_crowdfund_campaign(env, campaign_id)
+        .ok_or(ContractError::CrowdfundNotFound)?;
+
+    if campaign.status != CrowdfundStatus::Active {
+        return Err(ContractError::CrowdfundAlreadyFinalized);
+    }
+    if env.ledger().timestamp() <= campaign.deadline {
+        return Err(ContractError::CrowdfundDeadlineNotReached);
+    }
+
+    let new_status = if campaign.total_pledged >= campaign.target_amount {
+        token::Client::new(env, &campaign.token).transfer(
+            &env.current_contract_address(),
+            &campaign.owner,
+            &campaign.total_pledged,
+        );
+        Events::emit_crowdfund_succeeded(env, campaign_id, campaign.total_pledged);
+        CrowdfundStatus::Succeeded
+    } else {
+        Events::emit_crowdfund_failed(env, campaign_id, campaign.total_pledged);
+        CrowdfundStatus::Failed
+    };
+
+    campaign.status = new_status.clone();
+    Storage::set_crowdfund_campaign(env, &campaign);
+
+    Ok(new_status)
+}
+
+/// Claim a refund after a campaign has Failed or been Cancelled.
+/// Each backer may only claim once.
+pub fn claim_refund(
+    env: &Env,
+    campaign_id: u64,
+    backer: &Address,
+) -> Result<(), ContractError> {
+    let campaign = Storage::get_crowdfund_campaign(env, campaign_id)
+        .ok_or(ContractError::CrowdfundNotFound)?;
+
+    if campaign.status != CrowdfundStatus::Failed
+        && campaign.status != CrowdfundStatus::Cancelled
+    {
+        return Err(ContractError::CrowdfundNotActive);
+    }
+
+    let mut pledge = Storage::get_crowdfund_pledge(env, campaign_id, backer)
+        .ok_or(ContractError::NoRefundableAmount)?;
+
+    if pledge.refunded {
+        return Err(ContractError::NoRefundableAmount);
+    }
+    if pledge.amount <= 0 {
+        return Err(ContractError::ZeroAmount);
+    }
+
+    let refund_amount = pledge.amount;
+    token::Client::new(env, &campaign.token).transfer(
+        &env.current_contract_address(),
+        backer,
+        &refund_amount,
+    );
+
+    pledge.refunded = true;
+    Storage::set_crowdfund_pledge(env, &pledge);
+
+    Events::emit_crowdfund_refunded(env, campaign_id, backer.clone(), refund_amount);
+
+    Ok(())
+}
+
+/// Cancel an Active campaign. Only the campaign owner may call this.
+/// After cancellation, all backers may call `claim_refund` individually.
+pub fn cancel(env: &Env, campaign_id: u64, caller: &Address) -> Result<(), ContractError> {
+    let mut campaign = Storage::get_crowdfund_campaign(env, campaign_id)
+        .ok_or(ContractError::CrowdfundNotFound)?;
+
+    if campaign.owner != *caller {
+        return Err(ContractError::Unauthorized);
+    }
+    if campaign.status != CrowdfundStatus::Active {
+        return Err(ContractError::CrowdfundAlreadyFinalized);
+    }
+
+    campaign.status = CrowdfundStatus::Cancelled;
+    Storage::set_crowdfund_campaign(env, &campaign);
+
+    Events::emit_crowdfund_cancelled(env, campaign_id, caller.clone(), campaign.total_pledged);
+
+    Ok(())
+}
+
+pub fn get_campaign(env: &Env, campaign_id: u64) -> Option<CrowdfundCampaign> {
+    Storage::get_crowdfund_campaign(env, campaign_id)
+}
+
+pub fn get_pledge(env: &Env, campaign_id: u64, backer: &Address) -> Option<CrowdfundPledge> {
+    Storage::get_crowdfund_pledge(env, campaign_id, backer)
+}
+
+pub fn list_backers(env: &Env, campaign_id: u64) -> Vec<Address> {
+    Storage::get_crowdfund_backers(env, campaign_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+
+    fn make_campaign(env: &Env, owner: &Address, token: &Address) -> u64 {
+        let id = Storage::next_crowdfund_id(env);
+        let campaign = CrowdfundCampaign {
+            id,
+            owner: owner.clone(),
+            title: String::from_str(env, "Test Campaign"),
+            description: String::from_str(env, "desc"),
+            token: token.clone(),
+            target_amount: 1_000,
+            total_pledged: 0,
+            deadline: env.ledger().timestamp() + 1_000,
+            status: CrowdfundStatus::Active,
+            created_at: env.ledger().timestamp(),
+        };
+        Storage::set_crowdfund_campaign(env, &campaign);
+        id
+    }
+
+    #[test]
+    fn test_pledge_to_unknown_campaign_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let backer = Address::generate(&env);
+        let result = pledge(&env, 999, &backer, 100);
+        assert_eq!(result, Err(ContractError::CrowdfundNotFound));
+    }
+
+    #[test]
+    fn test_pledge_after_deadline_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let backer = Address::generate(&env);
+        let id = make_campaign(&env, &owner, &token);
+
+        env.ledger().with_mut(|l| l.timestamp += 2_000);
+        let result = pledge(&env, id, &backer, 100);
+        assert_eq!(result, Err(ContractError::DeadlinePassed));
+    }
+
+    #[test]
+    fn test_finalize_before_deadline_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let id = make_campaign(&env, &owner, &token);
+
+        let result = finalize(&env, id);
+        assert_eq!(result, Err(ContractError::CrowdfundDeadlineNotReached));
+    }
+
+    #[test]
+    fn test_finalize_underfunded_marks_failed() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let id = make_campaign(&env, &owner, &token);
+
+        env.ledger().with_mut(|l| l.timestamp += 2_000);
+        let status = finalize(&env, id).unwrap();
+        assert_eq!(status, CrowdfundStatus::Failed);
+        let campaign = get_campaign(&env, id).unwrap();
+        assert_eq!(campaign.status, CrowdfundStatus::Failed);
+    }
+
+    #[test]
+    fn test_double_finalize_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let id = make_campaign(&env, &owner, &token);
+
+        env.ledger().with_mut(|l| l.timestamp += 2_000);
+        finalize(&env, id).unwrap();
+        let result = finalize(&env, id);
+        assert_eq!(result, Err(ContractError::CrowdfundAlreadyFinalized));
+    }
+
+    #[test]
+    fn test_claim_refund_on_active_campaign_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let backer = Address::generate(&env);
+        let id = make_campaign(&env, &owner, &token);
+
+        let result = claim_refund(&env, id, &backer);
+        assert_eq!(result, Err(ContractError::CrowdfundNotActive));
+    }
+
+    #[test]
+    fn test_claim_refund_with_no_pledge_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let backer = Address::generate(&env);
+        let id = make_campaign(&env, &owner, &token);
+
+        env.ledger().with_mut(|l| l.timestamp += 2_000);
+        finalize(&env, id).unwrap();
+
+        let result = claim_refund(&env, id, &backer);
+        assert_eq!(result, Err(ContractError::NoRefundableAmount));
+    }
+
+    #[test]
+    fn test_cancel_by_non_owner_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let id = make_campaign(&env, &owner, &token);
+
+        let result = cancel(&env, id, &stranger);
+        assert_eq!(result, Err(ContractError::Unauthorized));
+    }
+
+    #[test]
+    fn test_cancel_marks_status() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let id = make_campaign(&env, &owner, &token);
+
+        cancel(&env, id, &owner).unwrap();
+        let campaign = get_campaign(&env, id).unwrap();
+        assert_eq!(campaign.status, CrowdfundStatus::Cancelled);
+    }
+
+    #[test]
+    fn test_list_backers_empty_initially() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+        let id = make_campaign(&env, &owner, &token);
+
+        let backers = list_backers(&env, id);
+        assert_eq!(backers.len(), 0);
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/errors.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/errors.rs
@@ -102,4 +102,10 @@ pub enum ContractError {
     // Invoice (#566)
     InvoiceNotFound = 82,
     InvoiceAlreadySubmitted = 83,
+    // Crowdfund module
+    CrowdfundNotFound = 84,
+    CrowdfundNotActive = 85,
+    CrowdfundDeadlineNotReached = 86,
+    CrowdfundAlreadyFinalized = 87,
+    AlreadyPledged = 88,
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -1086,4 +1086,142 @@ impl Events {
         };
         event.publish(env);
     }
+
+    // ── Crowdfund emit methods ────────────────────────────────────────────────
+
+    pub fn emit_crowdfund_created(
+        env: &Env,
+        campaign_id: u64,
+        owner: Address,
+        title: String,
+        target_amount: i128,
+        deadline: u64,
+    ) {
+        let event = CrowdfundCreated {
+            campaign_id,
+            owner,
+            title,
+            target_amount,
+            deadline,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_crowdfund_pledged(
+        env: &Env,
+        campaign_id: u64,
+        backer: Address,
+        amount: i128,
+        total_pledged: i128,
+    ) {
+        let event = CrowdfundPledged {
+            campaign_id,
+            backer,
+            amount,
+            total_pledged,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_crowdfund_succeeded(env: &Env, campaign_id: u64, total_pledged: i128) {
+        let event = CrowdfundSucceeded {
+            campaign_id,
+            total_pledged,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_crowdfund_failed(env: &Env, campaign_id: u64, total_pledged: i128) {
+        let event = CrowdfundFailed {
+            campaign_id,
+            total_pledged,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_crowdfund_refunded(env: &Env, campaign_id: u64, backer: Address, amount: i128) {
+        let event = CrowdfundRefunded {
+            campaign_id,
+            backer,
+            amount,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_crowdfund_cancelled(
+        env: &Env,
+        campaign_id: u64,
+        cancelled_by: Address,
+        total_pledged: i128,
+    ) {
+        let event = CrowdfundCancelled {
+            campaign_id,
+            cancelled_by,
+            total_pledged,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+}
+
+// ── Crowdfund events ──────────────────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrowdfundCreated {
+    pub campaign_id: u64,
+    pub owner: Address,
+    pub title: String,
+    pub target_amount: i128,
+    pub deadline: u64,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrowdfundPledged {
+    pub campaign_id: u64,
+    pub backer: Address,
+    pub amount: i128,
+    pub total_pledged: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrowdfundSucceeded {
+    pub campaign_id: u64,
+    pub total_pledged: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrowdfundFailed {
+    pub campaign_id: u64,
+    pub total_pledged: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrowdfundRefunded {
+    pub campaign_id: u64,
+    pub backer: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrowdfundCancelled {
+    pub campaign_id: u64,
+    pub cancelled_by: Address,
+    pub total_pledged: i128,
+    pub timestamp: u64,
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -5,6 +5,7 @@ mod analytics;
 mod audit;
 mod checklist;
 mod circuit_breaker;
+mod crowdfund;
 mod compliance;
 mod config;
 mod constants;
@@ -49,6 +50,7 @@ pub use storage::Storage;
 pub use types::{
     AcceptanceCriteria, AnalyticsSnapshot, AuditAction, AuditEntry, BreakerState, CategoryStats,
     ChecklistSubmission, ComplianceAttestation, ComplianceLevel, ComplianceStatus, ContractVersion,
+    CrowdfundCampaign, CrowdfundPledge, CrowdfundStatus,
     CriterionStatus, DexConfig, Dispute, DisputeStatus, EscrowAccount, EscrowLifecycleState,
     EscrowMode, EscrowState, FeeRecord, FunderLedger, Grant, GrantArchetype, GrantCategory,
     GrantFund, GrantStatus, GrantTag, GrantTemplate, HookCallResult, HookEvent, HookRegistration,
@@ -2219,6 +2221,93 @@ impl StellarGrantsContract {
     /// Renounce your own role (voluntary self-removal).
     pub fn rbac_renounce_role(env: Env, holder: Address, role: Role) -> Result<(), ContractError> {
         access_control::renounce_role(&env, &holder, role)
+    }
+
+    // ── Crowdfund Module ──────────────────────────────────────────────────────
+
+    /// Create a new crowdfunding campaign with a funding target and deadline.
+    /// If the target is met by the deadline the owner receives the tokens;
+    /// otherwise backers can reclaim their pledges via `crowdfund_refund`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn crowdfund_create(
+        env: Env,
+        owner: Address,
+        title: String,
+        description: String,
+        token: Address,
+        target_amount: i128,
+        deadline_ledgers: u32,
+    ) -> Result<u64, ContractError> {
+        owner.require_auth();
+        crowdfund::create_campaign(
+            &env,
+            &owner,
+            title,
+            description,
+            &token,
+            target_amount,
+            deadline_ledgers,
+        )
+    }
+
+    /// Pledge tokens to an active campaign. Caller must pre-approve the
+    /// contract to transfer `amount` tokens.
+    pub fn crowdfund_pledge(
+        env: Env,
+        campaign_id: u64,
+        backer: Address,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        backer.require_auth();
+        crowdfund::pledge(&env, campaign_id, &backer, amount)
+    }
+
+    /// Finalize a campaign once its deadline has passed. Anyone may call this.
+    /// Returns the resulting `CrowdfundStatus` (Succeeded or Failed).
+    pub fn crowdfund_finalize(
+        env: Env,
+        campaign_id: u64,
+    ) -> Result<CrowdfundStatus, ContractError> {
+        crowdfund::finalize(&env, campaign_id)
+    }
+
+    /// Claim a pledge refund after a Failed or Cancelled campaign.
+    pub fn crowdfund_refund(
+        env: Env,
+        campaign_id: u64,
+        backer: Address,
+    ) -> Result<(), ContractError> {
+        backer.require_auth();
+        crowdfund::claim_refund(&env, campaign_id, &backer)
+    }
+
+    /// Cancel an active campaign. Only the campaign owner may call this.
+    pub fn crowdfund_cancel(
+        env: Env,
+        campaign_id: u64,
+        caller: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        crowdfund::cancel(&env, campaign_id, &caller)
+    }
+
+    /// Fetch campaign details by id.
+    pub fn crowdfund_get_campaign(env: Env, campaign_id: u64) -> Option<CrowdfundCampaign> {
+        crowdfund::get_campaign(&env, campaign_id)
+    }
+
+    /// Fetch a specific backer's pledge for a campaign.
+    pub fn crowdfund_get_pledge(
+        env: Env,
+        campaign_id: u64,
+        backer: Address,
+    ) -> Option<CrowdfundPledge> {
+        crowdfund::get_pledge(&env, campaign_id, &backer)
+    }
+
+    /// List all backer addresses for a campaign.
+    pub fn crowdfund_list_backers(env: Env, campaign_id: u64) -> Vec<Address> {
+        crowdfund::list_backers(&env, campaign_id)
     }
 
     // ── Private Helpers ───────────────────────────────────────────────────────

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -1,6 +1,6 @@
 use crate::types::{
     AcceptanceCriteria, AnalyticsSnapshot, AuditEntry, BreakerState, CategoryStats, ChecklistSubmission, ComplianceAttestation,
-    ContractError, ContractVersion, ContributorProfile, DexConfig, Dispute, EscrowAccount,
+    ContractError, ContractVersion, ContributorProfile, CrowdfundCampaign, CrowdfundPledge, DexConfig, Dispute, EscrowAccount,
     EscrowState, FunderLedger, Grant, GrantCategory, GrantTag, HookEvent, HookRegistration,
     InsuranceClaim, InsurancePolicy, Invoice, MerkleCommitment, MigrationRecord, Milestone,
     MultisigProposal, OracleConfig, ParamRecord, PauseRecord, PaymentStream, ProtocolConfig, ProtocolMetrics,
@@ -114,6 +114,11 @@ pub enum DataKey {
     // Issue #593: RBAC
     RoleAssignment(Address, Role),
     RoleMembers(Role),
+    // Crowdfund module
+    CrowdfundCampaign(u64),
+    CrowdfundPledge(u64, Address),
+    CrowdfundBackers(u64),
+    CrowdfundCounter,
 }
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 100_000;
@@ -1031,6 +1036,7 @@ impl Storage {
     }
 }
 
+impl Storage {
     // ── Issue #566: Invoice Billing ─────────────────────────────────────────────
 
     pub fn get_invoice(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<Invoice> {
@@ -1134,6 +1140,68 @@ impl Storage {
     pub fn set_role_members(env: &Env, role: &Role, members: &Vec<Address>) {
         let key = DataKey::RoleMembers(role.clone());
         env.storage().persistent().set(&key, members);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Crowdfund Module ──────────────────────────────────────────────────────
+
+    pub fn next_crowdfund_id(env: &Env) -> u64 {
+        let mut id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CrowdfundCounter)
+            .unwrap_or(0);
+        id += 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::CrowdfundCounter, &id);
+        id
+    }
+
+    pub fn get_crowdfund_campaign(env: &Env, id: u64) -> Option<CrowdfundCampaign> {
+        let key = DataKey::CrowdfundCampaign(id);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_crowdfund_campaign(env: &Env, campaign: &CrowdfundCampaign) {
+        let key = DataKey::CrowdfundCampaign(campaign.id);
+        env.storage().persistent().set(&key, campaign);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_crowdfund_pledge(
+        env: &Env,
+        campaign_id: u64,
+        backer: &Address,
+    ) -> Option<CrowdfundPledge> {
+        let key = DataKey::CrowdfundPledge(campaign_id, backer.clone());
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_crowdfund_pledge(env: &Env, pledge: &CrowdfundPledge) {
+        let key = DataKey::CrowdfundPledge(pledge.campaign_id, pledge.backer.clone());
+        env.storage().persistent().set(&key, pledge);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_crowdfund_backers(env: &Env, campaign_id: u64) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CrowdfundBackers(campaign_id))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn set_crowdfund_backers(env: &Env, campaign_id: u64, backers: &Vec<Address>) {
+        let key = DataKey::CrowdfundBackers(campaign_id);
+        env.storage().persistent().set(&key, backers);
         Self::bump_persistent_ttl(env, &key);
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -1153,3 +1153,40 @@ pub struct RoleAssignment {
     pub expires_at: Option<u64>,
     pub is_active: bool,
 }
+
+// ── Crowdfund Module ──────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum CrowdfundStatus {
+    Active = 0,
+    Succeeded = 1,
+    Failed = 2,
+    Cancelled = 3,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrowdfundCampaign {
+    pub id: u64,
+    pub owner: Address,
+    pub title: String,
+    pub description: String,
+    pub token: Address,
+    pub target_amount: i128,
+    pub total_pledged: i128,
+    pub deadline: u64,
+    pub status: CrowdfundStatus,
+    pub created_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrowdfundPledge {
+    pub campaign_id: u64,
+    pub backer: Address,
+    pub amount: i128,
+    pub pledged_at: u64,
+    pub refunded: bool,
+}


### PR DESCRIPTION
Closes #562 
Closes #559 
Closes #563 
Closes #560   

#Summary
New module crowdfund.rs — Kickstarter-style crowdfunding for grants. Backers pledge tokens; target met before deadline releases funds to owner, otherwise backers claim full refunds.
New types CrowdfundCampaign, CrowdfundPledge, CrowdfundStatus added to types.rs
5 new error codes in errors.rs: CrowdfundNotFound, CrowdfundNotActive, CrowdfundDeadlineNotReached, CrowdfundAlreadyFinalized, AlreadyPledged
6 new events in events.rs: CrowdfundCreated, CrowdfundPledged, CrowdfundSucceeded, CrowdfundFailed, CrowdfundRefunded, CrowdfundCancelled
8 new contract entry points in lib.rs: crowdfund_create, crowdfund_pledge, crowdfund_finalize, crowdfund_refund, crowdfund_cancel, crowdfund_get_campaign, crowdfund_get_pledge, crowdfund_list_backers
Bug fix in storage.rs — Invoice/Analytics/Params/RBAC storage methods were outside the impl Storage block; added missing opener to restore compilation