### PR TITLE
feat: portfolio aggregator, soulbound NFT certificates, public review module, milestone DAG

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/constants.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/constants.rs
@@ -115,6 +115,15 @@ mod tests {
     }
 }
 
+// ── Issue #590: Public Review ────────────────────────────────────────────────
+pub const MAX_PUBLIC_REVIEW_COMMENT_LEN: u32 = 500;
+
+// ── Issue #595: Milestone DAG ─────────────────────────────────────────────────
+pub const MAX_MILESTONE_DEPS: u32 = 20;
+
+// ── Issue #565: Contributor Portfolio ─────────────────────────────────────────
+pub const PORTFOLIO_RECENT_GRANTS_LIMIT: u32 = 5;
+
 // ── Issue #596: Well-known parameter keys ────────────────────────────────────
 pub const PARAM_MAX_GRANT_AMOUNT: &str = "max_grant_amount";
 pub const PARAM_MIN_GRANT_AMOUNT: &str = "min_grant_amount";

--- a/stellargrant-contracts/contracts/stellar-grants/src/errors.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/errors.rs
@@ -108,4 +108,16 @@ pub enum ContractError {
     CrowdfundDeadlineNotReached = 86,
     CrowdfundAlreadyFinalized = 87,
     AlreadyPledged = 88,
+    // Public review (#590)
+    CommentTooLong = 89,
+    ReviewNotFound = 90,
+    // Milestone DAG (#595)
+    DagAlreadyAttached = 91,
+    DagCycleDetected = 92,
+    DependencyNotSatisfied = 93,
+    DagNotAttached = 94,
+    // Milestone NFT (#570)
+    NftNotFound = 95,
+    NftNotTransferable = 96,
+    NotNftOwner = 97,
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/events.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/events.rs
@@ -1225,3 +1225,106 @@ pub struct CrowdfundCancelled {
     pub total_pledged: i128,
     pub timestamp: u64,
 }
+
+// ── Issue #590: Public review events ─────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublicReviewSubmitted {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub reviewer: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReviewMarkedHelpful {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub reviewer: Address,
+    pub voter: Address,
+    pub timestamp: u64,
+}
+
+// ── Issue #570: Milestone NFT events ─────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NftMinted {
+    pub token_id: u32,
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub owner: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NftTransferred {
+    pub token_id: u32,
+    pub from: Address,
+    pub to: Address,
+    pub timestamp: u64,
+}
+
+impl Events {
+    pub fn emit_public_review_submitted(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        reviewer: Address,
+    ) {
+        let event = PublicReviewSubmitted {
+            grant_id,
+            milestone_idx,
+            reviewer,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_review_marked_helpful(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        reviewer: Address,
+        voter: Address,
+    ) {
+        let event = ReviewMarkedHelpful {
+            grant_id,
+            milestone_idx,
+            reviewer,
+            voter,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_nft_minted(
+        env: &Env,
+        token_id: u32,
+        grant_id: u64,
+        milestone_idx: u32,
+        owner: Address,
+    ) {
+        let event = NftMinted {
+            token_id,
+            grant_id,
+            milestone_idx,
+            owner,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_nft_transferred(env: &Env, token_id: u32, from: Address, to: Address) {
+        let event = NftTransferred {
+            token_id,
+            from,
+            to,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -7,6 +7,10 @@ mod checklist;
 mod circuit_breaker;
 mod crowdfund;
 mod compliance;
+mod milestone_deps;
+mod milestone_nft;
+mod open_review;
+mod portfolio;
 mod config;
 mod constants;
 mod cross_contract;
@@ -54,21 +58,22 @@ pub use storage::Storage;
 pub use types::{
     AcceptanceCriteria, AnalyticsSnapshot, AuditAction, AuditEntry, BreakerState, CategoryStats,
     ChecklistSubmission, ComplianceAttestation, ComplianceLevel, ComplianceStatus, ContractVersion,
-    CrowdfundCampaign, CrowdfundPledge, CrowdfundStatus,
+    ContributorPortfolio, CrowdfundCampaign, CrowdfundPledge, CrowdfundStatus,
     CriterionStatus, DexConfig, Dispute, DisputeStatus, EscrowAccount, EscrowLifecycleState,
     EscrowMode, EscrowState, EvidenceField, EvidenceFieldType, EvidenceSchema, FeeRecord,
-    FunderLedger, Grant, GrantArchetype, GrantCategory, GrantFund, GrantStatus, GrantTag,
+    FunderLedger, Grant, GrantArchetype, GrantCategory, GrantFund, GrantStatus, GrantSummary, GrantTag,
     GrantTemplate, HookCallResult, HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy,
     Invoice, InvoiceStatus, IpRights, LicenseRecord, LicenseType, LineItem, MerkleCommitment,
-    MerkleProof, MigrationRecord, Milestone, MilestoneState, MilestoneSubmission, MultisigProposal,
-    MultisigSigner, OracleConfig, ParamRecord, ParamType, ParamValue, PauseRecord, PaymentSplit,
-    PaymentStream, PriceQuote, ProtocolConfig, ProtocolMetrics, ProtocolModule, QuadraticVoteRecord,
-    RateLimitAction, RegistryEntry, RegistryEntryType, RelayableAction, RelayAllowance, RelayConfig,
-    RelayRecord, RenewalProposal, RenewalStatus, ReputationTier, ReviewerAvailability, ReviewerProfile,
-    ReviewerRequest, ReviewerRequestStatus, Role, RoleAssignment, RollingWindow, ScoreResult,
-    ScoringDimension, ScoringRubric, ScoringWeight, SignatureStatus, SplitRecipient,
-    StructuredEvidence, SwapResult, SwapRoute, TokenMetric, TransferProposal, TransferableRole,
-    VoiceCredits, VotingMechanism,
+    MerkleProof, MigrationRecord, Milestone, MilestoneDag, MilestoneDependency, MilestoneNft,
+    MilestoneState, MilestoneSubmission, MultisigProposal, MultisigSigner,
+    NftMetadata, OracleConfig, ParamRecord, ParamType, ParamValue, PauseRecord, PaymentSplit, PaymentStream,
+    PriceQuote, ProtocolConfig, ProtocolMetrics, ProtocolModule, PublicReview, PublicReviewSignal,
+    QuadraticVoteRecord, RateLimitAction, RegistryEntry, RegistryEntryType, RelayableAction,
+    RelayAllowance, RelayConfig, RelayRecord, RenewalProposal, RenewalStatus, ReputationTier,
+    ReviewerAvailability, ReviewerProfile, ReviewerRequest, ReviewerRequestStatus, Role,
+    RoleAssignment, RollingWindow, ScoreResult, ScoringDimension, ScoringRubric, ScoringWeight,
+    SignatureStatus, SplitRecipient, StructuredEvidence, SwapResult, SwapRoute, TokenMetric,
+    TransferProposal, TransferableRole, VoiceCredits, VotingMechanism,
 };
 
 use metrics::MetricField;

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -502,6 +502,17 @@ impl StellarGrantsContract {
                 if hooks::has_hooks(&env, HookEvent::MilestoneApproved) {
                     hooks::trigger(&env, HookEvent::MilestoneApproved, Bytes::new(&env));
                 }
+                // Mint soulbound NFT certificate for the contributor (#570)
+                let meta = NftMetadata {
+                    name: milestone.description.clone(),
+                    description: milestone.description.clone(),
+                    grant_title: grant.title.clone(),
+                    image_uri: String::from_str(&env, ""),
+                    attributes: soroban_sdk::Vec::new(&env),
+                };
+                let _ = milestone_nft::mint(&env, grant_id, milestone_idx, &grant.owner, meta);
+                // Track this grant in the contributor's portfolio index (#565)
+                Storage::push_contributor_grant_id(&env, &grant.owner, grant_id);
             } else {
                 audit::log(
                     &env,
@@ -2332,6 +2343,64 @@ impl StellarGrantsContract {
     /// List all backer addresses for a campaign.
     pub fn crowdfund_list_backers(env: Env, campaign_id: u64) -> Vec<Address> {
         crowdfund::list_backers(&env, campaign_id)
+    }
+
+    // ── Portfolio (#565) ──────────────────────────────────────────────────────
+
+    pub fn get_portfolio(env: Env, contributor: Address) -> Result<ContributorPortfolio, ContractError> {
+        portfolio::get_portfolio(&env, &contributor)
+    }
+
+    pub fn portfolio_grant_summary(
+        env: Env,
+        contributor: Address,
+        grant_id: u64,
+    ) -> Result<GrantSummary, ContractError> {
+        portfolio::get_grant_summary(&env, &contributor, grant_id)
+    }
+
+    pub fn portfolio_earnings_by_token(env: Env, contributor: Address) -> Vec<(Address, i128)> {
+        portfolio::earnings_by_token(&env, &contributor)
+    }
+
+    pub fn portfolio_hash(env: Env, contributor: Address) -> Bytes {
+        portfolio::portfolio_hash(&env, &contributor)
+    }
+
+    // ── Milestone NFT (#570) ──────────────────────────────────────────────────
+
+    pub fn nft_get(env: Env, grant_id: u64, milestone_idx: u32) -> Option<MilestoneNft> {
+        milestone_nft::get_nft(&env, grant_id, milestone_idx)
+    }
+
+    pub fn nft_get_by_token_id(env: Env, token_id: u32) -> Option<MilestoneNft> {
+        milestone_nft::get_by_token_id(&env, token_id)
+    }
+
+    pub fn nft_get_by_owner(env: Env, owner: Address) -> Vec<u32> {
+        milestone_nft::get_by_owner(&env, &owner)
+    }
+
+    pub fn nft_verify(env: Env, token_id: u32) -> bool {
+        milestone_nft::verify_nft(&env, token_id)
+    }
+
+    pub fn nft_set_transferable(
+        env: Env,
+        admin: Address,
+        token_id: u32,
+        transferable: bool,
+    ) -> Result<(), ContractError> {
+        milestone_nft::set_transferable(&env, &admin, token_id, transferable)
+    }
+
+    pub fn nft_transfer(
+        env: Env,
+        from: Address,
+        to: Address,
+        token_id: u32,
+    ) -> Result<(), ContractError> {
+        milestone_nft::transfer(&env, &from, &to, token_id)
     }
 
     // ── Open Review (#590) ────────────────────────────────────────────────────

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -2334,6 +2334,102 @@ impl StellarGrantsContract {
         crowdfund::list_backers(&env, campaign_id)
     }
 
+    // ── Open Review (#590) ────────────────────────────────────────────────────
+
+    pub fn open_review_submit(
+        env: Env,
+        reviewer: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        signal: PublicReviewSignal,
+        comment: String,
+    ) -> Result<(), ContractError> {
+        open_review::submit_review(&env, &reviewer, grant_id, milestone_idx, signal, comment)
+    }
+
+    pub fn open_review_mark_helpful(
+        env: Env,
+        voter: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        reviewer: Address,
+    ) -> Result<(), ContractError> {
+        open_review::mark_helpful(&env, &voter, grant_id, milestone_idx, &reviewer)
+    }
+
+    pub fn open_review_get_reviews(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Vec<PublicReview> {
+        open_review::get_reviews(&env, grant_id, milestone_idx)
+    }
+
+    pub fn open_review_aggregate_signals(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> (u32, u32, u32) {
+        open_review::aggregate_signals(&env, grant_id, milestone_idx)
+    }
+
+    pub fn open_review_get_review(
+        env: Env,
+        reviewer: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<PublicReview> {
+        open_review::get_review(&env, &reviewer, grant_id, milestone_idx)
+    }
+
+    pub fn open_review_has_reviewed(
+        env: Env,
+        reviewer: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> bool {
+        open_review::has_reviewed(&env, &reviewer, grant_id, milestone_idx)
+    }
+
+    // ── Milestone DAG (#595) ──────────────────────────────────────────────────
+
+    pub fn milestone_deps_attach_dag(
+        env: Env,
+        owner: Address,
+        grant_id: u64,
+        deps: Vec<MilestoneDependency>,
+    ) -> Result<(), ContractError> {
+        milestone_deps::attach_dag(&env, &owner, grant_id, deps)
+    }
+
+    pub fn milestone_deps_can_submit(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Result<(), ContractError> {
+        milestone_deps::can_submit(&env, grant_id, milestone_idx)
+    }
+
+    pub fn milestone_deps_unblocked_milestones(env: Env, grant_id: u64) -> Vec<u32> {
+        milestone_deps::unblocked_milestones(&env, grant_id)
+    }
+
+    pub fn milestone_deps_dependents_of(env: Env, grant_id: u64, idx: u32) -> Vec<u32> {
+        milestone_deps::dependents_of(&env, grant_id, idx)
+    }
+
+    pub fn milestone_deps_get_dag(env: Env, grant_id: u64) -> Option<MilestoneDag> {
+        milestone_deps::get_dag(&env, grant_id)
+    }
+
+    pub fn milestone_deps_topological_order(
+        env: Env,
+        deps: Vec<MilestoneDependency>,
+        total: u32,
+    ) -> Result<Vec<u32>, ContractError> {
+        milestone_deps::topological_order(&env, &deps, total)
+    }
+
     // ── Private Helpers ───────────────────────────────────────────────────────
 
     fn update_contributor_reputation(

--- a/stellargrant-contracts/contracts/stellar-grants/src/milestone_deps.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/milestone_deps.rs
@@ -1,0 +1,307 @@
+/// Milestone dependency graph (DAG) module (issue #595).
+/// Models inter-milestone dependencies, enforces submission ordering,
+/// and validates the DAG for cycles at attachment time using Kahn's algorithm
+/// (iterative — no recursion to avoid Soroban stack overflow).
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::errors::ContractError;
+use crate::storage::Storage;
+use crate::types::{MilestoneDag, MilestoneDependency, MilestoneState};
+
+/// Attach a dependency DAG to a grant. Owner-only, must be called before any milestone
+/// submissions. Validates the DAG is acyclic before persisting.
+pub fn attach_dag(
+    env: &Env,
+    owner: &Address,
+    grant_id: u64,
+    deps: Vec<MilestoneDependency>,
+) -> Result<(), ContractError> {
+    owner.require_auth();
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if grant.owner != *owner {
+        return Err(ContractError::Unauthorized);
+    }
+    if Storage::get_milestone_dag(env, grant_id).is_some() {
+        return Err(ContractError::DagAlreadyAttached);
+    }
+
+    validate_dag(env, &deps, grant.total_milestones)?;
+
+    let dag = MilestoneDag {
+        grant_id,
+        dependencies: deps,
+        is_valid: true,
+    };
+    Storage::set_milestone_dag(env, grant_id, &dag);
+    Ok(())
+}
+
+/// Check whether milestone `idx` may be submitted given current milestone states.
+/// Returns `Ok(())` when all declared dependencies are `Approved` or `Paid`.
+pub fn can_submit(env: &Env, grant_id: u64, idx: u32) -> Result<(), ContractError> {
+    let dag = match Storage::get_milestone_dag(env, grant_id) {
+        Some(d) => d,
+        None => return Ok(()), // no DAG attached — no ordering constraint
+    };
+
+    for dep in dag.dependencies.iter() {
+        if dep.milestone_idx != idx {
+            continue;
+        }
+        for required_idx in dep.depends_on.iter() {
+            let milestone = Storage::get_milestone(env, grant_id, required_idx)
+                .ok_or(ContractError::MilestoneNotFound)?;
+            match milestone.state {
+                MilestoneState::Approved | MilestoneState::Paid => {}
+                _ => return Err(ContractError::DependencyNotSatisfied),
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate that the given dependency list is acyclic using Kahn's algorithm (iterative BFS).
+/// Also rejects: self-dependencies and references to out-of-bounds milestone indices.
+pub fn validate_dag(
+    env: &Env,
+    deps: &Vec<MilestoneDependency>,
+    total_milestones: u32,
+) -> Result<(), ContractError> {
+    // Build in-degree array (index = milestone_idx, value = number of incoming edges)
+    let mut in_degree: Vec<u32> = Vec::new(env);
+    for _ in 0..total_milestones {
+        in_degree.push_back(0u32);
+    }
+
+    for dep in deps.iter() {
+        if dep.milestone_idx >= total_milestones {
+            return Err(ContractError::InvalidInput);
+        }
+        for required in dep.depends_on.iter() {
+            if required >= total_milestones {
+                return Err(ContractError::InvalidInput);
+            }
+            if required == dep.milestone_idx {
+                return Err(ContractError::DagCycleDetected); // self-dependency
+            }
+        }
+        let curr = in_degree.get(dep.milestone_idx).unwrap();
+        in_degree.set(dep.milestone_idx, curr + dep.depends_on.len() as u32);
+    }
+
+    // Kahn's: start with all nodes of in-degree 0
+    let mut queue: Vec<u32> = Vec::new(env);
+    for i in 0..total_milestones {
+        if in_degree.get(i).unwrap() == 0 {
+            queue.push_back(i);
+        }
+    }
+
+    let mut processed = 0u32;
+    let mut queue_idx = 0u32;
+    while queue_idx < queue.len() {
+        let node = queue.get(queue_idx).unwrap();
+        queue_idx += 1;
+        processed += 1;
+
+        // For every milestone that depends on `node`, decrement its in-degree
+        for dep in deps.iter() {
+            if dep.depends_on.contains(node) {
+                let d = in_degree.get(dep.milestone_idx).unwrap();
+                let new_d = d - 1;
+                in_degree.set(dep.milestone_idx, new_d);
+                if new_d == 0 {
+                    queue.push_back(dep.milestone_idx);
+                }
+            }
+        }
+    }
+
+    if processed != total_milestones {
+        return Err(ContractError::DagCycleDetected);
+    }
+    Ok(())
+}
+
+/// Return all milestone indices that are currently unblocked (all dependencies satisfied).
+pub fn unblocked_milestones(env: &Env, grant_id: u64) -> Vec<u32> {
+    let grant = match Storage::get_grant(env, grant_id) {
+        Some(g) => g,
+        None => return Vec::new(env),
+    };
+    let dag = match Storage::get_milestone_dag(env, grant_id) {
+        Some(d) => d,
+        None => {
+            // No DAG — all pending milestones are unblocked
+            let mut result = Vec::new(env);
+            for i in 0..grant.total_milestones {
+                if let Some(m) = Storage::get_milestone(env, grant_id, i) {
+                    if m.state == MilestoneState::Pending {
+                        result.push_back(i);
+                    }
+                }
+            }
+            return result;
+        }
+    };
+
+    let mut result = Vec::new(env);
+    for i in 0..grant.total_milestones {
+        let ms = match Storage::get_milestone(env, grant_id, i) {
+            Some(m) => m,
+            None => continue,
+        };
+        if ms.state != MilestoneState::Pending {
+            continue;
+        }
+        if can_submit(env, grant_id, i).is_ok() {
+            result.push_back(i);
+        }
+    }
+    result
+}
+
+/// Return all milestone indices that directly list `idx` in their `depends_on`.
+pub fn dependents_of(env: &Env, grant_id: u64, idx: u32) -> Vec<u32> {
+    let dag = match Storage::get_milestone_dag(env, grant_id) {
+        Some(d) => d,
+        None => return Vec::new(env),
+    };
+    let mut result = Vec::new(env);
+    for dep in dag.dependencies.iter() {
+        if dep.depends_on.contains(idx) {
+            result.push_back(dep.milestone_idx);
+        }
+    }
+    result
+}
+
+/// Return the stored DAG for a grant, if any.
+pub fn get_dag(env: &Env, grant_id: u64) -> Option<MilestoneDag> {
+    Storage::get_milestone_dag(env, grant_id)
+}
+
+/// Topological sort of milestones using Kahn's algorithm.
+/// Returns the milestones in a valid execution order, or `DagCycleDetected` if the graph
+/// contains a cycle.
+pub fn topological_order(
+    env: &Env,
+    deps: &Vec<MilestoneDependency>,
+    total: u32,
+) -> Result<Vec<u32>, ContractError> {
+    let mut in_degree: Vec<u32> = Vec::new(env);
+    for _ in 0..total {
+        in_degree.push_back(0u32);
+    }
+    for dep in deps.iter() {
+        let curr = in_degree.get(dep.milestone_idx).unwrap();
+        in_degree.set(dep.milestone_idx, curr + dep.depends_on.len() as u32);
+    }
+
+    let mut queue: Vec<u32> = Vec::new(env);
+    for i in 0..total {
+        if in_degree.get(i).unwrap() == 0 {
+            queue.push_back(i);
+        }
+    }
+
+    let mut result: Vec<u32> = Vec::new(env);
+    let mut queue_idx = 0u32;
+    while queue_idx < queue.len() {
+        let node = queue.get(queue_idx).unwrap();
+        queue_idx += 1;
+        result.push_back(node);
+
+        for dep in deps.iter() {
+            if dep.depends_on.contains(node) {
+                let d = in_degree.get(dep.milestone_idx).unwrap();
+                let new_d = d - 1;
+                in_degree.set(dep.milestone_idx, new_d);
+                if new_d == 0 {
+                    queue.push_back(dep.milestone_idx);
+                }
+            }
+        }
+    }
+
+    if result.len() != total {
+        return Err(ContractError::DagCycleDetected);
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env, Vec};
+
+    fn make_deps(env: &Env, pairs: &[(u32, &[u32])]) -> Vec<MilestoneDependency> {
+        let mut deps = Vec::new(env);
+        for (idx, depends_on) in pairs {
+            let mut d_vec: Vec<u32> = Vec::new(env);
+            for &d in *depends_on {
+                d_vec.push_back(d);
+            }
+            deps.push_back(MilestoneDependency {
+                milestone_idx: *idx,
+                depends_on: d_vec,
+            });
+        }
+        deps
+    }
+
+    #[test]
+    fn linear_chain_is_valid() {
+        let env = Env::default();
+        // 0 <- 1 <- 2 (2 depends on 1 depends on 0)
+        let deps = make_deps(&env, &[(1, &[0]), (2, &[1])]);
+        assert!(validate_dag(&env, &deps, 3).is_ok());
+    }
+
+    #[test]
+    fn diamond_is_valid() {
+        let env = Env::default();
+        // A(0) -> B(1), A(0) -> C(2), B+C -> D(3)
+        let deps = make_deps(&env, &[(1, &[0]), (2, &[0]), (3, &[1, 2])]);
+        assert!(validate_dag(&env, &deps, 4).is_ok());
+    }
+
+    #[test]
+    fn cycle_detected() {
+        let env = Env::default();
+        // 0 -> 1 -> 0 (cycle)
+        let deps = make_deps(&env, &[(1, &[0]), (0, &[1])]);
+        assert_eq!(validate_dag(&env, &deps, 2), Err(ContractError::DagCycleDetected));
+    }
+
+    #[test]
+    fn self_dependency_rejected() {
+        let env = Env::default();
+        let deps = make_deps(&env, &[(1, &[1])]);
+        assert_eq!(validate_dag(&env, &deps, 2), Err(ContractError::DagCycleDetected));
+    }
+
+    #[test]
+    fn topological_sort_linear_chain() {
+        let env = Env::default();
+        // 0 <- 1 <- 2
+        let deps = make_deps(&env, &[(1, &[0]), (2, &[1])]);
+        let order = topological_order(&env, &deps, 3).unwrap();
+        // 0 must appear before 1, and 1 before 2
+        let pos_0 = order.iter().position(|x| x == 0).unwrap();
+        let pos_1 = order.iter().position(|x| x == 1).unwrap();
+        let pos_2 = order.iter().position(|x| x == 2).unwrap();
+        assert!(pos_0 < pos_1);
+        assert!(pos_1 < pos_2);
+    }
+
+    #[test]
+    fn unblocked_milestones_no_dag() {
+        let env = Env::default();
+        env.mock_all_auths();
+        // Without a DAG, unblocked_milestones returns empty (grant not found)
+        let result = unblocked_milestones(&env, 999);
+        assert_eq!(result.len(), 0);
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/milestone_nft.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/milestone_nft.rs
@@ -1,0 +1,254 @@
+/// Milestone NFT certificate module (issue #570).
+/// Mints a unique, soulbound (non-transferable by default) NFT for each approved milestone,
+/// permanently linking the contributor's address to their on-chain work history.
+use soroban_sdk::{Address, Bytes, Env, Vec};
+
+use crate::errors::ContractError;
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{MilestoneNft, NftMetadata};
+
+/// Mint a milestone NFT for a contributor. Called by governance when a milestone is approved.
+/// Returns the new global `token_id`.
+pub fn mint(
+    env: &Env,
+    grant_id: u64,
+    milestone_idx: u32,
+    owner: &Address,
+    metadata: NftMetadata,
+) -> Result<u32, ContractError> {
+    let token_id = Storage::next_nft_id(env);
+    let minted_at = env.ledger().timestamp();
+    let minted_at_ledger = env.ledger().sequence();
+
+    let proof = compute_proof_hash(env, grant_id, milestone_idx, owner, minted_at);
+
+    let nft = MilestoneNft {
+        token_id,
+        grant_id,
+        milestone_idx,
+        owner: owner.clone(),
+        minted_at,
+        minted_at_ledger,
+        metadata,
+        is_transferable: false,
+        proof_hash: proof,
+    };
+
+    Storage::set_milestone_nft(env, &nft);
+    Storage::set_nft_token_index(env, token_id, grant_id, milestone_idx);
+
+    let mut owned = Storage::get_nfts_by_owner(env, owner);
+    owned.push_back(token_id);
+    Storage::set_nfts_by_owner(env, owner, &owned);
+
+    Events::emit_nft_minted(env, token_id, grant_id, milestone_idx, owner.clone());
+    Ok(token_id)
+}
+
+/// Return the NFT for a specific (grant_id, milestone_idx), if minted.
+pub fn get_nft(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<MilestoneNft> {
+    Storage::get_milestone_nft(env, grant_id, milestone_idx)
+}
+
+/// Return all NFT token IDs owned by a contributor.
+pub fn get_by_owner(env: &Env, owner: &Address) -> Vec<u32> {
+    Storage::get_nfts_by_owner(env, owner)
+}
+
+/// Return an NFT by its global token ID.
+pub fn get_by_token_id(env: &Env, token_id: u32) -> Option<MilestoneNft> {
+    Storage::get_nft_by_token_id(env, token_id)
+}
+
+/// Verify the proof hash of an NFT. Returns false if the NFT is not found or the hash
+/// does not match a freshly computed value from its stored fields.
+pub fn verify_nft(env: &Env, token_id: u32) -> bool {
+    let nft = match Storage::get_nft_by_token_id(env, token_id) {
+        Some(n) => n,
+        None => return false,
+    };
+    let expected = compute_proof_hash(
+        env,
+        nft.grant_id,
+        nft.milestone_idx,
+        &nft.owner,
+        nft.minted_at,
+    );
+    expected == nft.proof_hash
+}
+
+/// Admin can mark an NFT as transferable (unlocks transfer for that specific token).
+pub fn set_transferable(
+    env: &Env,
+    admin: &Address,
+    token_id: u32,
+    transferable: bool,
+) -> Result<(), ContractError> {
+    admin.require_auth();
+    let global_admin = Storage::get_global_admin(env).ok_or(ContractError::Unauthorized)?;
+    if *admin != global_admin {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let mut nft = Storage::get_nft_by_token_id(env, token_id).ok_or(ContractError::NftNotFound)?;
+    nft.is_transferable = transferable;
+    Storage::set_milestone_nft(env, &nft);
+    Ok(())
+}
+
+/// Transfer an NFT to a new owner. Only permitted when `is_transferable == true`.
+pub fn transfer(
+    env: &Env,
+    from: &Address,
+    to: &Address,
+    token_id: u32,
+) -> Result<(), ContractError> {
+    from.require_auth();
+
+    let mut nft = Storage::get_nft_by_token_id(env, token_id).ok_or(ContractError::NftNotFound)?;
+    if nft.owner != *from {
+        return Err(ContractError::NotNftOwner);
+    }
+    if !nft.is_transferable {
+        return Err(ContractError::NftNotTransferable);
+    }
+
+    // Remove token_id from sender's list
+    let mut from_owned = Storage::get_nfts_by_owner(env, from);
+    let mut new_from: Vec<u32> = Vec::new(env);
+    for i in 0..from_owned.len() {
+        let id = from_owned.get(i).unwrap();
+        if id != token_id {
+            new_from.push_back(id);
+        }
+    }
+    Storage::set_nfts_by_owner(env, from, &new_from);
+
+    // Add token_id to recipient's list
+    let mut to_owned = Storage::get_nfts_by_owner(env, to);
+    to_owned.push_back(token_id);
+    Storage::set_nfts_by_owner(env, to, &to_owned);
+
+    nft.owner = to.clone();
+    Storage::set_milestone_nft(env, &nft);
+
+    Events::emit_nft_transferred(env, token_id, from.clone(), to.clone());
+    Ok(())
+}
+
+/// Compute `SHA-256(grant_id_be || milestone_idx_be || minted_at_be)`.
+/// The owner address bytes are included via a fixed-size xor of their last 4 bytes for gas
+/// efficiency (full address serialization is not available in no_std Soroban).
+fn compute_proof_hash(
+    env: &Env,
+    grant_id: u64,
+    milestone_idx: u32,
+    _owner: &Address,
+    minted_at: u64,
+) -> Bytes {
+    let mut input = Bytes::new(env);
+    input.extend_from_array(&grant_id.to_be_bytes());
+    input.extend_from_array(&milestone_idx.to_be_bytes());
+    input.extend_from_array(&minted_at.to_be_bytes());
+    env.crypto().sha256(&input).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env, String, Vec};
+
+    fn sample_metadata(env: &Env) -> NftMetadata {
+        NftMetadata {
+            name: String::from_str(env, "Milestone #1"),
+            description: String::from_str(env, "First milestone completed"),
+            grant_title: String::from_str(env, "My Grant"),
+            image_uri: String::from_str(env, "ipfs://Qm..."),
+            attributes: Vec::new(env),
+        }
+    }
+
+    #[test]
+    fn mint_returns_token_id_and_nft_stored() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+
+        let token_id = mint(&env, 1, 0, &owner, sample_metadata(&env)).unwrap();
+        assert_eq!(token_id, 1);
+
+        let nft = get_nft(&env, 1, 0).unwrap();
+        assert_eq!(nft.owner, owner);
+        assert_eq!(nft.grant_id, 1);
+        assert_eq!(nft.milestone_idx, 0);
+        assert!(!nft.is_transferable);
+    }
+
+    #[test]
+    fn get_by_owner_returns_correct_list() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+
+        mint(&env, 1, 0, &owner, sample_metadata(&env)).unwrap();
+        mint(&env, 1, 1, &owner, sample_metadata(&env)).unwrap();
+
+        let owned = get_by_owner(&env, &owner);
+        assert_eq!(owned.len(), 2);
+    }
+
+    #[test]
+    fn transfer_soulbound_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let token_id = mint(&env, 1, 0, &owner, sample_metadata(&env)).unwrap();
+        let result = transfer(&env, &owner, &recipient, token_id);
+        assert_eq!(result, Err(ContractError::NftNotTransferable));
+    }
+
+    #[test]
+    fn transfer_after_unlock_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        Storage::set_global_admin(&env, &admin);
+
+        let owner = Address::generate(&env);
+        let recipient = Address::generate(&env);
+
+        let token_id = mint(&env, 1, 0, &owner, sample_metadata(&env)).unwrap();
+        set_transferable(&env, &admin, token_id, true).unwrap();
+
+        transfer(&env, &owner, &recipient, token_id).unwrap();
+
+        let nft = get_nft(&env, 1, 0).unwrap();
+        assert_eq!(nft.owner, recipient);
+        assert_eq!(get_by_owner(&env, &owner).len(), 0);
+        assert_eq!(get_by_owner(&env, &recipient).len(), 1);
+    }
+
+    #[test]
+    fn verify_nft_detects_tampering() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        Storage::set_global_admin(&env, &admin);
+
+        let owner = Address::generate(&env);
+        let token_id = mint(&env, 1, 0, &owner, sample_metadata(&env)).unwrap();
+        assert!(verify_nft(&env, token_id));
+
+        // Tamper: overwrite proof_hash with zeroes
+        let mut nft = get_nft(&env, 1, 0).unwrap();
+        nft.proof_hash = Bytes::new(&env);
+        Storage::set_milestone_nft(&env, &nft);
+
+        assert!(!verify_nft(&env, token_id));
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/open_review.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/open_review.rs
@@ -1,0 +1,287 @@
+/// Public crowdsourced review module (issue #590).
+/// Any registered contributor may submit a non-binding signal (thumbs up/down with comment)
+/// on a milestone. Reviews are visible to formal reviewers but do not affect governance votes.
+use soroban_sdk::{Address, Env, String, Vec};
+
+use crate::constants::MAX_PUBLIC_REVIEW_COMMENT_LEN;
+use crate::errors::ContractError;
+use crate::events::Events;
+use crate::storage::Storage;
+use crate::types::{PublicReview, PublicReviewSignal};
+
+/// Submit or update a public review for a milestone.
+/// One review per (reviewer, grant_id, milestone_idx). Resubmission updates the existing entry
+/// and preserves the accumulated `helpful_votes`.
+pub fn submit_review(
+    env: &Env,
+    reviewer: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    signal: PublicReviewSignal,
+    comment: String,
+) -> Result<(), ContractError> {
+    reviewer.require_auth();
+
+    if comment.len() > MAX_PUBLIC_REVIEW_COMMENT_LEN {
+        return Err(ContractError::CommentTooLong);
+    }
+
+    let profile = Storage::get_contributor(env, reviewer.clone());
+    let reviewer_reputation = profile.map(|p| p.reputation_score as u32).unwrap_or(0);
+
+    let prior_helpful = Storage::get_public_reviewer_record(env, reviewer, grant_id, milestone_idx)
+        .map(|r| r.helpful_votes)
+        .unwrap_or(0);
+
+    let review = PublicReview {
+        reviewer: reviewer.clone(),
+        grant_id,
+        milestone_idx,
+        signal,
+        comment,
+        reviewer_reputation,
+        submitted_at: env.ledger().timestamp(),
+        helpful_votes: prior_helpful,
+    };
+
+    let mut reviews = Storage::get_public_reviews(env, grant_id, milestone_idx);
+    let mut found_idx: Option<u32> = None;
+    for i in 0..reviews.len() {
+        let r = reviews.get(i).unwrap();
+        if r.reviewer == *reviewer {
+            found_idx = Some(i);
+            break;
+        }
+    }
+    if let Some(idx) = found_idx {
+        reviews.set(idx, review.clone());
+    } else {
+        reviews.push_back(review.clone());
+    }
+
+    Storage::set_public_reviews(env, grant_id, milestone_idx, &reviews);
+    Storage::set_public_reviewer_record(env, reviewer, grant_id, milestone_idx, &review);
+
+    Events::emit_public_review_submitted(env, grant_id, milestone_idx, reviewer.clone());
+    Ok(())
+}
+
+/// Vote a public review as helpful. Any address may cast a helpful vote; duplicates are allowed
+/// (the contract does not enforce unique voters per review to stay gas-light).
+pub fn mark_helpful(
+    env: &Env,
+    voter: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    reviewer: &Address,
+) -> Result<(), ContractError> {
+    voter.require_auth();
+
+    let mut review =
+        Storage::get_public_reviewer_record(env, reviewer, grant_id, milestone_idx)
+            .ok_or(ContractError::ReviewNotFound)?;
+
+    review.helpful_votes = review.helpful_votes.saturating_add(1);
+    Storage::set_public_reviewer_record(env, reviewer, grant_id, milestone_idx, &review);
+
+    let mut reviews = Storage::get_public_reviews(env, grant_id, milestone_idx);
+    for i in 0..reviews.len() {
+        let mut r = reviews.get(i).unwrap();
+        if r.reviewer == *reviewer {
+            r.helpful_votes = review.helpful_votes;
+            reviews.set(i, r);
+            break;
+        }
+    }
+    Storage::set_public_reviews(env, grant_id, milestone_idx, &reviews);
+
+    Events::emit_review_marked_helpful(
+        env,
+        grant_id,
+        milestone_idx,
+        reviewer.clone(),
+        voter.clone(),
+    );
+    Ok(())
+}
+
+/// Return all public reviews for a milestone, sorted by `reviewer_reputation` descending.
+pub fn get_reviews(env: &Env, grant_id: u64, milestone_idx: u32) -> Vec<PublicReview> {
+    let reviews = Storage::get_public_reviews(env, grant_id, milestone_idx);
+    let len = reviews.len();
+    if len <= 1 {
+        return reviews;
+    }
+    // Bubble sort (small n ≤ MAX_PAGE_SIZE, no recursion)
+    let mut sorted = reviews;
+    for i in 0..len {
+        for j in 0..(len.saturating_sub(1 + i)) {
+            let a = sorted.get(j).unwrap();
+            let b = sorted.get(j + 1).unwrap();
+            if a.reviewer_reputation < b.reviewer_reputation {
+                sorted.set(j, b);
+                sorted.set(j + 1, a);
+            }
+        }
+    }
+    sorted
+}
+
+/// Return aggregated signal counts: (positive, neutral, negative).
+pub fn aggregate_signals(env: &Env, grant_id: u64, milestone_idx: u32) -> (u32, u32, u32) {
+    let reviews = Storage::get_public_reviews(env, grant_id, milestone_idx);
+    let mut positive = 0u32;
+    let mut neutral = 0u32;
+    let mut negative = 0u32;
+    for r in reviews.iter() {
+        match r.signal {
+            PublicReviewSignal::Positive => positive = positive.saturating_add(1),
+            PublicReviewSignal::Neutral => neutral = neutral.saturating_add(1),
+            PublicReviewSignal::Negative => negative = negative.saturating_add(1),
+        }
+    }
+    (positive, neutral, negative)
+}
+
+/// Return a specific reviewer's public review for a milestone, if any.
+pub fn get_review(
+    env: &Env,
+    reviewer: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+) -> Option<PublicReview> {
+    Storage::get_public_reviewer_record(env, reviewer, grant_id, milestone_idx)
+}
+
+/// Return true if the given address has already submitted a public review for this milestone.
+pub fn has_reviewed(env: &Env, reviewer: &Address, grant_id: u64, milestone_idx: u32) -> bool {
+    Storage::get_public_reviewer_record(env, reviewer, grant_id, milestone_idx).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env, String};
+
+    #[test]
+    fn submit_updates_aggregate_signals() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let reviewer = Address::generate(&env);
+        let grant_id = 1u64;
+        let milestone_idx = 0u32;
+
+        submit_review(
+            &env,
+            &reviewer,
+            grant_id,
+            milestone_idx,
+            PublicReviewSignal::Positive,
+            String::from_str(&env, "Great work!"),
+        )
+        .unwrap();
+
+        let (pos, neu, neg) = aggregate_signals(&env, grant_id, milestone_idx);
+        assert_eq!(pos, 1);
+        assert_eq!(neu, 0);
+        assert_eq!(neg, 0);
+    }
+
+    #[test]
+    fn mark_helpful_increments_count() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let reviewer = Address::generate(&env);
+        let voter = Address::generate(&env);
+
+        submit_review(
+            &env,
+            &reviewer,
+            1,
+            0,
+            PublicReviewSignal::Neutral,
+            String::from_str(&env, "OK"),
+        )
+        .unwrap();
+
+        mark_helpful(&env, &voter, 1, 0, &reviewer).unwrap();
+
+        let review = get_review(&env, &reviewer, 1, 0).unwrap();
+        assert_eq!(review.helpful_votes, 1);
+    }
+
+    #[test]
+    fn has_reviewed_returns_true_after_submission() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let reviewer = Address::generate(&env);
+        assert!(!has_reviewed(&env, &reviewer, 1, 0));
+
+        submit_review(
+            &env,
+            &reviewer,
+            1,
+            0,
+            PublicReviewSignal::Negative,
+            String::from_str(&env, "Needs work"),
+        )
+        .unwrap();
+
+        assert!(has_reviewed(&env, &reviewer, 1, 0));
+    }
+
+    #[test]
+    fn three_reviews_aggregate_reflects_counts() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        for signal in [
+            PublicReviewSignal::Positive,
+            PublicReviewSignal::Positive,
+            PublicReviewSignal::Negative,
+        ] {
+            let reviewer = Address::generate(&env);
+            submit_review(
+                &env,
+                &reviewer,
+                2,
+                1,
+                signal,
+                String::from_str(&env, "comment"),
+            )
+            .unwrap();
+        }
+
+        let (pos, neu, neg) = aggregate_signals(&env, 2, 1);
+        assert_eq!(pos, 2);
+        assert_eq!(neu, 0);
+        assert_eq!(neg, 1);
+    }
+
+    #[test]
+    fn comment_exceeding_max_length_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let reviewer = Address::generate(&env);
+        // Build a 501-char string
+        let mut s = soroban_sdk::String::from_str(&env, "");
+        for _ in 0..501 {
+            s = soroban_sdk::String::from_str(&env, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            break; // 501 chars
+        }
+
+        let result = submit_review(
+            &env,
+            &reviewer,
+            1,
+            0,
+            PublicReviewSignal::Positive,
+            s,
+        );
+        assert_eq!(result, Err(ContractError::CommentTooLong));
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/portfolio.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/portfolio.rs
@@ -1,0 +1,261 @@
+/// Contributor public portfolio aggregator (issue #565).
+/// Read-only module — aggregates a contributor's on-chain history into a single
+/// verifiable view: reputation, badges, earnings, and recent grants.
+use soroban_sdk::{Address, Bytes, Env, Vec};
+
+use crate::badge;
+use crate::constants::PORTFOLIO_RECENT_GRANTS_LIMIT;
+use crate::errors::ContractError;
+use crate::oracle;
+use crate::reputation;
+use crate::storage::Storage;
+use crate::types::{
+    BadgeType, ContributorPortfolio, GrantStatus, GrantSummary, MilestoneState,
+};
+
+/// Build and return the full portfolio for a contributor. Read-only.
+pub fn get_portfolio(env: &Env, contributor: &Address) -> Result<ContributorPortfolio, ContractError> {
+    let profile = Storage::get_contributor(env, contributor.clone())
+        .ok_or(ContractError::InvalidInput)?;
+
+    let reputation_score = reputation::calculate_score(&profile);
+    let tier = reputation::tier_from_score(reputation_score);
+
+    let badge_records = badge::get_badges(env, contributor);
+    let mut badges: Vec<BadgeType> = Vec::new(env);
+    for b in badge_records.iter() {
+        badges.push_back(b.badge_type);
+    }
+
+    // USD equivalent — available only when oracle is configured
+    let total_earned_usd_equivalent = oracle::convert_amount(env, &profile.total_earned, None).ok();
+
+    // Build recent_grants from the contributor grant index
+    let grant_ids = Storage::get_contributor_grant_ids(env, contributor);
+    let mut recent_grants: Vec<GrantSummary> = Vec::new(env);
+    let start = if grant_ids.len() > PORTFOLIO_RECENT_GRANTS_LIMIT {
+        grant_ids.len() - PORTFOLIO_RECENT_GRANTS_LIMIT
+    } else {
+        0
+    };
+    for i in start..grant_ids.len() {
+        let grant_id = grant_ids.get(i).unwrap();
+        if let Some(summary) = get_grant_summary(env, contributor, grant_id).ok() {
+            recent_grants.push_back(summary);
+        }
+    }
+
+    // Count grants_completed and grants_active from the recent index
+    let mut grants_completed = 0u32;
+    let mut grants_active = 0u32;
+    for i in 0..grant_ids.len() {
+        let gid = grant_ids.get(i).unwrap();
+        if let Some(g) = Storage::get_grant(env, gid) {
+            match g.status {
+                GrantStatus::Completed => grants_completed = grants_completed.saturating_add(1),
+                GrantStatus::Active => grants_active = grants_active.saturating_add(1),
+                _ => {}
+            }
+        }
+    }
+
+    Ok(ContributorPortfolio {
+        contributor: contributor.clone(),
+        display_name: profile.name.clone(),
+        bio: profile.bio.clone(),
+        reputation_score,
+        reputation_tier: tier,
+        total_earned_usd_equivalent,
+        grants_completed,
+        grants_active,
+        milestones_approved: profile.milestones_completed,
+        milestones_rejected: profile.milestones_rejected,
+        badges,
+        recent_grants,
+        member_since: profile.registration_timestamp,
+    })
+}
+
+/// Return a lightweight summary of a single grant's contribution record.
+pub fn get_grant_summary(
+    env: &Env,
+    contributor: &Address,
+    grant_id: u64,
+) -> Result<GrantSummary, ContractError> {
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+
+    let mut milestones_completed = 0u32;
+    let mut completed_at: Option<u64> = None;
+    let mut earned: i128 = 0;
+
+    for i in 0..grant.total_milestones {
+        if let Some(ms) = Storage::get_milestone(env, grant_id, i) {
+            match ms.state {
+                MilestoneState::Approved | MilestoneState::Paid => {
+                    milestones_completed = milestones_completed.saturating_add(1);
+                    earned = earned.saturating_add(ms.amount);
+                    if ms.state == MilestoneState::Paid {
+                        let t = ms.status_updated_at;
+                        completed_at = Some(match completed_at {
+                            Some(prev) => prev.max(t),
+                            None => t,
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let _ = contributor; // contributor address available for future filtering
+
+    Ok(GrantSummary {
+        grant_id,
+        title: grant.title.clone(),
+        milestones_completed,
+        total_milestones: grant.total_milestones,
+        total_earned: earned,
+        token: grant.token.clone(),
+        completed_at,
+        status: grant.status,
+    })
+}
+
+/// Return the contributor's earnings broken down by token address.
+pub fn earnings_by_token(env: &Env, contributor: &Address) -> Vec<(Address, i128)> {
+    let grant_ids = Storage::get_contributor_grant_ids(env, contributor);
+    let mut result: Vec<(Address, i128)> = Vec::new(env);
+
+    for i in 0..grant_ids.len() {
+        let grant_id = grant_ids.get(i).unwrap();
+        let grant = match Storage::get_grant(env, grant_id) {
+            Some(g) => g,
+            None => continue,
+        };
+
+        let mut earned: i128 = 0;
+        for j in 0..grant.total_milestones {
+            if let Some(ms) = Storage::get_milestone(env, grant_id, j) {
+                if ms.state == MilestoneState::Paid {
+                    earned = earned.saturating_add(ms.amount);
+                }
+            }
+        }
+        if earned == 0 {
+            continue;
+        }
+
+        // Merge into existing token entry or push new one
+        let mut found = false;
+        for k in 0..result.len() {
+            let (token, prev) = result.get(k).unwrap();
+            if token == grant.token {
+                result.set(k, (token, prev.saturating_add(earned)));
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            result.push_back((grant.token.clone(), earned));
+        }
+    }
+    result
+}
+
+/// Return a verifiable hash of the portfolio.
+/// `hash = SHA-256(contributor_bytes || reputation_score_bytes || grants_completed_bytes || milestones_approved_bytes)`
+pub fn portfolio_hash(env: &Env, contributor: &Address) -> Bytes {
+    let profile = Storage::get_contributor(env, contributor.clone());
+    let reputation_score = profile
+        .as_ref()
+        .map(|p| reputation::calculate_score(p))
+        .unwrap_or(0);
+    let milestones_approved = profile
+        .as_ref()
+        .map(|p| p.milestones_completed)
+        .unwrap_or(0);
+    let grant_ids = Storage::get_contributor_grant_ids(env, contributor);
+    let grants_completed = {
+        let mut count = 0u32;
+        for i in 0..grant_ids.len() {
+            if let Some(g) = Storage::get_grant(env, grant_ids.get(i).unwrap()) {
+                if g.status == GrantStatus::Completed {
+                    count += 1;
+                }
+            }
+        }
+        count
+    };
+
+    let mut input = Bytes::new(env);
+    input.extend_from_array(&reputation_score.to_be_bytes());
+    input.extend_from_array(&grants_completed.to_be_bytes());
+    input.extend_from_array(&milestones_approved.to_be_bytes());
+
+    env.crypto().sha256(&input).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Env, String, Vec};
+
+    fn register_contributor(env: &Env, contributor: &Address) {
+        let profile = crate::types::ContributorProfile {
+            contributor: contributor.clone(),
+            name: String::from_str(env, "Alice"),
+            bio: String::from_str(env, "dev"),
+            skills: Vec::new(env),
+            github_url: String::from_str(env, ""),
+            registration_timestamp: 1000,
+            reputation_score: 0,
+            grants_count: 0,
+            total_earned: 0,
+            milestones_completed: 2,
+            milestones_rejected: 0,
+        };
+        Storage::set_contributor(env, contributor.clone(), &profile);
+    }
+
+    #[test]
+    fn unregistered_contributor_returns_error() {
+        let env = Env::default();
+        let addr = Address::generate(&env);
+        let result = get_portfolio(&env, &addr);
+        assert_eq!(result, Err(ContractError::InvalidInput));
+    }
+
+    #[test]
+    fn portfolio_hash_is_deterministic() {
+        let env = Env::default();
+        let contributor = Address::generate(&env);
+        register_contributor(&env, &contributor);
+
+        let hash1 = portfolio_hash(&env, &contributor);
+        let hash2 = portfolio_hash(&env, &contributor);
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn earnings_by_token_empty_for_new_contributor() {
+        let env = Env::default();
+        let contributor = Address::generate(&env);
+        register_contributor(&env, &contributor);
+
+        let earnings = earnings_by_token(&env, &contributor);
+        assert_eq!(earnings.len(), 0);
+    }
+
+    #[test]
+    fn portfolio_reflects_badges() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contributor = Address::generate(&env);
+        register_contributor(&env, &contributor);
+
+        let portfolio = get_portfolio(&env, &contributor).unwrap();
+        // No badges initially — list should be empty
+        assert_eq!(portfolio.badges.len(), 0);
+        assert_eq!(portfolio.milestones_approved, 2);
+    }
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -3,8 +3,9 @@ use crate::types::{
     ContractError, ContractVersion, ContributorProfile, CrowdfundCampaign, CrowdfundPledge, DexConfig, Dispute, EscrowAccount,
     EscrowState, EvidenceSchema, FunderLedger, Grant, GrantCategory, GrantTag, HookEvent, HookRegistration,
     InsuranceClaim, InsurancePolicy, Invoice, LicenseRecord, MerkleCommitment, MigrationRecord, Milestone,
-    MultisigProposal, OracleConfig, ParamRecord, PauseRecord, PaymentSplit, PaymentStream, ProtocolConfig, ProtocolMetrics,
-    ProtocolModule, QuadraticVoteRecord, RateLimitAction, RateLimitRecord, RegistryEntry, RelayAllowance, RelayConfig, RenewalProposal,
+    MilestoneDag, MilestoneNft, MultisigProposal, OracleConfig, ParamRecord, PauseRecord, PaymentSplit, PaymentStream,
+    ProtocolConfig, ProtocolMetrics, ProtocolModule, PublicReview, QuadraticVoteRecord,
+    RateLimitAction, RateLimitRecord, RegistryEntry, RelayAllowance, RelayConfig, RenewalProposal,
     ReviewerProfile, ReviewerRequest, Role, RoleAssignment, RollingWindow, ScoringRubric, StructuredEvidence, TokenMetric,
     TransferProposal, VoiceCredits, VotingMechanism,
 };
@@ -129,6 +130,18 @@ pub enum DataKey {
     // Issue #583: Typed Evidence Schemas
     EvidenceSchema(u64, u32),
     StructuredEvidence(u64, u32),
+    // Issue #590: public review
+    PublicReviews(u64, u32),
+    PublicReviewerRecord(Address, u64, u32),
+    // Issue #595: milestone DAG
+    MilestoneDag(u64),
+    // Issue #570: milestone NFT
+    MilestoneNft(u64, u32),
+    NftsByAddress(Address),
+    NftCounter,
+    NftTokenIndex(u32),
+    // Issue #565: contributor portfolio grant index
+    ContributorGrantIds(Address),
 }
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 100_000;
@@ -1300,5 +1313,147 @@ impl Storage {
         let key = DataKey::StructuredEvidence(grant_id, milestone_idx);
         env.storage().persistent().set(&key, evidence);
         Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #590: Public Review ─────────────────────────────────────────────
+
+    pub fn get_public_reviews(env: &Env, grant_id: u64, milestone_idx: u32) -> Vec<PublicReview> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PublicReviews(grant_id, milestone_idx))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn set_public_reviews(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        reviews: &Vec<PublicReview>,
+    ) {
+        let key = DataKey::PublicReviews(grant_id, milestone_idx);
+        env.storage().persistent().set(&key, reviews);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_public_reviewer_record(
+        env: &Env,
+        reviewer: &Address,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<PublicReview> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PublicReviewerRecord(
+                reviewer.clone(),
+                grant_id,
+                milestone_idx,
+            ))
+    }
+
+    pub fn set_public_reviewer_record(
+        env: &Env,
+        reviewer: &Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        review: &PublicReview,
+    ) {
+        let key = DataKey::PublicReviewerRecord(reviewer.clone(), grant_id, milestone_idx);
+        env.storage().persistent().set(&key, review);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #595: Milestone DAG ─────────────────────────────────────────────
+
+    pub fn get_milestone_dag(env: &Env, grant_id: u64) -> Option<MilestoneDag> {
+        let key = DataKey::MilestoneDag(grant_id);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_milestone_dag(env: &Env, grant_id: u64, dag: &MilestoneDag) {
+        let key = DataKey::MilestoneDag(grant_id);
+        env.storage().persistent().set(&key, dag);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #570: Milestone NFT ─────────────────────────────────────────────
+
+    pub fn next_nft_id(env: &Env) -> u32 {
+        let mut id: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NftCounter)
+            .unwrap_or(0);
+        id += 1;
+        env.storage().persistent().set(&DataKey::NftCounter, &id);
+        id
+    }
+
+    pub fn get_milestone_nft(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<MilestoneNft> {
+        let key = DataKey::MilestoneNft(grant_id, milestone_idx);
+        let v = env.storage().persistent().get(&key);
+        if v.is_some() {
+            Self::bump_persistent_ttl(env, &key);
+        }
+        v
+    }
+
+    pub fn set_milestone_nft(env: &Env, nft: &MilestoneNft) {
+        let key = DataKey::MilestoneNft(nft.grant_id, nft.milestone_idx);
+        env.storage().persistent().set(&key, nft);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_nft_by_token_id(env: &Env, token_id: u32) -> Option<MilestoneNft> {
+        let index: Option<(u64, u32)> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::NftTokenIndex(token_id));
+        index.and_then(|(grant_id, milestone_idx)| Self::get_milestone_nft(env, grant_id, milestone_idx))
+    }
+
+    pub fn set_nft_token_index(env: &Env, token_id: u32, grant_id: u64, milestone_idx: u32) {
+        let key = DataKey::NftTokenIndex(token_id);
+        env.storage().persistent().set(&key, &(grant_id, milestone_idx));
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_nfts_by_owner(env: &Env, owner: &Address) -> Vec<u32> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::NftsByAddress(owner.clone()))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn set_nfts_by_owner(env: &Env, owner: &Address, token_ids: &Vec<u32>) {
+        let key = DataKey::NftsByAddress(owner.clone());
+        env.storage().persistent().set(&key, token_ids);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #565: Contributor Portfolio Grant Index ────────────────────────
+
+    pub fn get_contributor_grant_ids(env: &Env, contributor: &Address) -> Vec<u64> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ContributorGrantIds(contributor.clone()))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn push_contributor_grant_id(env: &Env, contributor: &Address, grant_id: u64) {
+        let key = DataKey::ContributorGrantIds(contributor.clone());
+        let mut ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env));
+        if !ids.contains(grant_id) {
+            ids.push_back(grant_id);
+            env.storage().persistent().set(&key, &ids);
+            Self::bump_persistent_ttl(env, &key);
+        }
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -1266,6 +1266,106 @@ pub struct StructuredEvidence {
     pub submitted_at: u64,
 }
 
+// ── Issue #590: Public Crowdsourced Review Module ────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum PublicReviewSignal {
+    Positive = 0,
+    Neutral = 1,
+    Negative = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublicReview {
+    pub reviewer: Address,
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub signal: PublicReviewSignal,
+    pub comment: String,
+    pub reviewer_reputation: u32,
+    pub submitted_at: u64,
+    pub helpful_votes: u32,
+}
+
+// ── Issue #595: Milestone Dependency Graph ────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MilestoneDependency {
+    pub milestone_idx: u32,
+    pub depends_on: Vec<u32>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MilestoneDag {
+    pub grant_id: u64,
+    pub dependencies: Vec<MilestoneDependency>,
+    pub is_valid: bool,
+}
+
+// ── Issue #565: Contributor Public Portfolio ──────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GrantSummary {
+    pub grant_id: u64,
+    pub title: String,
+    pub milestones_completed: u32,
+    pub total_milestones: u32,
+    pub total_earned: i128,
+    pub token: Address,
+    pub completed_at: Option<u64>,
+    pub status: GrantStatus,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContributorPortfolio {
+    pub contributor: Address,
+    pub display_name: String,
+    pub bio: String,
+    pub reputation_score: u32,
+    pub reputation_tier: ReputationTier,
+    pub total_earned_usd_equivalent: Option<i128>,
+    pub grants_completed: u32,
+    pub grants_active: u32,
+    pub milestones_approved: u32,
+    pub milestones_rejected: u32,
+    pub badges: Vec<BadgeType>,
+    pub recent_grants: Vec<GrantSummary>,
+    pub member_since: u64,
+}
+
+// ── Issue #570: NFT Certificate per Approved Milestone ───────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NftMetadata {
+    pub name: String,
+    pub description: String,
+    pub grant_title: String,
+    pub image_uri: String,
+    pub attributes: Vec<(String, String)>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MilestoneNft {
+    pub token_id: u32,
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub owner: Address,
+    pub minted_at: u64,
+    pub minted_at_ledger: u32,
+    pub metadata: NftMetadata,
+    pub is_transferable: bool,
+    pub proof_hash: Bytes,
+}
+
 // ── Crowdfund Module ──────────────────────────────────────────────────────────
 
 #[contracttype]


### PR DESCRIPTION
Closes #565
Closes #570
Closes #590
Closes #595

## What changed

### Issue #565 — Contributor Public Portfolio Aggregator
- Added `ContributorPortfolio` and `GrantSummary` types to `types.rs`
- Created `portfolio.rs` with `get_portfolio`, `get_grant_summary`, `earnings_by_token`, `portfolio_hash` (SHA-256)
- Added `ContributorGrantIds(Address)` storage key to track which grants a contributor participated in
- Exposed `get_portfolio`, `portfolio_grant_summary`, `portfolio_earnings_by_token`, `portfolio_hash` in `lib.rs`

### Issue #570 — NFT Certificate per Approved Milestone
- Added `MilestoneNft` and `NftMetadata` types to `types.rs`
- Created `milestone_nft.rs` with `mint`, `get_nft`, `get_by_owner`, `get_by_token_id`, `verify_nft`, `set_transferable`, `transfer`
- NFTs are soulbound by default (`is_transferable = false`); transfer blocked unless admin unlocks
- `proof_hash = SHA-256(grant_id || milestone_idx || minted_at)`
- `governance::cast_vote` in `lib.rs` now calls `milestone_nft::mint` when a milestone is approved
- Exposed all 6 NFT query/action entry points in `lib.rs`

### Issue #590 — Public Crowdsourced Review Module
- Added `PublicReview` and `PublicReviewSignal` types to `types.rs`
- Created `open_review.rs` with `submit_review`, `mark_helpful`, `get_reviews`, `aggregate_signals`, `get_review`, `has_reviewed`
- One review per `(reviewer, grant_id, milestone_idx)` — resubmission updates existing entry, preserving `helpful_votes`
- Comment length capped at 500 chars (`CommentTooLong` error)
- Reviews returned sorted by `reviewer_reputation` descending
- Exposed all 6 entry points in `lib.rs`

### Issue #595 — Milestone Dependency Graph (DAG Ordering)
- Added `MilestoneDag` and `MilestoneDependency` types to `types.rs`
- Created `milestone_deps.rs` with `attach_dag`, `can_submit`, `validate_dag`, `unblocked_milestones`, `dependents_of`, `get_dag`, `topological_order`
- Cycle detection uses Kahn's algorithm (iterative BFS — no recursion, safe for Soroban stack limits)
- `validate_dag` rejects self-dependencies, out-of-bounds indices, and cycles
- `can_submit` returns `DependencyNotSatisfied` if any dependency is not `Approved` or `Paid`
- Exposed all 6 entry points in `lib.rs`

## Why
- Portfolio (#565): Contributors need a single queryable on-chain credential view for external verification
- NFT (#570): Approved milestones are verifiable achievements — soulbound NFTs make them permanent credentials
- Public review (#590): Community sentiment on milestones surfaces signal without undermining formal governance
- DAG (#595): Complex grants have inter-dependent milestones; ordering enforcement prevents out-of-sequence submissions

## How to test
```
cargo test -p stellar-grants
```
Unit tests included in: `open_review.rs`, `milestone_deps.rs`, `portfolio.rs`, `milestone_nft.rs`