### PR TITLE
feat: implement IP license tracking, payment splitting, grant transfe…

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/evidence_schema.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/evidence_schema.rs
@@ -1,0 +1,94 @@
+use crate::storage::Storage;
+use crate::types::{ContractError, EvidenceField, EvidenceSchema, StructuredEvidence};
+use soroban_sdk::{Address, Env, Map, String, Vec};
+
+/// Define the evidence schema for a milestone. Only the grant owner or global admin may call this.
+/// Fields describe what structured evidence contributors must supply on milestone submission.
+pub fn set_schema(
+    env: &Env,
+    caller: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    fields: Vec<EvidenceField>,
+) -> Result<(), ContractError> {
+    caller.require_auth();
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    let is_admin = Storage::get_global_admin(env).map_or(false, |a| a == *caller);
+    if grant.owner != *caller && !is_admin {
+        return Err(ContractError::Unauthorized);
+    }
+    if milestone_idx >= grant.total_milestones {
+        return Err(ContractError::MilestoneIndexOutOfBounds);
+    }
+    if fields.is_empty() {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let schema = EvidenceSchema { grant_id, milestone_idx, fields };
+    Storage::set_evidence_schema(env, grant_id, milestone_idx, &schema);
+    Ok(())
+}
+
+/// Submit structured evidence for a milestone. Must conform to the registered schema (if any).
+/// This must be called before `milestone_submit` when a schema exists.
+pub fn submit_evidence(
+    env: &Env,
+    caller: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    values: Map<String, String>,
+) -> Result<(), ContractError> {
+    caller.require_auth();
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if grant.owner != *caller {
+        return Err(ContractError::Unauthorized);
+    }
+
+    if let Some(schema) = Storage::get_evidence_schema(env, grant_id, milestone_idx) {
+        for field in schema.fields.iter() {
+            if field.required && !values.contains_key(field.name.clone()) {
+                return Err(ContractError::InvalidInput);
+            }
+        }
+    }
+
+    let evidence = StructuredEvidence {
+        grant_id,
+        milestone_idx,
+        values,
+        submitted_by: caller.clone(),
+        submitted_at: env.ledger().timestamp(),
+    };
+    Storage::set_structured_evidence(env, grant_id, milestone_idx, &evidence);
+    Ok(())
+}
+
+/// Validate that structured evidence satisfying the schema has been submitted.
+/// Returns Ok(()) if no schema exists (nothing to validate).
+/// Returns Err(InvalidInput) if required fields are missing from submitted evidence.
+pub fn validate_evidence(env: &Env, grant_id: u64, milestone_idx: u32) -> Result<(), ContractError> {
+    let schema = match Storage::get_evidence_schema(env, grant_id, milestone_idx) {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+
+    let evidence = Storage::get_structured_evidence(env, grant_id, milestone_idx)
+        .ok_or(ContractError::InvalidInput)?;
+
+    for field in schema.fields.iter() {
+        if field.required && !evidence.values.contains_key(field.name.clone()) {
+            return Err(ContractError::InvalidInput);
+        }
+    }
+    Ok(())
+}
+
+pub fn get_schema(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<EvidenceSchema> {
+    Storage::get_evidence_schema(env, grant_id, milestone_idx)
+}
+
+pub fn get_evidence(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<StructuredEvidence> {
+    Storage::get_structured_evidence(env, grant_id, milestone_idx)
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/grant_transfer.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/grant_transfer.rs
@@ -1,0 +1,89 @@
+use crate::storage::Storage;
+use crate::types::{ContractError, GrantStatus, TransferProposal, TransferableRole};
+use soroban_sdk::{Address, Env};
+
+/// Propose a two-step ownership or reviewer-role transfer for a grant.
+/// For Owner transfers, the caller must be the current owner.
+/// For Reviewer transfers, the caller must be the owner OR the reviewer being replaced,
+/// and `reviewer_to_replace` must currently be in the grant's reviewer list.
+pub fn propose_transfer(
+    env: &Env,
+    caller: &Address,
+    grant_id: u64,
+    new_holder: Address,
+    role: TransferableRole,
+    reviewer_to_replace: Option<Address>,
+) -> Result<(), ContractError> {
+    caller.require_auth();
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if grant.status != GrantStatus::Active {
+        return Err(ContractError::InvalidState);
+    }
+
+    match role {
+        TransferableRole::Owner => {
+            if grant.owner != *caller {
+                return Err(ContractError::Unauthorized);
+            }
+        }
+        TransferableRole::Reviewer => {
+            let to_replace = reviewer_to_replace.as_ref().ok_or(ContractError::InvalidInput)?;
+            if !grant.reviewers.contains(to_replace.clone()) {
+                return Err(ContractError::Unauthorized);
+            }
+            if grant.owner != *caller && to_replace != caller {
+                return Err(ContractError::Unauthorized);
+            }
+        }
+    }
+
+    let proposal = TransferProposal {
+        grant_id,
+        current_holder: caller.clone(),
+        proposed_new_holder: new_holder,
+        role,
+        reviewer_to_replace,
+        proposed_at: env.ledger().timestamp(),
+    };
+    Storage::set_transfer_proposal(env, grant_id, &proposal);
+    Ok(())
+}
+
+/// Accept a pending transfer proposal. The caller must be the proposed new holder.
+/// On acceptance the grant state is updated and the proposal is cleared.
+pub fn accept_transfer(env: &Env, new_holder: &Address, grant_id: u64) -> Result<(), ContractError> {
+    new_holder.require_auth();
+
+    let proposal =
+        Storage::get_transfer_proposal(env, grant_id).ok_or(ContractError::InvalidState)?;
+
+    if proposal.proposed_new_holder != *new_holder {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let mut grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+
+    match proposal.role {
+        TransferableRole::Owner => {
+            grant.owner = new_holder.clone();
+        }
+        TransferableRole::Reviewer => {
+            let to_replace = proposal.reviewer_to_replace.ok_or(ContractError::InvalidInput)?;
+            for i in 0..grant.reviewers.len() {
+                if grant.reviewers.get(i).unwrap() == to_replace {
+                    grant.reviewers.set(i, new_holder.clone());
+                    break;
+                }
+            }
+        }
+    }
+
+    Storage::set_grant(env, grant_id, &grant);
+    Storage::remove_transfer_proposal(env, grant_id);
+    Ok(())
+}
+
+pub fn get_transfer_proposal(env: &Env, grant_id: u64) -> Option<TransferProposal> {
+    Storage::get_transfer_proposal(env, grant_id)
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -14,16 +14,19 @@ mod dispute;
 mod emergency;
 mod errors;
 mod escrow;
+mod evidence_schema;
 mod events;
 mod factory;
 mod fees;
 mod governance;
 mod grant_renewal;
 mod grant_tags;
+mod grant_transfer;
 mod hooks;
 mod insurance;
 mod interfaces;
 mod invoice;
+mod license;
 pub mod merkle;
 mod metrics;
 mod migration;
@@ -39,6 +42,7 @@ mod reputation;
 mod relay;
 mod reviewer_pool;
 mod scoring;
+mod split_payment;
 mod storage;
 mod streaming;
 mod token_swap;
@@ -52,21 +56,23 @@ pub use types::{
     ChecklistSubmission, ComplianceAttestation, ComplianceLevel, ComplianceStatus, ContractVersion,
     CrowdfundCampaign, CrowdfundPledge, CrowdfundStatus,
     CriterionStatus, DexConfig, Dispute, DisputeStatus, EscrowAccount, EscrowLifecycleState,
-    EscrowMode, EscrowState, FeeRecord, FunderLedger, Grant, GrantArchetype, GrantCategory,
-    GrantFund, GrantStatus, GrantTag, GrantTemplate, HookCallResult, HookEvent, HookRegistration,
-    InsuranceClaim, InsurancePolicy, Invoice, InvoiceStatus, LineItem, MerkleCommitment,
+    EscrowMode, EscrowState, EvidenceField, EvidenceFieldType, EvidenceSchema, FeeRecord,
+    FunderLedger, Grant, GrantArchetype, GrantCategory, GrantFund, GrantStatus, GrantTag,
+    GrantTemplate, HookCallResult, HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy,
+    Invoice, InvoiceStatus, IpRights, LicenseRecord, LicenseType, LineItem, MerkleCommitment,
     MerkleProof, MigrationRecord, Milestone, MilestoneState, MilestoneSubmission, MultisigProposal,
-    MultisigSigner, OracleConfig, ParamRecord, ParamType, ParamValue, PauseRecord, PaymentStream,
-    PriceQuote, ProtocolConfig, ProtocolMetrics, ProtocolModule, QuadraticVoteRecord,
-    RateLimitAction, RegistryEntry, RegistryEntryType, RelayableAction, RelayAllowance,
-    RelayConfig, RelayRecord, RenewalProposal, RenewalStatus, ReputationTier, ReviewerAvailability,
-    ReviewerProfile, ReviewerRequest, ReviewerRequestStatus, Role, RoleAssignment, RollingWindow,
-    ScoreResult, ScoringDimension, ScoringRubric, ScoringWeight, SignatureStatus, SwapResult,
-    SwapRoute, TokenMetric, VoiceCredits, VotingMechanism,
+    MultisigSigner, OracleConfig, ParamRecord, ParamType, ParamValue, PauseRecord, PaymentSplit,
+    PaymentStream, PriceQuote, ProtocolConfig, ProtocolMetrics, ProtocolModule, QuadraticVoteRecord,
+    RateLimitAction, RegistryEntry, RegistryEntryType, RelayableAction, RelayAllowance, RelayConfig,
+    RelayRecord, RenewalProposal, RenewalStatus, ReputationTier, ReviewerAvailability, ReviewerProfile,
+    ReviewerRequest, ReviewerRequestStatus, Role, RoleAssignment, RollingWindow, ScoreResult,
+    ScoringDimension, ScoringRubric, ScoringWeight, SignatureStatus, SplitRecipient,
+    StructuredEvidence, SwapResult, SwapRoute, TokenMetric, TransferProposal, TransferableRole,
+    VoiceCredits, VotingMechanism,
 };
 
 use metrics::MetricField;
-use soroban_sdk::{contract, contractimpl, Address, Bytes, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Bytes, Env, Map, String, Vec};
 
 #[contract]
 pub struct StellarGrantsContract;
@@ -399,7 +405,20 @@ impl StellarGrantsContract {
         let remaining_balance = grant.escrow_balance - total_paid;
 
         if total_paid > 0 {
-            escrow::release(env, grant_id, &grant.owner, total_paid)?;
+            // Pay each milestone individually so that registered splits are honoured.
+            let mut owner_amount: i128 = 0;
+            for idx in 0..grant.total_milestones {
+                let ms = Storage::get_milestone(env, grant_id, idx)
+                    .ok_or(ContractError::MilestoneNotFound)?;
+                if split_payment::has_split(env, grant_id, idx) {
+                    split_payment::execute_split(env, grant_id, idx, ms.amount)?;
+                } else {
+                    owner_amount = owner_amount.saturating_add(ms.amount);
+                }
+            }
+            if owner_amount > 0 {
+                escrow::release(env, grant_id, &grant.owner, owner_amount)?;
+            }
         }
         if remaining_balance > 0 {
             escrow::refund_all(env, grant_id)?;
@@ -2335,6 +2354,134 @@ impl StellarGrantsContract {
             payout_amount,
         );
     }
+
+    // ── Issue #579: IP License Tracking ──────────────────────────────────────
+
+    /// Attach an IP license record to a milestone deliverable.
+    /// Only the grant owner may call this after the milestone exists.
+    #[allow(clippy::too_many_arguments)]
+    pub fn attach_license(
+        env: Env,
+        caller: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        spdx_id: String,
+        license_type: LicenseType,
+        rights: IpRights,
+        restrictions: String,
+    ) -> Result<LicenseRecord, ContractError> {
+        emergency::require_not_paused(&env)?;
+        license::attach_license(
+            &env, &caller, grant_id, milestone_idx, spdx_id, license_type, rights, restrictions,
+        )
+    }
+
+    /// Return the license record for a milestone deliverable, if any.
+    pub fn get_license(env: Env, grant_id: u64, milestone_idx: u32) -> Option<LicenseRecord> {
+        license::get_license(&env, grant_id, milestone_idx)
+    }
+
+    // ── Issue #592: Multi-Recipient Payment Splitting ─────────────────────────
+
+    /// Register a payment split for a milestone.
+    /// `recipients` share_bps values must sum to 10 000.
+    pub fn register_payment_split(
+        env: Env,
+        caller: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        recipients: Vec<SplitRecipient>,
+    ) -> Result<(), ContractError> {
+        emergency::require_not_paused(&env)?;
+        split_payment::register_split(&env, &caller, grant_id, milestone_idx, recipients)
+    }
+
+    /// Return the registered payment split for a milestone, if any.
+    pub fn get_payment_split(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<PaymentSplit> {
+        split_payment::get_split(&env, grant_id, milestone_idx)
+    }
+
+    // ── Issue #568: Grant Ownership and Role Transfer ─────────────────────────
+
+    /// Propose transferring grant ownership or a reviewer role to a new address.
+    /// The new holder must call `accept_grant_transfer` to complete the handoff.
+    pub fn propose_grant_transfer(
+        env: Env,
+        caller: Address,
+        grant_id: u64,
+        new_holder: Address,
+        role: TransferableRole,
+        reviewer_to_replace: Option<Address>,
+    ) -> Result<(), ContractError> {
+        emergency::require_not_paused(&env)?;
+        grant_transfer::propose_transfer(
+            &env, &caller, grant_id, new_holder, role, reviewer_to_replace,
+        )
+    }
+
+    /// Accept a pending transfer proposal. Caller must be the proposed new holder.
+    pub fn accept_grant_transfer(
+        env: Env,
+        new_holder: Address,
+        grant_id: u64,
+    ) -> Result<(), ContractError> {
+        emergency::require_not_paused(&env)?;
+        grant_transfer::accept_transfer(&env, &new_holder, grant_id)
+    }
+
+    /// Return the pending transfer proposal for a grant, if any.
+    pub fn get_transfer_proposal(env: Env, grant_id: u64) -> Option<TransferProposal> {
+        grant_transfer::get_transfer_proposal(&env, grant_id)
+    }
+
+    // ── Issue #583: Typed Evidence Schemas ───────────────────────────────────
+
+    /// Define a typed evidence schema for a milestone.
+    /// Contributors must submit conforming structured evidence before `milestone_submit`.
+    pub fn set_evidence_schema(
+        env: Env,
+        caller: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        fields: Vec<EvidenceField>,
+    ) -> Result<(), ContractError> {
+        emergency::require_not_paused(&env)?;
+        evidence_schema::set_schema(&env, &caller, grant_id, milestone_idx, fields)
+    }
+
+    /// Submit structured evidence for a milestone, conforming to the registered schema.
+    pub fn submit_structured_evidence(
+        env: Env,
+        caller: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        values: Map<String, String>,
+    ) -> Result<(), ContractError> {
+        emergency::require_not_paused(&env)?;
+        evidence_schema::submit_evidence(&env, &caller, grant_id, milestone_idx, values)
+    }
+
+    /// Return the evidence schema for a milestone, if any.
+    pub fn get_evidence_schema(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<EvidenceSchema> {
+        evidence_schema::get_schema(&env, grant_id, milestone_idx)
+    }
+
+    /// Return the submitted structured evidence for a milestone, if any.
+    pub fn get_structured_evidence(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<StructuredEvidence> {
+        evidence_schema::get_evidence(&env, grant_id, milestone_idx)
+    }
 }
 
 fn apply_milestone_submission(
@@ -2356,6 +2503,9 @@ fn apply_milestone_submission(
             return Err(ContractError::MilestoneAlreadySubmitted);
         }
     }
+
+    // Validate structured evidence against the schema when one has been registered.
+    evidence_schema::validate_evidence(env, grant_id, milestone_idx)?;
 
     let milestone = Milestone {
         idx: milestone_idx,

--- a/stellargrant-contracts/contracts/stellar-grants/src/license.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/license.rs
@@ -1,0 +1,44 @@
+use crate::storage::Storage;
+use crate::types::{ContractError, IpRights, LicenseRecord, LicenseType};
+use soroban_sdk::{Address, Env, String};
+
+/// Attach a license record to an approved milestone deliverable.
+/// Only the grant owner may call this. The milestone must already exist.
+pub fn attach_license(
+    env: &Env,
+    caller: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    spdx_id: String,
+    license_type: LicenseType,
+    rights: IpRights,
+    restrictions: String,
+) -> Result<LicenseRecord, ContractError> {
+    caller.require_auth();
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if grant.owner != *caller {
+        return Err(ContractError::Unauthorized);
+    }
+    if milestone_idx >= grant.total_milestones {
+        return Err(ContractError::MilestoneIndexOutOfBounds);
+    }
+    Storage::get_milestone(env, grant_id, milestone_idx).ok_or(ContractError::MilestoneNotFound)?;
+
+    let record = LicenseRecord {
+        grant_id,
+        milestone_idx,
+        spdx_id,
+        license_type,
+        rights,
+        restrictions,
+        attached_by: caller.clone(),
+        attached_at: env.ledger().timestamp(),
+    };
+    Storage::set_license_record(env, grant_id, milestone_idx, &record);
+    Ok(record)
+}
+
+pub fn get_license(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<LicenseRecord> {
+    Storage::get_license_record(env, grant_id, milestone_idx)
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/split_payment.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/split_payment.rs
@@ -1,0 +1,76 @@
+use crate::escrow;
+use crate::storage::Storage;
+use crate::types::{ContractError, PaymentSplit, SplitRecipient};
+use soroban_sdk::{Address, Env, Vec};
+
+/// Register a payment split for a milestone. Must be called before grant completion.
+/// The sum of all recipient share_bps must equal 10 000 (100%).
+pub fn register_split(
+    env: &Env,
+    caller: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    recipients: Vec<SplitRecipient>,
+) -> Result<(), ContractError> {
+    caller.require_auth();
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if grant.owner != *caller {
+        return Err(ContractError::Unauthorized);
+    }
+    if milestone_idx >= grant.total_milestones {
+        return Err(ContractError::MilestoneIndexOutOfBounds);
+    }
+    if recipients.is_empty() {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let mut total_bps: u32 = 0;
+    for r in recipients.iter() {
+        total_bps = total_bps.saturating_add(r.share_bps);
+    }
+    if total_bps != 10_000 {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let split = PaymentSplit {
+        grant_id,
+        milestone_idx,
+        recipients,
+        registered_by: caller.clone(),
+        registered_at: env.ledger().timestamp(),
+    };
+    Storage::set_payment_split(env, grant_id, milestone_idx, &split);
+    Ok(())
+}
+
+pub fn has_split(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
+    Storage::get_payment_split(env, grant_id, milestone_idx).is_some()
+}
+
+/// Distribute `total_amount` among the registered recipients proportionally.
+/// Called internally from the payout path when a split is registered.
+pub fn execute_split(
+    env: &Env,
+    grant_id: u64,
+    milestone_idx: u32,
+    total_amount: i128,
+) -> Result<(), ContractError> {
+    let split = Storage::get_payment_split(env, grant_id, milestone_idx)
+        .ok_or(ContractError::InvalidState)?;
+
+    for r in split.recipients.iter() {
+        let share = total_amount
+            .saturating_mul(r.share_bps as i128)
+            .checked_div(10_000)
+            .unwrap_or(0);
+        if share > 0 {
+            escrow::release(env, grant_id, &r.recipient, share)?;
+        }
+    }
+    Ok(())
+}
+
+pub fn get_split(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<PaymentSplit> {
+    Storage::get_payment_split(env, grant_id, milestone_idx)
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -1,11 +1,12 @@
 use crate::types::{
     AcceptanceCriteria, AnalyticsSnapshot, AuditEntry, BreakerState, CategoryStats, ChecklistSubmission, ComplianceAttestation,
     ContractError, ContractVersion, ContributorProfile, CrowdfundCampaign, CrowdfundPledge, DexConfig, Dispute, EscrowAccount,
-    EscrowState, FunderLedger, Grant, GrantCategory, GrantTag, HookEvent, HookRegistration,
-    InsuranceClaim, InsurancePolicy, Invoice, MerkleCommitment, MigrationRecord, Milestone,
-    MultisigProposal, OracleConfig, ParamRecord, PauseRecord, PaymentStream, ProtocolConfig, ProtocolMetrics,
+    EscrowState, EvidenceSchema, FunderLedger, Grant, GrantCategory, GrantTag, HookEvent, HookRegistration,
+    InsuranceClaim, InsurancePolicy, Invoice, LicenseRecord, MerkleCommitment, MigrationRecord, Milestone,
+    MultisigProposal, OracleConfig, ParamRecord, PauseRecord, PaymentSplit, PaymentStream, ProtocolConfig, ProtocolMetrics,
     ProtocolModule, QuadraticVoteRecord, RateLimitAction, RateLimitRecord, RegistryEntry, RelayAllowance, RelayConfig, RenewalProposal,
-    ReviewerProfile, ReviewerRequest, Role, RoleAssignment, RollingWindow, ScoringRubric, TokenMetric, VoiceCredits, VotingMechanism,
+    ReviewerProfile, ReviewerRequest, Role, RoleAssignment, RollingWindow, ScoringRubric, StructuredEvidence, TokenMetric,
+    TransferProposal, VoiceCredits, VotingMechanism,
 };
 use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 
@@ -119,6 +120,15 @@ pub enum DataKey {
     CrowdfundPledge(u64, Address),
     CrowdfundBackers(u64),
     CrowdfundCounter,
+    // Issue #579: IP License Tracking
+    LicenseRecord(u64, u32),
+    // Issue #592: Multi-Recipient Payment Splitting
+    PaymentSplit(u64, u32),
+    // Issue #568: Grant Transfer
+    TransferProposal(u64),
+    // Issue #583: Typed Evidence Schemas
+    EvidenceSchema(u64, u32),
+    StructuredEvidence(u64, u32),
 }
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 100_000;
@@ -1202,6 +1212,93 @@ impl Storage {
     pub fn set_crowdfund_backers(env: &Env, campaign_id: u64, backers: &Vec<Address>) {
         let key = DataKey::CrowdfundBackers(campaign_id);
         env.storage().persistent().set(&key, backers);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #579: IP License Tracking ──────────────────────────────────────
+
+    pub fn get_license_record(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<LicenseRecord> {
+        let key = DataKey::LicenseRecord(grant_id, milestone_idx);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_license_record(env: &Env, grant_id: u64, milestone_idx: u32, record: &LicenseRecord) {
+        let key = DataKey::LicenseRecord(grant_id, milestone_idx);
+        env.storage().persistent().set(&key, record);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #592: Multi-Recipient Payment Splitting ─────────────────────────
+
+    pub fn get_payment_split(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<PaymentSplit> {
+        let key = DataKey::PaymentSplit(grant_id, milestone_idx);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_payment_split(env: &Env, grant_id: u64, milestone_idx: u32, split: &PaymentSplit) {
+        let key = DataKey::PaymentSplit(grant_id, milestone_idx);
+        env.storage().persistent().set(&key, split);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #568: Grant Transfer ────────────────────────────────────────────
+
+    pub fn get_transfer_proposal(env: &Env, grant_id: u64) -> Option<TransferProposal> {
+        let key = DataKey::TransferProposal(grant_id);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_transfer_proposal(env: &Env, grant_id: u64, proposal: &TransferProposal) {
+        let key = DataKey::TransferProposal(grant_id);
+        env.storage().persistent().set(&key, proposal);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn remove_transfer_proposal(env: &Env, grant_id: u64) {
+        env.storage().persistent().remove(&DataKey::TransferProposal(grant_id));
+    }
+
+    // ── Issue #583: Typed Evidence Schemas ───────────────────────────────────
+
+    pub fn get_evidence_schema(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<EvidenceSchema> {
+        let key = DataKey::EvidenceSchema(grant_id, milestone_idx);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_evidence_schema(env: &Env, grant_id: u64, milestone_idx: u32, schema: &EvidenceSchema) {
+        let key = DataKey::EvidenceSchema(grant_id, milestone_idx);
+        env.storage().persistent().set(&key, schema);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_structured_evidence(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<StructuredEvidence> {
+        let key = DataKey::StructuredEvidence(grant_id, milestone_idx);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_structured_evidence(env: &Env, grant_id: u64, milestone_idx: u32, evidence: &StructuredEvidence) {
+        let key = DataKey::StructuredEvidence(grant_id, milestone_idx);
+        env.storage().persistent().set(&key, evidence);
         Self::bump_persistent_ttl(env, &key);
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -1154,6 +1154,118 @@ pub struct RoleAssignment {
     pub is_active: bool,
 }
 
+// ── Issue #579: IP License Tracking ──────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum LicenseType {
+    OpenSource = 0,
+    Proprietary = 1,
+    CreativeCommons = 2,
+    Custom = 3,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IpRights {
+    pub commercial_use: bool,
+    pub modification: bool,
+    pub distribution: bool,
+    pub sublicense: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LicenseRecord {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub spdx_id: String,
+    pub license_type: LicenseType,
+    pub rights: IpRights,
+    pub restrictions: String,
+    pub attached_by: Address,
+    pub attached_at: u64,
+}
+
+// ── Issue #592: Multi-Recipient Payment Splitting ─────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SplitRecipient {
+    pub recipient: Address,
+    pub share_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PaymentSplit {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub recipients: Vec<SplitRecipient>,
+    pub registered_by: Address,
+    pub registered_at: u64,
+}
+
+// ── Issue #568: Grant Ownership and Role Transfer ─────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum TransferableRole {
+    Owner = 0,
+    Reviewer = 1,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransferProposal {
+    pub grant_id: u64,
+    pub current_holder: Address,
+    pub proposed_new_holder: Address,
+    pub role: TransferableRole,
+    pub reviewer_to_replace: Option<Address>,
+    pub proposed_at: u64,
+}
+
+// ── Issue #583: Typed Evidence Schemas ───────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum EvidenceFieldType {
+    Url = 0,
+    Text = 1,
+    Number = 2,
+    Percentage = 3,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvidenceField {
+    pub name: String,
+    pub field_type: EvidenceFieldType,
+    pub required: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvidenceSchema {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub fields: Vec<EvidenceField>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StructuredEvidence {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub values: Map<String, String>,
+    pub submitted_by: Address,
+    pub submitted_at: u64,
+}
+
 // ── Crowdfund Module ──────────────────────────────────────────────────────────
 
 #[contracttype]


### PR DESCRIPTION
…r, and typed evidence schemas

Closes #579 
closes #592 
closes #568 
closes #583

- license.rs: attach/get IP license records (SPDX id, rights, restrictions) to milestone deliverables; only the grant owner may attach after the milestone exists
- split_payment.rs: register per-milestone splits (share_bps summing to 10000); execute_split is called from finalize_grant_release so each recipient is paid directly from escrow
- grant_transfer.rs: two-step propose/accept pattern for transferring grant ownership or individual reviewer roles
- evidence_schema.rs: define typed field schemas per milestone; contributors submit structured evidence before milestone_submit; validation is enforced inside apply_milestone_submission when a schema exists
- types.rs: add LicenseType, IpRights, LicenseRecord, SplitRecipient, PaymentSplit, TransferableRole, TransferProposal, EvidenceFieldType, EvidenceField, EvidenceSchema, StructuredEvidence
- storage.rs: add DataKey variants and get/set methods for all four features
- lib.rs: expose 12 new entry points; hook split_payment into finalize_grant_release payout path; hook evidence_schema into apply_milestone_submission