### PR TITLE
Feat/569 572 573 574 protocol growth modules

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/arbitration_pool.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/arbitration_pool.rs
@@ -1,0 +1,421 @@
+use soroban_sdk::{contractevent, token, Address, Env, Vec};
+
+use crate::constants::BASIS_POINTS_SCALE;
+use crate::errors::ContractError;
+use crate::storage::Storage;
+use crate::types::{Arbiter, ArbiterVote, ArbitrationCase};
+
+/// Voting window for an arbitration case, in seconds (~1 day).
+const ARBITRATION_VOTING_WINDOW: u64 = 86_400;
+/// Portion of a minority arbiter's stake that is slashed and redistributed.
+const ARBITER_SLASH_BPS: u32 = 1_000; // 10%
+
+// ── Events ──────────────────────────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArbiterJoined {
+    pub arbiter: Address,
+    pub stake: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArbiterLeft {
+    pub arbiter: Address,
+    pub returned: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PanelAssigned {
+    pub case_id: u32,
+    pub dispute_id: u32,
+    pub panel_size: u32,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArbiterVoteCast {
+    pub case_id: u32,
+    pub arbiter: Address,
+    pub favor_contributor: bool,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CaseFinalized {
+    pub case_id: u32,
+    pub outcome: bool,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RewardsSettled {
+    pub case_id: u32,
+    pub total_slashed: i128,
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Join the arbitration pool by staking tokens.
+pub fn join_pool(
+    env: &Env,
+    arbiter: &Address,
+    token: &Address,
+    stake: i128,
+) -> Result<(), ContractError> {
+    arbiter.require_auth();
+
+    if stake <= 0 {
+        return Err(ContractError::InvalidInput);
+    }
+
+    // The pool operates on a single staking token, fixed by the first joiner.
+    match Storage::get_arbiter_pool_token(env) {
+        Some(existing) => {
+            if existing != *token {
+                return Err(ContractError::InvalidInput);
+            }
+        }
+        None => Storage::set_arbiter_pool_token(env, token),
+    }
+
+    if let Some(existing) = Storage::get_arbiter(env, arbiter) {
+        if existing.is_active {
+            return Err(ContractError::ArbiterAlreadyJoined);
+        }
+    }
+
+    token::Client::new(env, token).transfer(arbiter, &env.current_contract_address(), &stake);
+
+    let now = env.ledger().timestamp();
+    let record = match Storage::get_arbiter(env, arbiter) {
+        Some(mut a) => {
+            a.stake = a
+                .stake
+                .checked_add(stake)
+                .ok_or(ContractError::InvalidInput)?;
+            a.is_active = true;
+            a
+        }
+        None => Arbiter {
+            address: arbiter.clone(),
+            stake,
+            cases_decided: 0,
+            cases_correct: 0,
+            is_active: true,
+            joined_at: now,
+        },
+    };
+    Storage::set_arbiter(env, &record);
+
+    let mut pool = Storage::get_arbiter_pool(env);
+    if !pool.contains(arbiter.clone()) {
+        pool.push_back(arbiter.clone());
+        Storage::set_arbiter_pool(env, &pool);
+    }
+
+    ArbiterJoined {
+        arbiter: arbiter.clone(),
+        stake,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Leave the pool and withdraw stake (only when not in an active case).
+pub fn leave_pool(env: &Env, arbiter: &Address) -> Result<i128, ContractError> {
+    arbiter.require_auth();
+
+    let mut record = Storage::get_arbiter(env, arbiter).ok_or(ContractError::ArbiterNotFound)?;
+    if !record.is_active {
+        return Err(ContractError::ArbiterNotFound);
+    }
+
+    if Storage::get_arbiter_active_cases(env, arbiter) > 0 {
+        return Err(ContractError::ArbiterInActiveCase);
+    }
+
+    let refund = record.stake;
+    record.stake = 0;
+    record.is_active = false;
+    Storage::set_arbiter(env, &record);
+
+    // Remove from active pool list.
+    let pool = Storage::get_arbiter_pool(env);
+    let mut new_pool = Vec::new(env);
+    for a in pool.iter() {
+        if a != *arbiter {
+            new_pool.push_back(a);
+        }
+    }
+    Storage::set_arbiter_pool(env, &new_pool);
+
+    if refund > 0 {
+        let token = Storage::get_arbiter_pool_token(env).ok_or(ContractError::InvalidState)?;
+        token::Client::new(env, &token).transfer(&env.current_contract_address(), arbiter, &refund);
+    }
+
+    ArbiterLeft {
+        arbiter: arbiter.clone(),
+        returned: refund,
+    }
+    .publish(env);
+
+    Ok(refund)
+}
+
+/// Randomly assign a panel of `panel_size` arbiters for a dispute.
+/// Uses `env.prng().shuffle` over the active arbiter list.
+pub fn assign_panel(env: &Env, dispute_id: u32, panel_size: u32) -> Result<u32, ContractError> {
+    if panel_size != 3 && panel_size != 5 {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let mut pool = Storage::get_arbiter_pool(env);
+    if pool.len() < panel_size {
+        return Err(ContractError::InsufficientArbiters);
+    }
+
+    // Fisher-Yates shuffle via ledger PRNG, then take the first `panel_size`.
+    env.prng().shuffle(&mut pool);
+
+    let mut panel = Vec::new(env);
+    for i in 0..panel_size {
+        let addr = pool.get(i).ok_or(ContractError::InsufficientArbiters)?;
+        panel.push_back(addr.clone());
+        // Lock each selected arbiter against leaving while the case is active.
+        let count = Storage::get_arbiter_active_cases(env, &addr);
+        Storage::set_arbiter_active_cases(env, &addr, count.saturating_add(1));
+    }
+
+    let case_id = Storage::next_arbitration_case_id(env);
+    let now = env.ledger().timestamp();
+    let case = ArbitrationCase {
+        id: case_id,
+        dispute_id,
+        panel,
+        votes: Vec::new(env),
+        outcome: None,
+        finalized: false,
+        assigned_at: now,
+        deadline: now + ARBITRATION_VOTING_WINDOW,
+    };
+    Storage::set_arbitration_case(env, &case);
+    Storage::set_case_id_by_dispute(env, dispute_id, case_id);
+
+    PanelAssigned {
+        case_id,
+        dispute_id,
+        panel_size,
+    }
+    .publish(env);
+
+    Ok(case_id)
+}
+
+/// Arbiter casts their vote on an arbitration case.
+pub fn cast_arbiter_vote(
+    env: &Env,
+    arbiter: &Address,
+    case_id: u32,
+    favor_contributor: bool,
+    confidence: u32,
+) -> Result<(), ContractError> {
+    arbiter.require_auth();
+
+    if confidence < 1 || confidence > 100 {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let mut case = Storage::get_arbitration_case(env, case_id)
+        .ok_or(ContractError::ArbitrationCaseNotFound)?;
+
+    if case.finalized {
+        return Err(ContractError::CaseAlreadyFinalized);
+    }
+    if env.ledger().timestamp() > case.deadline {
+        return Err(ContractError::VotingDeadlinePassed);
+    }
+    if !case.panel.contains(arbiter.clone()) {
+        return Err(ContractError::NotPanelMember);
+    }
+    if Storage::get_arbiter_vote(env, case_id, arbiter).is_some() {
+        return Err(ContractError::AlreadyVoted);
+    }
+
+    let vote = ArbiterVote {
+        arbiter: arbiter.clone(),
+        favor_contributor,
+        confidence,
+        voted_at: env.ledger().timestamp(),
+    };
+    Storage::set_arbiter_vote(env, case_id, &vote);
+    case.votes.push_back(vote);
+    Storage::set_arbitration_case(env, &case);
+
+    ArbiterVoteCast {
+        case_id,
+        arbiter: arbiter.clone(),
+        favor_contributor,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Finalize a case once voting closes. Majority vote determines the outcome.
+pub fn finalize_case(env: &Env, case_id: u32) -> Result<bool, ContractError> {
+    let mut case = Storage::get_arbitration_case(env, case_id)
+        .ok_or(ContractError::ArbitrationCaseNotFound)?;
+
+    if case.finalized {
+        return Err(ContractError::CaseAlreadyFinalized);
+    }
+
+    // Voting must be closed: either deadline passed or all panellists voted.
+    let all_voted = case.votes.len() >= case.panel.len();
+    if env.ledger().timestamp() <= case.deadline && !all_voted {
+        return Err(ContractError::InvalidState);
+    }
+
+    let mut favor: u32 = 0;
+    let mut against: u32 = 0;
+    for v in case.votes.iter() {
+        if v.favor_contributor {
+            favor += 1;
+        } else {
+            against += 1;
+        }
+    }
+
+    // Majority (>50% of those who voted). Ties resolve in favour of the funder.
+    let outcome = favor > against;
+    case.outcome = Some(outcome);
+    case.finalized = true;
+    Storage::set_arbitration_case(env, &case);
+
+    // Release the active-case lock on every panellist.
+    for addr in case.panel.iter() {
+        let count = Storage::get_arbiter_active_cases(env, &addr);
+        Storage::set_arbiter_active_cases(env, &addr, count.saturating_sub(1));
+    }
+
+    CaseFinalized { case_id, outcome }.publish(env);
+
+    Ok(outcome)
+}
+
+/// Distribute rewards to majority arbiters and slash minority arbiters.
+pub fn settle_rewards(env: &Env, case_id: u32) -> Result<(), ContractError> {
+    let case = Storage::get_arbitration_case(env, case_id)
+        .ok_or(ContractError::ArbitrationCaseNotFound)?;
+
+    if !case.finalized {
+        return Err(ContractError::CaseNotFinalized);
+    }
+    if Storage::is_arbitration_settled(env, case_id) {
+        return Err(ContractError::InvalidState);
+    }
+
+    let outcome = case.outcome.ok_or(ContractError::CaseNotFinalized)?;
+
+    // Slash minority arbiters and accumulate the redistributable pot. Track the
+    // confidence-weighted majority for proportional payout.
+    let mut total_slashed: i128 = 0;
+    let mut majority_weight: u64 = 0;
+    for v in case.votes.iter() {
+        let in_majority = v.favor_contributor == outcome;
+        let mut arb = match Storage::get_arbiter(env, &v.arbiter) {
+            Some(a) => a,
+            None => continue,
+        };
+        arb.cases_decided = arb.cases_decided.saturating_add(1);
+        if in_majority {
+            arb.cases_correct = arb.cases_correct.saturating_add(1);
+            majority_weight = majority_weight.saturating_add(v.confidence as u64);
+        } else {
+            let slash = arb
+                .stake
+                .checked_mul(ARBITER_SLASH_BPS as i128)
+                .ok_or(ContractError::InvalidInput)?
+                .checked_div(BASIS_POINTS_SCALE as i128)
+                .ok_or(ContractError::InvalidInput)?;
+            if slash > 0 {
+                arb.stake = arb
+                    .stake
+                    .checked_sub(slash)
+                    .ok_or(ContractError::InvalidInput)?;
+                total_slashed = total_slashed.saturating_add(slash);
+            }
+        }
+        Storage::set_arbiter(env, &arb);
+    }
+
+    // Distribute the slashed pot to majority arbiters, weighted by confidence.
+    if total_slashed > 0 && majority_weight > 0 {
+        let mut distributed: i128 = 0;
+        let votes_len = case.votes.len();
+        let mut last_majority_idx: Option<u32> = None;
+        for i in 0..votes_len {
+            let v = case.votes.get(i).ok_or(ContractError::InvalidInput)?;
+            if v.favor_contributor == outcome {
+                last_majority_idx = Some(i);
+            }
+        }
+        for i in 0..votes_len {
+            let v = case.votes.get(i).ok_or(ContractError::InvalidInput)?;
+            if v.favor_contributor != outcome {
+                continue;
+            }
+            let share = if Some(i) == last_majority_idx {
+                total_slashed - distributed
+            } else {
+                total_slashed
+                    .checked_mul(v.confidence as i128)
+                    .ok_or(ContractError::InvalidInput)?
+                    .checked_div(majority_weight as i128)
+                    .ok_or(ContractError::InvalidInput)?
+            };
+            if share > 0 {
+                if let Some(mut arb) = Storage::get_arbiter(env, &v.arbiter) {
+                    arb.stake = arb
+                        .stake
+                        .checked_add(share)
+                        .ok_or(ContractError::InvalidInput)?;
+                    Storage::set_arbiter(env, &arb);
+                    distributed = distributed.saturating_add(share);
+                }
+            }
+        }
+    }
+
+    Storage::set_arbitration_settled(env, case_id);
+
+    RewardsSettled {
+        case_id,
+        total_slashed,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Return pool statistics: (active_arbiters, total_staked).
+pub fn pool_stats(env: &Env) -> (u32, i128) {
+    let pool = Storage::get_arbiter_pool(env);
+    let mut total: i128 = 0;
+    for addr in pool.iter() {
+        if let Some(a) = Storage::get_arbiter(env, &addr) {
+            total = total.saturating_add(a.stake);
+        }
+    }
+    (pool.len(), total)
+}
+
+/// Return an arbiter's profile.
+pub fn get_arbiter(env: &Env, address: &Address) -> Option<Arbiter> {
+    Storage::get_arbiter(env, address)
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/config.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/config.rs
@@ -15,6 +15,7 @@ pub fn default_config() -> ProtocolConfig {
         max_grant_desc_len: 1024,
         multisig_threshold: 0,
         rate_limit_multiplier: 1,
+        referral_fee_bps: 1000,
     }
 }
 
@@ -27,6 +28,9 @@ pub fn validate_config(config: &ProtocolConfig) -> Result<(), ContractError> {
         return Err(ContractError::InvalidInput);
     }
     if config.protocol_fee_bps > 1000 {
+        return Err(ContractError::InvalidInput);
+    }
+    if config.referral_fee_bps > 10_000 {
         return Err(ContractError::InvalidInput);
     }
     if config.max_reviewers < 1 {

--- a/stellargrant-contracts/contracts/stellar-grants/src/dispute.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/dispute.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{token, Address, Env, String, Vec};
 
+use crate::arbitration_pool;
 use crate::events::Events;
 use crate::storage::Storage;
 use crate::types::{ContractError, Dispute, DisputeStatus, Grant};
@@ -64,6 +65,26 @@ pub fn assign_arbiter(
         arbiter.clone(),
     );
     Ok(())
+}
+
+/// Assign a randomized community-pool panel to an open dispute (Issue #573).
+///
+/// Used instead of the manual `assign_arbiter` flow when community/pool
+/// arbitration is enabled. Delegates panel selection to the arbitration pool and
+/// moves the dispute into `UnderReview`. Returns the created arbitration case id.
+pub fn assign_pool_panel(
+    env: &Env,
+    dispute: &mut Dispute,
+    dispute_id: u32,
+    panel_size: u32,
+) -> Result<u32, ContractError> {
+    if dispute.status != DisputeStatus::Open {
+        return Err(ContractError::InvalidState);
+    }
+    let case_id = arbitration_pool::assign_panel(env, dispute_id, panel_size)?;
+    dispute.status = DisputeStatus::UnderReview;
+    Storage::set_dispute(env, dispute.grant_id, dispute.milestone_idx, dispute);
+    Ok(case_id)
 }
 
 pub fn arbiter_vote(

--- a/stellargrant-contracts/contracts/stellar-grants/src/errors.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/errors.rs
@@ -120,4 +120,32 @@ pub enum ContractError {
     NftNotFound = 95,
     NftNotTransferable = 96,
     NotNftOwner = 97,
+    // Referral system (#569)
+    ReferralCodeNotFound = 98,
+    ReferralCodeInactive = 99,
+    ReferralCodeExpired = 100,
+    ReferralCodeExhausted = 101,
+    AlreadyReferred = 102,
+    ReferralRecordNotFound = 103,
+    NoRewardsToClaim = 104,
+    // Deadline extension (#572)
+    ExtensionRequestNotFound = 105,
+    ExtensionAlreadyResolved = 106,
+    NoDeadlineSet = 107,
+    // Arbitration pool (#573)
+    ArbiterNotFound = 108,
+    ArbiterAlreadyJoined = 109,
+    ArbiterInActiveCase = 110,
+    ArbitrationCaseNotFound = 111,
+    CaseAlreadyFinalized = 112,
+    CaseNotFinalized = 113,
+    NotPanelMember = 114,
+    VotingDeadlinePassed = 115,
+    InsufficientArbiters = 116,
+    // Performance bond (#574)
+    BondNotFound = 117,
+    BondAlreadyPosted = 118,
+    BondNotPosted = 119,
+    BondNotActive = 120,
+    BondExpired = 121,
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/fees.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/fees.rs
@@ -48,6 +48,12 @@ pub fn deduct_and_transfer(
         treasury.clone(),
     );
 
+    // Issue #569: if the grant owner was referred, accrue a share of this fee to
+    // their referrer's pending rewards. No-op when no referral record exists.
+    if let Some(grant) = Storage::get_grant(env, grant_id) {
+        crate::referral::trigger_reward(env, &grant.owner, token, fee)?;
+    }
+
     gross.checked_sub(fee).ok_or(ContractError::InvalidInput)
 }
 

--- a/stellargrant-contracts/contracts/stellar-grants/src/governance.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/governance.rs
@@ -237,6 +237,7 @@ mod tests {
             status_updated_at: 0,
             proof_url: None,
             submission_timestamp: 0,
+            deadline: None,
         };
         let result = VoteResult {
             approved: true,
@@ -262,6 +263,7 @@ mod tests {
             status_updated_at: 0,
             proof_url: None,
             submission_timestamp: 0,
+            deadline: None,
         };
         let result = VoteResult {
             approved: false,

--- a/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::too_many_arguments)]
 mod access_control;
 mod analytics;
+mod arbitration_pool;
 mod audit;
 mod checklist;
 mod circuit_breaker;
@@ -34,12 +35,15 @@ mod license;
 pub mod merkle;
 mod metrics;
 mod migration;
+mod milestone_extension;
 mod multisig;
 mod oracle;
 mod pagination;
 mod params;
+mod performance_bond;
 mod quadratic;
 mod rate_limit;
+mod referral;
 mod reentrancy;
 mod registry;
 mod reputation;
@@ -77,6 +81,9 @@ pub use types::{
     RoleAssignment, RollingWindow, ScoreResult, ScoringDimension, ScoringRubric, ScoringWeight,
     SignatureStatus, SplitRecipient, StructuredEvidence, SwapResult, SwapRoute, SyndicateGrant,
     SyndicateMember, SyndicateStatus, TokenMetric, TransferProposal, TransferableRole, VoiceCredits, VotingMechanism,
+    // Issue #569/#572/#573/#574: growth, extension, arbitration, and bond modules
+    Arbiter, ArbiterVote, ArbitrationCase, BondClaim, BondStatus, ExtensionRequest,
+    ExtensionStatus, PerformanceBond, ReferralCode, ReferralRecord, ReferralReward,
 };
 
 use metrics::MetricField;
@@ -448,6 +455,9 @@ impl StellarGrantsContract {
         metrics::increment(env, MetricField::GrantsCompleted, 1);
         metrics::update_token_locked(env, &grant.token, -total_paid);
 
+        // Issue #574: return any active performance bond to the guarantor.
+        performance_bond::release_bond(env, grant_id)?;
+
         Events::emit_grant_completed(env, grant_id, total_paid, remaining_balance);
         Ok(())
     }
@@ -622,6 +632,9 @@ impl StellarGrantsContract {
             return Err(ContractError::Unauthorized);
         }
 
+        // Issue #574: a required bond must be posted before any milestone submission.
+        require_bond_posted(&env, grant_id)?;
+
         apply_milestone_submission(
             &env,
             grant_id,
@@ -660,6 +673,9 @@ impl StellarGrantsContract {
         if grant.owner != recipient {
             return Err(ContractError::Unauthorized);
         }
+
+        // Issue #574: a required bond must be posted before any milestone submission.
+        require_bond_posted(&env, grant_id)?;
 
         for sub in submissions.iter() {
             apply_milestone_submission(
@@ -2787,6 +2803,228 @@ impl StellarGrantsContract {
     ) -> Option<StructuredEvidence> {
         evidence_schema::get_evidence(&env, grant_id, milestone_idx)
     }
+
+    // ── Issue #569: Referral and Growth Incentive System ─────────────────────
+
+    /// Create a referral code. Any registered contributor or reviewer.
+    pub fn referral_create_code(
+        env: Env,
+        referrer: Address,
+        expires_at: Option<u64>,
+        max_uses: Option<u32>,
+    ) -> Result<Bytes, ContractError> {
+        referral::create_code(&env, &referrer, expires_at, max_uses)
+    }
+
+    /// Apply a referral code when a new contributor/funder joins.
+    pub fn referral_apply_code(
+        env: Env,
+        referred: Address,
+        code_hash: Bytes,
+    ) -> Result<(), ContractError> {
+        referral::apply_code(&env, &referred, &code_hash)
+    }
+
+    /// Referrer claims accumulated referral rewards for a token.
+    pub fn referral_claim_rewards(
+        env: Env,
+        referrer: Address,
+        token: Address,
+    ) -> Result<i128, ContractError> {
+        referral::claim_rewards(&env, &referrer, &token)
+    }
+
+    /// Return total unclaimed referral rewards for a referrer and token.
+    pub fn referral_pending_rewards(env: Env, referrer: Address, token: Address) -> i128 {
+        referral::pending_rewards(&env, &referrer, &token)
+    }
+
+    /// Return the referral record for a referred address.
+    pub fn referral_get_record(env: Env, referred: Address) -> Option<ReferralRecord> {
+        referral::get_record(&env, &referred)
+    }
+
+    /// Deactivate a referral code. Creator or admin only.
+    pub fn referral_deactivate_code(
+        env: Env,
+        caller: Address,
+        code_hash: Bytes,
+    ) -> Result<(), ContractError> {
+        referral::deactivate_code(&env, &caller, &code_hash)
+    }
+
+    // ── Issue #572: Deadline Extension Request Workflow ──────────────────────
+
+    /// Contributor requests a deadline extension for a milestone.
+    pub fn request_extension(
+        env: Env,
+        contributor: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        new_deadline: u64,
+        reason: String,
+    ) -> Result<(), ContractError> {
+        milestone_extension::request_extension(
+            &env,
+            &contributor,
+            grant_id,
+            milestone_idx,
+            new_deadline,
+            reason,
+        )
+    }
+
+    /// Reviewer votes on a pending extension request.
+    pub fn vote_extension(
+        env: Env,
+        reviewer: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        approve: bool,
+    ) -> Result<ExtensionStatus, ContractError> {
+        milestone_extension::vote_extension(&env, &reviewer, grant_id, milestone_idx, approve)
+    }
+
+    /// Contributor withdraws a pending extension request.
+    pub fn withdraw_extension(
+        env: Env,
+        contributor: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Result<(), ContractError> {
+        milestone_extension::withdraw_request(&env, &contributor, grant_id, milestone_idx)
+    }
+
+    /// Return the current extension request for a milestone.
+    pub fn get_extension_request(
+        env: Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<ExtensionRequest> {
+        milestone_extension::get_request(&env, grant_id, milestone_idx)
+    }
+
+    /// Return all resolved extension requests for a grant.
+    pub fn get_extension_history(env: Env, grant_id: u64) -> Vec<ExtensionRequest> {
+        milestone_extension::get_extension_history(&env, grant_id)
+    }
+
+    // ── Issue #573: Community Arbitration Pool ───────────────────────────────
+
+    /// Join the arbitration pool by staking tokens.
+    pub fn arbiter_join_pool(
+        env: Env,
+        arbiter: Address,
+        token: Address,
+        stake: i128,
+    ) -> Result<(), ContractError> {
+        arbitration_pool::join_pool(&env, &arbiter, &token, stake)
+    }
+
+    /// Leave the arbitration pool and withdraw stake.
+    pub fn arbiter_leave_pool(env: Env, arbiter: Address) -> Result<i128, ContractError> {
+        arbitration_pool::leave_pool(&env, &arbiter)
+    }
+
+    /// Enable community arbitration for an open dispute by assigning a randomized
+    /// panel from the pool. Admin-gated. Returns the arbitration case id.
+    pub fn assign_arbitration_panel(
+        env: Env,
+        admin: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+        dispute_id: u32,
+        panel_size: u32,
+    ) -> Result<u32, ContractError> {
+        admin.require_auth();
+        if Storage::get_global_admin(&env) != Some(admin.clone()) {
+            return Err(ContractError::Unauthorized);
+        }
+        let mut d = Storage::get_dispute(&env, grant_id, milestone_idx)
+            .ok_or(ContractError::InvalidState)?;
+        dispute::assign_pool_panel(&env, &mut d, dispute_id, panel_size)
+    }
+
+    /// Arbiter casts a vote on an arbitration case.
+    pub fn cast_arbiter_vote(
+        env: Env,
+        arbiter: Address,
+        case_id: u32,
+        favor_contributor: bool,
+        confidence: u32,
+    ) -> Result<(), ContractError> {
+        arbitration_pool::cast_arbiter_vote(&env, &arbiter, case_id, favor_contributor, confidence)
+    }
+
+    /// Finalize an arbitration case once voting closes.
+    pub fn finalize_arbitration_case(env: Env, case_id: u32) -> Result<bool, ContractError> {
+        arbitration_pool::finalize_case(&env, case_id)
+    }
+
+    /// Distribute rewards and slash minority arbiters for a finalized case.
+    pub fn settle_arbitration_rewards(env: Env, case_id: u32) -> Result<(), ContractError> {
+        arbitration_pool::settle_rewards(&env, case_id)
+    }
+
+    /// Return pool statistics: (active_arbiters, total_staked).
+    pub fn arbitration_pool_stats(env: Env) -> (u32, i128) {
+        arbitration_pool::pool_stats(&env)
+    }
+
+    /// Return an arbiter's profile.
+    pub fn get_arbiter(env: Env, address: Address) -> Option<Arbiter> {
+        arbitration_pool::get_arbiter(&env, &address)
+    }
+
+    // ── Issue #574: Surety Bonds for High-Value Grant Delivery ───────────────
+
+    /// Grant owner requires a performance bond for their grant.
+    pub fn require_bond(
+        env: Env,
+        owner: Address,
+        grant_id: u64,
+        token: Address,
+        amount: i128,
+        ttl_ledgers: u32,
+    ) -> Result<u32, ContractError> {
+        performance_bond::require_bond(&env, &owner, grant_id, &token, amount, ttl_ledgers)
+    }
+
+    /// Guarantor posts a required bond by depositing the bond amount.
+    pub fn post_bond(env: Env, guarantor: Address, bond_id: u32) -> Result<(), ContractError> {
+        performance_bond::post_bond(&env, &guarantor, bond_id)
+    }
+
+    /// Funder claims a bond payout after contributor default.
+    pub fn claim_bond(
+        env: Env,
+        funder: Address,
+        grant_id: u64,
+        reason: String,
+    ) -> Result<BondClaim, ContractError> {
+        performance_bond::claim_bond(&env, &funder, grant_id, reason)
+    }
+
+    /// Return the performance bond for a grant.
+    pub fn get_bond(env: Env, grant_id: u64) -> Option<PerformanceBond> {
+        performance_bond::get_bond(&env, grant_id)
+    }
+
+    /// Check if a grant has an active (posted) bond.
+    pub fn has_active_bond(env: Env, grant_id: u64) -> bool {
+        performance_bond::has_active_bond(&env, grant_id)
+    }
+}
+
+/// Issue #574: if a grant requires a performance bond, block milestone work until
+/// the guarantor has posted it. No-op for grants without a bond requirement.
+fn require_bond_posted(env: &Env, grant_id: u64) -> Result<(), ContractError> {
+    if let Some(bond) = performance_bond::get_bond(env, grant_id) {
+        if bond.status == BondStatus::Pending {
+            return Err(ContractError::BondNotPosted);
+        }
+    }
+    Ok(())
 }
 
 fn apply_milestone_submission(
@@ -2824,6 +3062,7 @@ fn apply_milestone_submission(
         status_updated_at: 0,
         proof_url: Some(proof_url),
         submission_timestamp: env.ledger().timestamp(),
+        deadline: None,
     };
 
     Storage::set_milestone(env, grant_id, milestone_idx, &milestone);

--- a/stellargrant-contracts/contracts/stellar-grants/src/milestone_extension.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/milestone_extension.rs
@@ -1,0 +1,226 @@
+use soroban_sdk::{contractevent, Address, Env, Map, String, Vec};
+
+use crate::errors::ContractError;
+use crate::storage::Storage;
+use crate::types::{ExtensionRequest, ExtensionStatus};
+
+// ── Events ──────────────────────────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExtensionRequested {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub requested_by: Address,
+    pub new_deadline: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExtensionApproved {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub new_deadline: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExtensionDenied {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExtensionWithdrawn {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Contributor (grant owner) requests a deadline extension for a milestone.
+pub fn request_extension(
+    env: &Env,
+    contributor: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    new_deadline: u64,
+    reason: String,
+) -> Result<(), ContractError> {
+    contributor.require_auth();
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if grant.owner != *contributor {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let milestone = Storage::get_milestone(env, grant_id, milestone_idx)
+        .ok_or(ContractError::MilestoneNotFound)?;
+
+    // Only one pending request per milestone at a time.
+    if let Some(existing) = Storage::get_extension_request(env, grant_id, milestone_idx) {
+        if existing.status == ExtensionStatus::Pending {
+            return Err(ContractError::InvalidState);
+        }
+    }
+
+    let original_deadline = milestone.deadline.unwrap_or(0);
+    let now = env.ledger().timestamp();
+    if new_deadline <= now || new_deadline <= original_deadline {
+        return Err(ContractError::InvalidInput);
+    }
+
+    let request = ExtensionRequest {
+        grant_id,
+        milestone_idx,
+        requested_by: contributor.clone(),
+        original_deadline,
+        new_deadline,
+        reason,
+        status: ExtensionStatus::Pending,
+        votes_approve: 0,
+        votes_deny: 0,
+        reviewer_votes: Map::new(env),
+        requested_at: now,
+        resolved_at: None,
+    };
+    Storage::set_extension_request(env, &request);
+
+    ExtensionRequested {
+        grant_id,
+        milestone_idx,
+        requested_by: contributor.clone(),
+        new_deadline,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Reviewer votes on an extension request. Returns the resulting status.
+pub fn vote_extension(
+    env: &Env,
+    reviewer: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    approve: bool,
+) -> Result<ExtensionStatus, ContractError> {
+    reviewer.require_auth();
+
+    let mut request = Storage::get_extension_request(env, grant_id, milestone_idx)
+        .ok_or(ContractError::ExtensionRequestNotFound)?;
+
+    if request.status != ExtensionStatus::Pending {
+        return Err(ContractError::ExtensionAlreadyResolved);
+    }
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if !grant.reviewers.contains(reviewer.clone()) {
+        return Err(ContractError::Unauthorized);
+    }
+    if request.reviewer_votes.contains_key(reviewer.clone()) {
+        return Err(ContractError::AlreadyVoted);
+    }
+
+    request.reviewer_votes.set(reviewer.clone(), approve);
+    if approve {
+        request.votes_approve = request.votes_approve.saturating_add(1);
+    } else {
+        request.votes_deny = request.votes_deny.saturating_add(1);
+    }
+
+    let total_reviewers = grant.reviewers.len();
+    let majority = total_reviewers / 2 + 1;
+
+    if request.votes_approve >= majority {
+        // Approved: update milestone deadline without touching vote/submission state.
+        request.status = ExtensionStatus::Approved;
+        request.resolved_at = Some(env.ledger().timestamp());
+
+        let mut milestone = Storage::get_milestone(env, grant_id, milestone_idx)
+            .ok_or(ContractError::MilestoneNotFound)?;
+        milestone.deadline = Some(request.new_deadline);
+        Storage::set_milestone(env, grant_id, milestone_idx, &milestone);
+
+        Storage::set_extension_request(env, &request);
+        Storage::push_extension_history(env, &request);
+
+        ExtensionApproved {
+            grant_id,
+            milestone_idx,
+            new_deadline: request.new_deadline,
+        }
+        .publish(env);
+    } else if request.votes_deny >= majority {
+        request.status = ExtensionStatus::Denied;
+        request.resolved_at = Some(env.ledger().timestamp());
+
+        Storage::set_extension_request(env, &request);
+        Storage::push_extension_history(env, &request);
+
+        ExtensionDenied {
+            grant_id,
+            milestone_idx,
+        }
+        .publish(env);
+    } else {
+        Storage::set_extension_request(env, &request);
+    }
+
+    Ok(request.status)
+}
+
+/// Contributor withdraws a pending extension request.
+pub fn withdraw_request(
+    env: &Env,
+    contributor: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+) -> Result<(), ContractError> {
+    contributor.require_auth();
+
+    let mut request = Storage::get_extension_request(env, grant_id, milestone_idx)
+        .ok_or(ContractError::ExtensionRequestNotFound)?;
+
+    if request.status != ExtensionStatus::Pending {
+        return Err(ContractError::ExtensionAlreadyResolved);
+    }
+    if request.requested_by != *contributor {
+        return Err(ContractError::Unauthorized);
+    }
+
+    request.status = ExtensionStatus::Withdrawn;
+    request.resolved_at = Some(env.ledger().timestamp());
+    Storage::push_extension_history(env, &request);
+    Storage::remove_extension_request(env, grant_id, milestone_idx);
+
+    ExtensionWithdrawn {
+        grant_id,
+        milestone_idx,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Return the current extension request for a milestone.
+pub fn get_request(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<ExtensionRequest> {
+    Storage::get_extension_request(env, grant_id, milestone_idx)
+}
+
+/// Check if a milestone is currently past its deadline (considering any approved extension).
+pub fn is_overdue(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
+    match Storage::get_milestone(env, grant_id, milestone_idx) {
+        Some(m) => match m.deadline {
+            Some(d) => env.ledger().timestamp() > d,
+            None => false,
+        },
+        None => false,
+    }
+}
+
+/// Return all resolved extension requests for a grant (including historical).
+pub fn get_extension_history(env: &Env, grant_id: u64) -> Vec<ExtensionRequest> {
+    Storage::get_extension_history(env, grant_id)
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/performance_bond.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/performance_bond.rs
@@ -1,0 +1,220 @@
+use soroban_sdk::{contractevent, token, Address, Env, String};
+
+use crate::errors::ContractError;
+use crate::storage::Storage;
+use crate::types::{BondClaim, BondStatus, GrantStatus, PerformanceBond};
+
+// ── Events ──────────────────────────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BondRequired {
+    pub bond_id: u32,
+    pub grant_id: u64,
+    pub bond_amount: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BondPosted {
+    pub bond_id: u32,
+    pub grant_id: u64,
+    pub guarantor: Address,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BondReleased {
+    pub bond_id: u32,
+    pub grant_id: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BondClaimed {
+    pub bond_id: u32,
+    pub grant_id: u64,
+    pub payout_amount: i128,
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Grant owner requires a bond for their grant. Sets the bond requirement.
+pub fn require_bond(
+    env: &Env,
+    owner: &Address,
+    grant_id: u64,
+    token: &Address,
+    amount: i128,
+    ttl_ledgers: u32,
+) -> Result<u32, ContractError> {
+    owner.require_auth();
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if grant.owner != *owner {
+        return Err(ContractError::Unauthorized);
+    }
+    if amount <= 0 {
+        return Err(ContractError::InvalidInput);
+    }
+    if Storage::get_performance_bond(env, grant_id).is_some() {
+        return Err(ContractError::AlreadyRegistered);
+    }
+
+    let bond_id = Storage::next_bond_id(env);
+    let now = env.ledger().timestamp();
+    let bond = PerformanceBond {
+        id: bond_id,
+        grant_id,
+        principal: grant.owner.clone(),
+        // Guarantor is finalised when the bond is posted; defaults to the principal.
+        guarantor: grant.owner.clone(),
+        bond_amount: amount,
+        token: token.clone(),
+        status: BondStatus::Pending,
+        posted_at: None,
+        expires_at: now + ttl_ledgers as u64,
+    };
+    Storage::set_performance_bond(env, &bond);
+    Storage::set_bond_grant(env, bond_id, grant_id);
+
+    BondRequired {
+        bond_id,
+        grant_id,
+        bond_amount: amount,
+    }
+    .publish(env);
+
+    Ok(bond_id)
+}
+
+/// Guarantor posts the bond by depositing the bond amount.
+pub fn post_bond(env: &Env, guarantor: &Address, bond_id: u32) -> Result<(), ContractError> {
+    guarantor.require_auth();
+
+    let grant_id = Storage::get_bond_grant(env, bond_id).ok_or(ContractError::BondNotFound)?;
+    let mut bond =
+        Storage::get_performance_bond(env, grant_id).ok_or(ContractError::BondNotFound)?;
+
+    if bond.status != BondStatus::Pending {
+        return Err(ContractError::BondAlreadyPosted);
+    }
+    if env.ledger().timestamp() > bond.expires_at {
+        return Err(ContractError::BondExpired);
+    }
+
+    token::Client::new(env, &bond.token).transfer(
+        guarantor,
+        &env.current_contract_address(),
+        &bond.bond_amount,
+    );
+
+    bond.guarantor = guarantor.clone();
+    bond.status = BondStatus::Active;
+    bond.posted_at = Some(env.ledger().timestamp());
+    Storage::set_performance_bond(env, &bond);
+
+    BondPosted {
+        bond_id,
+        grant_id,
+        guarantor: guarantor.clone(),
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Release bond back to the guarantor after successful grant completion.
+pub fn release_bond(env: &Env, grant_id: u64) -> Result<(), ContractError> {
+    let mut bond = match Storage::get_performance_bond(env, grant_id) {
+        Some(b) => b,
+        None => return Ok(()), // no bond on this grant — nothing to release
+    };
+
+    if bond.status != BondStatus::Active {
+        return Err(ContractError::BondNotActive);
+    }
+
+    token::Client::new(env, &bond.token).transfer(
+        &env.current_contract_address(),
+        &bond.guarantor,
+        &bond.bond_amount,
+    );
+
+    bond.status = BondStatus::Released;
+    Storage::set_performance_bond(env, &bond);
+
+    BondReleased {
+        bond_id: bond.id,
+        grant_id,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Funder claims the bond payout after a contributor default.
+pub fn claim_bond(
+    env: &Env,
+    funder: &Address,
+    grant_id: u64,
+    reason: String,
+) -> Result<BondClaim, ContractError> {
+    funder.require_auth();
+
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    let is_funder = grant.funders.iter().any(|f| f.funder == *funder);
+    if !is_funder {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let mut bond =
+        Storage::get_performance_bond(env, grant_id).ok_or(ContractError::BondNotFound)?;
+    if bond.status != BondStatus::Active {
+        return Err(ContractError::BondNotActive);
+    }
+
+    // Claimable only when the grant was cancelled/abandoned or the bond expired.
+    let expired = env.ledger().timestamp() > bond.expires_at;
+    let cancelled = grant.status == GrantStatus::Cancelled;
+    if !expired && !cancelled {
+        return Err(ContractError::InvalidState);
+    }
+
+    let payout = bond.bond_amount;
+    token::Client::new(env, &bond.token).transfer(&env.current_contract_address(), funder, &payout);
+
+    bond.status = BondStatus::Claimed;
+    Storage::set_performance_bond(env, &bond);
+
+    let claim = BondClaim {
+        bond_id: bond.id,
+        claimed_by: funder.clone(),
+        claim_reason: reason,
+        payout_amount: payout,
+        claimed_at: env.ledger().timestamp(),
+    };
+    Storage::set_bond_claim(env, &claim);
+
+    BondClaimed {
+        bond_id: bond.id,
+        grant_id,
+        payout_amount: payout,
+    }
+    .publish(env);
+
+    Ok(claim)
+}
+
+/// Return the bond for a grant.
+pub fn get_bond(env: &Env, grant_id: u64) -> Option<PerformanceBond> {
+    Storage::get_performance_bond(env, grant_id)
+}
+
+/// Check if a grant has an active (posted) bond.
+pub fn has_active_bond(env: &Env, grant_id: u64) -> bool {
+    matches!(
+        Storage::get_performance_bond(env, grant_id),
+        Some(b) if b.status == BondStatus::Active
+    )
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/referral.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/referral.rs
@@ -1,0 +1,287 @@
+use soroban_sdk::{contractevent, token, Address, Bytes, Env};
+
+use crate::config;
+use crate::constants::BASIS_POINTS_SCALE;
+use crate::errors::ContractError;
+use crate::storage::Storage;
+use crate::types::{ReferralCode, ReferralRecord};
+
+// ── Events ──────────────────────────────────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralCodeCreated {
+    pub referrer: Address,
+    pub code_hash: Bytes,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralApplied {
+    pub referred: Address,
+    pub referrer: Address,
+    pub code_hash: Bytes,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralRewardEarned {
+    pub referrer: Address,
+    pub referred: Address,
+    pub token: Address,
+    pub amount: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralRewardsClaimed {
+    pub referrer: Address,
+    pub token: Address,
+    pub amount: i128,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralCodeDeactivated {
+    pub referrer: Address,
+    pub code_hash: Bytes,
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn is_registered(env: &Env, addr: &Address) -> bool {
+    Storage::get_contributor(env, addr.clone()).is_some()
+        || Storage::get_reviewer_profile(env, addr).is_some()
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Create a referral code. Any registered contributor or reviewer.
+/// Returns the SHA-256 code hash that the referrer shares with new joiners.
+pub fn create_code(
+    env: &Env,
+    referrer: &Address,
+    expires_at: Option<u64>,
+    max_uses: Option<u32>,
+) -> Result<Bytes, ContractError> {
+    referrer.require_auth();
+
+    if !is_registered(env, referrer) {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let now = env.ledger().timestamp();
+    if let Some(exp) = expires_at {
+        if exp <= now {
+            return Err(ContractError::InvalidInput);
+        }
+    }
+    if let Some(mu) = max_uses {
+        if mu == 0 {
+            return Err(ContractError::InvalidInput);
+        }
+    }
+
+    // Derive a unique, unguessable code hash from PRNG salt + ledger context.
+    let salt: u64 = env.prng().gen();
+    let mut plain = Bytes::new(env);
+    plain.extend_from_array(&salt.to_be_bytes());
+    plain.extend_from_array(&now.to_be_bytes());
+    plain.extend_from_array(&(env.ledger().sequence() as u64).to_be_bytes());
+    let code_hash: Bytes = env.crypto().sha256(&plain).into();
+
+    let code = ReferralCode {
+        code_hash: code_hash.clone(),
+        referrer: referrer.clone(),
+        created_at: now,
+        expires_at,
+        max_uses,
+        uses: 0,
+        is_active: true,
+    };
+    Storage::set_referral_code(env, &code);
+
+    ReferralCodeCreated {
+        referrer: referrer.clone(),
+        code_hash: code_hash.clone(),
+    }
+    .publish(env);
+
+    Ok(code_hash)
+}
+
+/// Apply a referral code on registration. Called once per referred address.
+pub fn apply_code(env: &Env, referred: &Address, code_hash: &Bytes) -> Result<(), ContractError> {
+    referred.require_auth();
+
+    let mut code =
+        Storage::get_referral_code(env, code_hash).ok_or(ContractError::ReferralCodeNotFound)?;
+
+    if !code.is_active {
+        return Err(ContractError::ReferralCodeInactive);
+    }
+
+    let now = env.ledger().timestamp();
+    if let Some(exp) = code.expires_at {
+        if now > exp {
+            return Err(ContractError::ReferralCodeExpired);
+        }
+    }
+    if let Some(mu) = code.max_uses {
+        if code.uses >= mu {
+            return Err(ContractError::ReferralCodeExhausted);
+        }
+    }
+
+    // Self-referral and double-referral are rejected.
+    if code.referrer == *referred {
+        return Err(ContractError::InvalidInput);
+    }
+    if Storage::get_referral_record(env, referred).is_some() {
+        return Err(ContractError::AlreadyReferred);
+    }
+
+    code.uses = code.uses.saturating_add(1);
+    Storage::set_referral_code(env, &code);
+
+    let record = ReferralRecord {
+        referred: referred.clone(),
+        referrer: code.referrer.clone(),
+        code_hash: code_hash.clone(),
+        referred_at: now,
+        first_action_at: None,
+        reward_paid: false,
+    };
+    Storage::set_referral_record(env, &record);
+
+    ReferralApplied {
+        referred: referred.clone(),
+        referrer: code.referrer.clone(),
+        code_hash: code_hash.clone(),
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Trigger reward after referred address completes its first qualifying action.
+/// No-op (Ok) if there is no referral record or the reward was already paid.
+pub fn trigger_reward(
+    env: &Env,
+    referred: &Address,
+    token: &Address,
+    fee_amount: i128,
+) -> Result<(), ContractError> {
+    let mut record = match Storage::get_referral_record(env, referred) {
+        Some(r) => r,
+        None => return Ok(()),
+    };
+
+    if record.reward_paid {
+        return Ok(());
+    }
+
+    let referral_bps = config::get_config(env).referral_fee_bps;
+    let reward = if fee_amount > 0 && referral_bps > 0 {
+        fee_amount
+            .checked_mul(referral_bps as i128)
+            .ok_or(ContractError::InvalidInput)?
+            .checked_div(BASIS_POINTS_SCALE as i128)
+            .ok_or(ContractError::InvalidInput)?
+    } else {
+        0
+    };
+
+    let now = env.ledger().timestamp();
+    record.first_action_at = Some(now);
+    record.reward_paid = true;
+    Storage::set_referral_record(env, &record);
+
+    if reward > 0 {
+        let pending = Storage::get_referral_rewards(env, &record.referrer, token);
+        Storage::set_referral_rewards(
+            env,
+            &record.referrer,
+            token,
+            pending
+                .checked_add(reward)
+                .ok_or(ContractError::InvalidInput)?,
+        );
+
+        ReferralRewardEarned {
+            referrer: record.referrer.clone(),
+            referred: referred.clone(),
+            token: token.clone(),
+            amount: reward,
+        }
+        .publish(env);
+    }
+
+    Ok(())
+}
+
+/// Referrer claims accumulated rewards for a token.
+pub fn claim_rewards(
+    env: &Env,
+    referrer: &Address,
+    token: &Address,
+) -> Result<i128, ContractError> {
+    referrer.require_auth();
+
+    let pending = Storage::get_referral_rewards(env, referrer, token);
+    if pending <= 0 {
+        return Err(ContractError::NoRewardsToClaim);
+    }
+
+    Storage::set_referral_rewards(env, referrer, token, 0);
+
+    token::Client::new(env, token).transfer(&env.current_contract_address(), referrer, &pending);
+
+    ReferralRewardsClaimed {
+        referrer: referrer.clone(),
+        token: token.clone(),
+        amount: pending,
+    }
+    .publish(env);
+
+    Ok(pending)
+}
+
+/// Return total unclaimed rewards for a referrer and token.
+pub fn pending_rewards(env: &Env, referrer: &Address, token: &Address) -> i128 {
+    Storage::get_referral_rewards(env, referrer, token)
+}
+
+/// Return the referral record for a referred address.
+pub fn get_record(env: &Env, referred: &Address) -> Option<ReferralRecord> {
+    Storage::get_referral_record(env, referred)
+}
+
+/// Deactivate a referral code. Creator or admin only.
+pub fn deactivate_code(
+    env: &Env,
+    caller: &Address,
+    code_hash: &Bytes,
+) -> Result<(), ContractError> {
+    caller.require_auth();
+
+    let mut code =
+        Storage::get_referral_code(env, code_hash).ok_or(ContractError::ReferralCodeNotFound)?;
+
+    let is_creator = code.referrer == *caller;
+    let is_admin = Storage::get_global_admin(env) == Some(caller.clone());
+    if !is_creator && !is_admin {
+        return Err(ContractError::Unauthorized);
+    }
+
+    code.is_active = false;
+    Storage::set_referral_code(env, &code);
+
+    ReferralCodeDeactivated {
+        referrer: code.referrer.clone(),
+        code_hash: code_hash.clone(),
+    }
+    .publish(env);
+
+    Ok(())
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage.rs
@@ -9,7 +9,11 @@ use crate::types::{
     ReviewerProfile, ReviewerRequest, Role, RoleAssignment, RollingWindow, ScoringRubric, StructuredEvidence, SyndicateGrant,
     SyndicateMember, TokenMetric, TransferProposal, VoiceCredits, VotingMechanism,
 };
-use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+use crate::types::{
+    Arbiter, ArbiterVote, ArbitrationCase, BondClaim, ExtensionRequest, PerformanceBond,
+    ReferralCode, ReferralRecord,
+};
+use soroban_sdk::{contracttype, Address, Bytes, Env, Symbol, Vec};
 
 #[contracttype]
 pub enum DataKey {
@@ -152,6 +156,28 @@ pub enum DataKey {
     NftTokenIndex(u32),
     // Issue #565: contributor portfolio grant index
     ContributorGrantIds(Address),
+    // Issue #569: referral system
+    ReferralCode(Bytes),
+    ReferralRecord(Address),
+    ReferralRewards(Address, Address), // (referrer, token) -> pending amount
+    // Issue #572: deadline extension requests
+    ExtensionRequest(u64, u32),
+    ExtensionHistory(u64),
+    // Issue #573: community arbitration pool
+    ArbiterPool,
+    ArbiterPoolToken,
+    Arbiter(Address),
+    ArbiterActiveCases(Address),
+    ArbitrationCase(u32),
+    ArbitrationCaseByDispute(u32),
+    ArbitrationCaseCounter,
+    ArbitrationSettled(u32),
+    ArbiterVote(u32, Address),
+    // Issue #574: performance bonds
+    PerformanceBond(u64),
+    BondGrant(u32),
+    BondClaim(u32),
+    BondCounter,
 }
 
 const PERSISTENT_TTL_THRESHOLD: u32 = 100_000;
@@ -1574,5 +1600,241 @@ impl Storage {
             env.storage().persistent().set(&key, &ids);
             Self::bump_persistent_ttl(env, &key);
         }
+    }
+
+    // ── Issue #569: Referral System ──────────────────────────────────────────
+
+    pub fn get_referral_code(env: &Env, code_hash: &Bytes) -> Option<ReferralCode> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReferralCode(code_hash.clone()))
+    }
+
+    pub fn set_referral_code(env: &Env, code: &ReferralCode) {
+        let key = DataKey::ReferralCode(code.code_hash.clone());
+        env.storage().persistent().set(&key, code);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_referral_record(env: &Env, referred: &Address) -> Option<ReferralRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReferralRecord(referred.clone()))
+    }
+
+    pub fn set_referral_record(env: &Env, record: &ReferralRecord) {
+        let key = DataKey::ReferralRecord(record.referred.clone());
+        env.storage().persistent().set(&key, record);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_referral_rewards(env: &Env, referrer: &Address, token: &Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReferralRewards(referrer.clone(), token.clone()))
+            .unwrap_or(0)
+    }
+
+    pub fn set_referral_rewards(env: &Env, referrer: &Address, token: &Address, amount: i128) {
+        let key = DataKey::ReferralRewards(referrer.clone(), token.clone());
+        env.storage().persistent().set(&key, &amount);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #572: Deadline Extension Requests ──────────────────────────────
+
+    pub fn get_extension_request(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<ExtensionRequest> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ExtensionRequest(grant_id, milestone_idx))
+    }
+
+    pub fn set_extension_request(env: &Env, req: &ExtensionRequest) {
+        let key = DataKey::ExtensionRequest(req.grant_id, req.milestone_idx);
+        env.storage().persistent().set(&key, req);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn remove_extension_request(env: &Env, grant_id: u64, milestone_idx: u32) {
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ExtensionRequest(grant_id, milestone_idx));
+    }
+
+    pub fn get_extension_history(env: &Env, grant_id: u64) -> Vec<ExtensionRequest> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ExtensionHistory(grant_id))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn push_extension_history(env: &Env, req: &ExtensionRequest) {
+        let key = DataKey::ExtensionHistory(req.grant_id);
+        let mut history = Self::get_extension_history(env, req.grant_id);
+        history.push_back(req.clone());
+        env.storage().persistent().set(&key, &history);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #573: Community Arbitration Pool ───────────────────────────────
+
+    pub fn get_arbiter_pool(env: &Env) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ArbiterPool)
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn set_arbiter_pool(env: &Env, pool: &Vec<Address>) {
+        env.storage().persistent().set(&DataKey::ArbiterPool, pool);
+        Self::bump_persistent_ttl(env, &DataKey::ArbiterPool);
+    }
+
+    pub fn get_arbiter(env: &Env, address: &Address) -> Option<Arbiter> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Arbiter(address.clone()))
+    }
+
+    pub fn set_arbiter(env: &Env, arbiter: &Arbiter) {
+        let key = DataKey::Arbiter(arbiter.address.clone());
+        env.storage().persistent().set(&key, arbiter);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_arbiter_pool_token(env: &Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::ArbiterPoolToken)
+    }
+
+    pub fn set_arbiter_pool_token(env: &Env, token: &Address) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ArbiterPoolToken, token);
+    }
+
+    pub fn get_arbiter_active_cases(env: &Env, arbiter: &Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ArbiterActiveCases(arbiter.clone()))
+            .unwrap_or(0)
+    }
+
+    pub fn set_arbiter_active_cases(env: &Env, arbiter: &Address, count: u32) {
+        let key = DataKey::ArbiterActiveCases(arbiter.clone());
+        env.storage().persistent().set(&key, &count);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn next_arbitration_case_id(env: &Env) -> u32 {
+        let mut id: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ArbitrationCaseCounter)
+            .unwrap_or(0);
+        id += 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::ArbitrationCaseCounter, &id);
+        id
+    }
+
+    pub fn get_arbitration_case(env: &Env, case_id: u32) -> Option<ArbitrationCase> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ArbitrationCase(case_id))
+    }
+
+    pub fn set_arbitration_case(env: &Env, case: &ArbitrationCase) {
+        let key = DataKey::ArbitrationCase(case.id);
+        env.storage().persistent().set(&key, case);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_case_id_by_dispute(env: &Env, dispute_id: u32) -> Option<u32> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ArbitrationCaseByDispute(dispute_id))
+    }
+
+    pub fn set_case_id_by_dispute(env: &Env, dispute_id: u32, case_id: u32) {
+        let key = DataKey::ArbitrationCaseByDispute(dispute_id);
+        env.storage().persistent().set(&key, &case_id);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn is_arbitration_settled(env: &Env, case_id: u32) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ArbitrationSettled(case_id))
+            .unwrap_or(false)
+    }
+
+    pub fn set_arbitration_settled(env: &Env, case_id: u32) {
+        env.storage()
+            .persistent()
+            .set(&DataKey::ArbitrationSettled(case_id), &true);
+    }
+
+    pub fn get_arbiter_vote(env: &Env, case_id: u32, arbiter: &Address) -> Option<ArbiterVote> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ArbiterVote(case_id, arbiter.clone()))
+    }
+
+    pub fn set_arbiter_vote(env: &Env, case_id: u32, vote: &ArbiterVote) {
+        let key = DataKey::ArbiterVote(case_id, vote.arbiter.clone());
+        env.storage().persistent().set(&key, vote);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    // ── Issue #574: Performance Bonds ────────────────────────────────────────
+
+    pub fn get_performance_bond(env: &Env, grant_id: u64) -> Option<PerformanceBond> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::PerformanceBond(grant_id))
+    }
+
+    pub fn set_performance_bond(env: &Env, bond: &PerformanceBond) {
+        let key = DataKey::PerformanceBond(bond.grant_id);
+        env.storage().persistent().set(&key, bond);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn next_bond_id(env: &Env) -> u32 {
+        let mut id: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BondCounter)
+            .unwrap_or(0);
+        id += 1;
+        env.storage().persistent().set(&DataKey::BondCounter, &id);
+        id
+    }
+
+    pub fn get_bond_grant(env: &Env, bond_id: u32) -> Option<u64> {
+        env.storage().persistent().get(&DataKey::BondGrant(bond_id))
+    }
+
+    pub fn set_bond_grant(env: &Env, bond_id: u32, grant_id: u64) {
+        let key = DataKey::BondGrant(bond_id);
+        env.storage().persistent().set(&key, &grant_id);
+        Self::bump_persistent_ttl(env, &key);
+    }
+
+    pub fn get_bond_claim(env: &Env, bond_id: u32) -> Option<BondClaim> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::BondClaim(bond_id))
+    }
+
+    pub fn set_bond_claim(env: &Env, claim: &BondClaim) {
+        let key = DataKey::BondClaim(claim.bond_id);
+        env.storage().persistent().set(&key, claim);
+        Self::bump_persistent_ttl(env, &key);
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/test.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/test.rs
@@ -74,6 +74,7 @@ mod tests {
                 status_updated_at: 0,
                 proof_url: Some(String::from_str(env, "https://proof.url")),
                 submission_timestamp: env.ledger().timestamp(),
+                deadline: None,
             };
             Storage::set_milestone(env, grant_id, milestone_idx, &milestone);
         });

--- a/stellargrant-contracts/contracts/stellar-grants/src/types.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/types.rs
@@ -65,6 +65,8 @@ pub struct Milestone {
     pub status_updated_at: u64,
     pub proof_url: Option<String>,
     pub submission_timestamp: u64,
+    /// Optional milestone deadline (ledger timestamp). Updated by approved extensions (#572).
+    pub deadline: Option<u64>,
 }
 
 #[contracttype]
@@ -389,6 +391,8 @@ pub struct ProtocolConfig {
     pub multisig_threshold: i128,
     /// Multiplier applied to all default per-action rate limits (1 = use defaults).
     pub rate_limit_multiplier: u32,
+    /// Share of the protocol fee paid to referrers, in basis points (#569). Default 1000 = 10%.
+    pub referral_fee_bps: u32,
 }
 
 // ── Issue #517: Protocol Fee Collection ──────────────────────────────────────
@@ -1478,4 +1482,140 @@ pub struct CrowdfundPledge {
     pub amount: i128,
     pub pledged_at: u64,
     pub refunded: bool,
+}
+
+// ── Issue #569: Referral and Growth Incentive System ─────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralCode {
+    pub code_hash: Bytes, // SHA-256 of the plaintext code
+    pub referrer: Address,
+    pub created_at: u64,
+    pub expires_at: Option<u64>,
+    pub max_uses: Option<u32>,
+    pub uses: u32,
+    pub is_active: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralRecord {
+    pub referred: Address,
+    pub referrer: Address,
+    pub code_hash: Bytes,
+    pub referred_at: u64,
+    pub first_action_at: Option<u64>,
+    pub reward_paid: bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReferralReward {
+    pub referrer: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub earned_at: u64,
+    pub for_action: String,
+}
+
+// ── Issue #572: Deadline Extension Request Workflow ──────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ExtensionStatus {
+    Pending = 0,
+    Approved = 1,
+    Denied = 2,
+    Withdrawn = 3,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExtensionRequest {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub requested_by: Address,
+    pub original_deadline: u64,
+    pub new_deadline: u64,
+    pub reason: String,
+    pub status: ExtensionStatus,
+    pub votes_approve: u32,
+    pub votes_deny: u32,
+    pub reviewer_votes: Map<Address, bool>,
+    pub requested_at: u64,
+    pub resolved_at: Option<u64>,
+}
+
+// ── Issue #573: Community Arbitration Pool ───────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Arbiter {
+    pub address: Address,
+    pub stake: i128,
+    pub cases_decided: u32,
+    pub cases_correct: u32,
+    pub is_active: bool,
+    pub joined_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArbiterVote {
+    pub arbiter: Address,
+    pub favor_contributor: bool,
+    pub confidence: u32, // 1-100, affects reward weight
+    pub voted_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ArbitrationCase {
+    pub id: u32,
+    pub dispute_id: u32,
+    pub panel: Vec<Address>, // 3 or 5 randomly selected arbiters
+    pub votes: Vec<ArbiterVote>,
+    pub outcome: Option<bool>, // true = contributor wins, false = funder wins
+    pub finalized: bool,
+    pub assigned_at: u64,
+    pub deadline: u64,
+}
+
+// ── Issue #574: Surety Bonds for High-Value Grant Delivery ───────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[repr(u32)]
+pub enum BondStatus {
+    Pending = 0,  // awaiting guarantor deposit
+    Active = 1,   // bond posted, grant in progress
+    Released = 2, // returned to guarantor on completion
+    Claimed = 3,  // paid out to funder after default
+    Expired = 4,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PerformanceBond {
+    pub id: u32,
+    pub grant_id: u64,
+    pub principal: Address, // contributor
+    pub guarantor: Address, // bond backer
+    pub bond_amount: i128,
+    pub token: Address,
+    pub status: BondStatus,
+    pub posted_at: Option<u64>,
+    pub expires_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BondClaim {
+    pub bond_id: u32,
+    pub claimed_by: Address,
+    pub claim_reason: String,
+    pub payout_amount: i128,
+    pub claimed_at: u64,
 }


### PR DESCRIPTION
# feat(contracts): protocol growth, extension, arbitration, and bond modules

## What does this PR do?

Adds four self-funded, on-chain growth-and-resilience modules to the
`stellar-grants` Soroban contract, each closing a tracked issue. New modules:
`referral.rs`, `milestone_extension.rs`, `arbitration_pool.rs`, and
`performance_bond.rs`, plus the supporting types, storage keys, errors, config
field, and contract entry points to wire them in.

## Related Issues

Closes #569 
Closes #572 
Closes #573 
Closes #574 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Breaking change

> Note: `Milestone` gains a new `deadline: Option<u64>` field and `ProtocolConfig`
> gains a `referral_fee_bps` field. These are additive struct changes used by the
> new modules; all existing constructors were updated.

## Summary of Changes

### #569 — Protocol Referral and Growth Incentive System (`referral.rs`)
- Registered contributors/reviewers mint a SHA-256 referral code
  (`create_code`), optionally with an expiry and/or a max-uses cap.
- New joiners apply a code once (`apply_code`); self-referral and double-referral
  are rejected, and expired / exhausted codes are rejected.
- When a referred grant owner first incurs a protocol fee,
  `fees::deduct_and_transfer` calls `trigger_reward`, accruing
  `referral_fee_bps` (default 1000 = 10%) of the fee to the referrer's claimable
  balance.
- `claim_rewards`, `pending_rewards`, `get_record`, and `deactivate_code`
  complete the 7-function API.

### #572 — Deadline Extension Request Workflow (`milestone_extension.rs`)
- Grant owner requests an extension with a reason + new deadline
  (`request_extension`); only one pending request per milestone (second returns
  `InvalidState`).
- Reviewers vote (`vote_extension`); a majority approval updates
  `Milestone.deadline` in place without resetting votes or submission state, and
  a majority deny resolves the request as `Denied`.
- `withdraw_request`, `get_request`, `is_overdue`, and `get_extension_history`
  complete the API. Emits `extension_requested` / `extension_approved` /
  `extension_denied`.

### #573 — Community Arbitration Pool (`arbitration_pool.rs`)
- Arbiters stake into a shared pool (`join_pool`); a randomized panel of 3 or 5
  is drawn per dispute via `env.prng().shuffle` (`assign_panel`).
- Arbiters vote with a confidence weight (`cast_arbiter_vote`); `finalize_case`
  settles the majority outcome; `settle_rewards` slashes minority stake and
  redistributes it to the (confidence-weighted) majority.
- Active-case lock prevents an assigned arbiter from leaving the pool.
- `dispute::assign_pool_panel` routes an open dispute into
  `arbitration_pool::assign_panel` when pool arbitration is enabled.

### #574 — Surety Bonds for High-Value Grant Delivery (`performance_bond.rs`)
- A grant owner requires a bond (`require_bond`); a third-party guarantor posts
  it (`post_bond`). `milestone_submit` / `milestone_submit_batch` are blocked
  until a required bond is posted.
- Successful completion auto-releases the bond to the guarantor
  (`release_bond`, called from `grant_complete`); on contributor default
  (grant cancelled/abandoned or bond expired) a funder claims the payout
  (`claim_bond`).
- `get_bond` and `has_active_bond` complete the API.

## Testing Done

- [ ] Unit tests added or updated
- [x] `cargo build` confirmed to introduce **no new** compiler errors relative to
      the base branch (the base branch currently has pre-existing, unrelated
      compilation errors that were intentionally left untouched).

> Per the issue notes, dedicated unit tests were omitted to limit scope. The new
> modules follow the existing module/storage/event conventions in the crate.

## Checklist

- [x] New modules follow existing contract conventions (storage accessors,
      `#[contractevent]` events, `checked_*` arithmetic).
- [x] No secrets or environment values committed.
- [x] Conventional Commit message format used.
- [ ] `cargo test` — not run (base branch does not currently compile; unrelated
      pre-existing errors).
