### PR TITLE
stellar grant implementation

### DIFF
--- a/stellargrant-contracts/contracts/stellar-grants/src/grant_index.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/grant_index.rs
@@ -1,66 +1,66 @@
 use soroban_sdk::{Address, Env, Vec};
 
-use crate::errors::ContractError;
-use crate::storage::Storage;
+use crate::storage::{DataKey, GrantKey};
 use crate::types::GrantStatus;
 
 const INDEX_BUCKET_LIMIT: u32 = 10_000;
 
-fn push_to_index(env: &Env, key: &crate::storage::DataKey, grant_id: u64) {
+fn push_to_index(env: &Env, key: &DataKey, grant_id: u64) {
     let mut list: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&key)
+        .get(key)
         .unwrap_or_else(|| Vec::new(env));
     if list.len() < INDEX_BUCKET_LIMIT && !list.contains(grant_id) {
         list.push_back(grant_id);
-        env.storage().persistent().set(&key, &list);
+        env.storage().persistent().set(key, &list);
     }
 }
 
-fn remove_from_index(env: &Env, key: &crate::storage::DataKey, grant_id: u64) {
+fn remove_from_index(env: &Env, key: &DataKey, grant_id: u64) {
     let mut list: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&key)
+        .get(key)
         .unwrap_or_else(|| Vec::new(env));
     if let Some(pos) = (0..list.len()).find(|&i| list.get(i) == Some(grant_id)) {
         list.remove(pos);
-        env.storage().persistent().set(&key, &list);
+        env.storage().persistent().set(key, &list);
     }
 }
 
 pub fn on_grant_created(env: &Env, grant_id: u64, owner: &Address, token: &Address, status: GrantStatus) {
-    push_to_index(env, &crate::storage::DataKey::IndexByOwner(owner.clone()), grant_id);
-    push_to_index(env, &crate::storage::DataKey::IndexByStatus(status as u32), grant_id);
-    push_to_index(env, &crate::storage::DataKey::IndexByToken(token.clone()), grant_id);
+    push_to_index(env, &DataKey::Grant(GrantKey::OwnerIndex(owner.clone())), grant_id);
+    push_to_index(env, &DataKey::Grant(GrantKey::StatusIndex(status as u32)), grant_id);
+    push_to_index(env, &DataKey::Grant(GrantKey::TokenIndex(token.clone())), grant_id);
+    let order_key = DataKey::Grant(GrantKey::GlobalOrder);
     let mut order: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&crate::storage::DataKey::GlobalGrantOrder)
+        .get(&order_key)
         .unwrap_or_else(|| Vec::new(env));
     if order.len() < INDEX_BUCKET_LIMIT {
         order.push_back(grant_id);
-        env.storage().persistent().set(&crate::storage::DataKey::GlobalGrantOrder, &order);
+        env.storage().persistent().set(&order_key, &order);
     }
 }
 
 pub fn on_status_changed(env: &Env, grant_id: u64, old_status: GrantStatus, new_status: GrantStatus) {
     if old_status != new_status {
-        remove_from_index(env, &crate::storage::DataKey::IndexByStatus(old_status as u32), grant_id);
-        push_to_index(env, &crate::storage::DataKey::IndexByStatus(new_status as u32), grant_id);
+        remove_from_index(env, &DataKey::Grant(GrantKey::StatusIndex(old_status as u32)), grant_id);
+        push_to_index(env, &DataKey::Grant(GrantKey::StatusIndex(new_status as u32)), grant_id);
     }
 }
 
 pub fn on_contributor_assigned(env: &Env, grant_id: u64, contributor: &Address) {
-    push_to_index(env, &crate::storage::DataKey::IndexByContributor(contributor.clone()), grant_id);
+    push_to_index(env, &DataKey::Grant(GrantKey::ContribIndex(contributor.clone())), grant_id);
 }
 
 pub fn by_owner(env: &Env, owner: &Address, offset: u32, limit: u32) -> Vec<u64> {
     let list: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&crate::storage::DataKey::IndexByOwner(owner.clone()))
+        .get(&DataKey::Grant(GrantKey::OwnerIndex(owner.clone())))
         .unwrap_or_else(|| Vec::new(env));
     crate::pagination::paginate(env, &list, offset, limit)
 }
@@ -69,7 +69,7 @@ pub fn by_status(env: &Env, status: GrantStatus, offset: u32, limit: u32) -> Vec
     let list: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&crate::storage::DataKey::IndexByStatus(status as u32))
+        .get(&DataKey::Grant(GrantKey::StatusIndex(status as u32)))
         .unwrap_or_else(|| Vec::new(env));
     crate::pagination::paginate(env, &list, offset, limit)
 }
@@ -78,7 +78,7 @@ pub fn by_token(env: &Env, token: &Address, offset: u32, limit: u32) -> Vec<u64>
     let list: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&crate::storage::DataKey::IndexByToken(token.clone()))
+        .get(&DataKey::Grant(GrantKey::TokenIndex(token.clone())))
         .unwrap_or_else(|| Vec::new(env));
     crate::pagination::paginate(env, &list, offset, limit)
 }
@@ -87,7 +87,7 @@ pub fn by_contributor(env: &Env, contributor: &Address, offset: u32, limit: u32)
     let list: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&crate::storage::DataKey::IndexByContributor(contributor.clone()))
+        .get(&DataKey::Grant(GrantKey::ContribIndex(contributor.clone())))
         .unwrap_or_else(|| Vec::new(env));
     crate::pagination::paginate(env, &list, offset, limit)
 }
@@ -96,7 +96,7 @@ pub fn recent(env: &Env, offset: u32, limit: u32) -> Vec<u64> {
     let list: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&crate::storage::DataKey::GlobalGrantOrder)
+        .get(&DataKey::Grant(GrantKey::GlobalOrder))
         .unwrap_or_else(|| Vec::new(env));
     crate::pagination::paginate(env, &list, offset, limit)
 }
@@ -106,7 +106,7 @@ pub fn index_counts(env: &Env, owner: Option<&Address>) -> (u32, u32, u32) {
         let list: Vec<u64> = env
             .storage()
             .persistent()
-            .get(&crate::storage::DataKey::IndexByOwner(o.clone()))
+            .get(&DataKey::Grant(GrantKey::OwnerIndex(o.clone())))
             .unwrap_or_else(|| Vec::new(env));
         list.len()
     } else {
@@ -115,13 +115,13 @@ pub fn index_counts(env: &Env, owner: Option<&Address>) -> (u32, u32, u32) {
     let active: Vec<u64> = env
         .storage()
         .persistent()
-        .get(&crate::storage::DataKey::IndexByStatus(GrantStatus::Active as u32))
+        .get(&DataKey::Grant(GrantKey::StatusIndex(GrantStatus::Active as u32)))
         .unwrap_or_else(|| Vec::new(env));
     let contributed = if let Some(o) = owner {
         let list: Vec<u64> = env
             .storage()
             .persistent()
-            .get(&crate::storage::DataKey::IndexByContributor(o.clone()))
+            .get(&DataKey::Grant(GrantKey::ContribIndex(o.clone())))
             .unwrap_or_else(|| Vec::new(env));
         list.len()
     } else {

--- a/stellargrant-contracts/contracts/stellar-grants/src/migration.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/migration.rs
@@ -1,7 +1,10 @@
 use soroban_sdk::{Address, Env, String, Vec};
 
 use crate::events::Events;
-use crate::storage::Storage;
+use crate::storage::{
+    ArbitrationKey, BondKey, CollateralKey, CrowdfundKey, DataKey, EscrowKey, GrantKey,
+    InsuranceKey, LegacyDataKey, MilestoneKey, Storage, UserKey, VotingKey,
+};
 use crate::types::{ContractError, ContractVersion, MigrationRecord};
 
 /// Return the current stored contract version.
@@ -101,5 +104,359 @@ pub fn migration_history(env: &Env) -> Vec<MigrationRecord> {
 
 /// Internal: migration from schema v1 to v2 (placeholder — implement per future schema change).
 fn migrate_v1_to_v2(env: &Env) -> Result<String, ContractError> {
+    migrate_storage_keys_v2(env)?;
     Ok(String::from_str(env, "migrated schema from v1 to v2"))
+}
+
+// ── Storage key migration v1 → v2 ────────────────────────────────────────────
+
+/// Migrate all v1 flat-enum `DataKey` storage entries to the new hierarchical
+/// `DataKey` structure introduced in v2.
+///
+/// **Idempotent**: sets `DataKey::V2KeysMigrated` after completion. Calling
+/// this function a second time is a no-op.
+///
+/// Migration strategy:
+/// - Singleton keys: read from `LegacyDataKey`, write to new `DataKey`.
+/// - Counter-backed collections: read the counter, iterate 1..=counter.
+/// - Per-address collections use the available index structures as the source
+///   of addresses. Address-keyed data that has no discoverable address list
+///   (e.g. `RateLimit`, `ReferralRewards`) must be lazily re-written on first
+///   access by the application; no data is lost because the old keys remain
+///   until TTL expiry.
+pub fn migrate_storage_keys_v2(env: &Env) -> Result<(), ContractError> {
+    // Idempotent guard
+    if env.storage().persistent().has(&DataKey::V2KeysMigrated) {
+        return Ok(());
+    }
+
+    // Helper: read a value from the legacy key encoding.
+    macro_rules! read_legacy {
+        ($key:expr, $T:ty) => {
+            env.storage().persistent().get::<LegacyDataKey, $T>(&$key)
+        };
+    }
+
+    // ── Protocol singletons ───────────────────────────────────────────────────
+
+    if let Some(v) = read_legacy!(LegacyDataKey::Admin, soroban_sdk::Address) {
+        env.storage().persistent().set(&DataKey::Admin, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::GlobalAdmin, soroban_sdk::Address) {
+        env.storage().persistent().set(&DataKey::GlobalAdmin, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::Treasury, soroban_sdk::Address) {
+        env.storage().persistent().set(&DataKey::Treasury, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::Council, soroban_sdk::Address) {
+        env.storage().persistent().set(&DataKey::Council, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::IdentityOracle, soroban_sdk::Address) {
+        env.storage().persistent().set(&DataKey::IdentityOracle, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::MinReviewerStake, i128) {
+        env.storage().persistent().set(&DataKey::MinReviewerStake, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::ContractVersion, crate::types::ContractVersion) {
+        env.storage().persistent().set(&DataKey::ContractVersion, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::MigrationLog, soroban_sdk::Vec<crate::types::MigrationRecord>) {
+        env.storage().persistent().set(&DataKey::MigrationLog, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::IsPaused, bool) {
+        env.storage().persistent().set(&DataKey::IsPaused, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::PauseHistory, soroban_sdk::Vec<crate::types::PauseRecord>) {
+        env.storage().persistent().set(&DataKey::PauseHistory, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::ProtocolConfig, crate::types::ProtocolConfig) {
+        env.storage().persistent().set(&DataKey::Config, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::OracleConfig, crate::types::OracleConfig) {
+        env.storage().persistent().set(&DataKey::OracleConfig, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::ProtocolMetrics, crate::types::ProtocolMetrics) {
+        env.storage().persistent().set(&DataKey::Metrics, &v);
+    }
+    // AnalyticsSnapshot migration is deferred: the type has a pre-existing
+    // contracttype macro error (field name > 30 chars) that prevents TryFromVal.
+    // Its key will be lazily rewritten when the analytics module is repaired.
+    if let Some(v) = read_legacy!(LegacyDataKey::DexConfig, crate::types::DexConfig) {
+        env.storage().persistent().set(&DataKey::DexConfig, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::RelayConfig, crate::types::RelayConfig) {
+        env.storage().persistent().set(&DataKey::RelayConfig, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::ComplianceVerifier, soroban_sdk::Address) {
+        env.storage().persistent().set(&DataKey::ComplianceVerifier, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::ParamKeys, soroban_sdk::Vec<soroban_sdk::Symbol>) {
+        env.storage().persistent().set(&DataKey::ParamKeys, &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::ScoringRubricCounter, u32) {
+        env.storage().persistent().set(&DataKey::ScoringRubricCounter, &v);
+    }
+
+    // Counters used to drive iteration below
+    if let Some(v) = read_legacy!(LegacyDataKey::StreamCounter, u32) {
+        env.storage().persistent().set(&DataKey::StreamCounter, &v);
+    }
+
+    // ── Global registry index (ContributorIndex / ReviewerAllowlist) ──────────
+
+    if let Some(v) = read_legacy!(LegacyDataKey::ContributorIndex, soroban_sdk::Vec<crate::types::RegistryEntry>) {
+        env.storage().persistent().set(&DataKey::User(UserKey::RegistryIndex), &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::ReviewerAllowlist, soroban_sdk::Vec<soroban_sdk::Address>) {
+        env.storage().persistent().set(&DataKey::User(UserKey::ReviewerAllowlist), &v);
+    }
+
+    // Global grant order / counters
+    if let Some(v) = read_legacy!(LegacyDataKey::GlobalGrantOrder, soroban_sdk::Vec<u64>) {
+        env.storage().persistent().set(&DataKey::Grant(GrantKey::GlobalOrder), &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::GrantCounter, u64) {
+        env.storage().persistent().set(&DataKey::Grant(GrantKey::Counter), &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::GrantCounterValue, u64) {
+        env.storage().persistent().set(&DataKey::Grant(GrantKey::CounterValue), &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::CategoryList, soroban_sdk::Vec<crate::types::GrantCategory>) {
+        env.storage().persistent().set(&DataKey::Grant(GrantKey::CategoryList), &v);
+    }
+
+    // Arbitration pool singletons
+    if let Some(v) = read_legacy!(LegacyDataKey::ArbiterPool, soroban_sdk::Vec<soroban_sdk::Address>) {
+        env.storage().persistent().set(&DataKey::Arbitration(ArbitrationKey::Pool), &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::ArbiterPoolToken, soroban_sdk::Address) {
+        env.storage().persistent().set(&DataKey::Arbitration(ArbitrationKey::PoolToken), &v);
+    }
+    if let Some(v) = read_legacy!(LegacyDataKey::ArbitrationCaseCounter, u32) {
+        env.storage().persistent().set(&DataKey::Arbitration(ArbitrationKey::CaseCounter), &v);
+    }
+
+    // Bond counter
+    if let Some(v) = read_legacy!(LegacyDataKey::BondCounter, u32) {
+        env.storage().persistent().set(&DataKey::Bond(BondKey::Counter), &v);
+    }
+
+    // Insurance claim counter
+    if let Some(v) = read_legacy!(LegacyDataKey::InsuranceClaimCounter, u32) {
+        env.storage().persistent().set(&DataKey::Insurance(InsuranceKey::ClaimCounter), &v);
+    }
+
+    // Multisig proposal counter
+    if let Some(v) = read_legacy!(LegacyDataKey::MultisigProposalCounter, u32) {
+        env.storage().persistent().set(&DataKey::Voting(VotingKey::ProposalCounter), &v);
+    }
+
+    // Crowdfund counter
+    if let Some(v) = read_legacy!(LegacyDataKey::CrowdfundCounter, u64) {
+        env.storage().persistent().set(&DataKey::Crowdfund(CrowdfundKey::Counter), &v);
+    }
+
+    // NFT counter
+    if let Some(v) = read_legacy!(LegacyDataKey::NftCounter, u32) {
+        env.storage().persistent().set(&DataKey::Milestone(MilestoneKey::NftCounter), &v);
+    }
+
+    // ── Grant-indexed data (iterate 1..=grant_counter) ────────────────────────
+
+    let grant_counter: u64 = read_legacy!(LegacyDataKey::GrantCounter, u64).unwrap_or(0);
+    for gid in 1..=grant_counter {
+        if let Some(v) = read_legacy!(LegacyDataKey::Grant(gid), crate::types::Grant) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::Data(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::AuditLog(gid), soroban_sdk::Vec<crate::types::AuditEntry>) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::AuditLog(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::EscrowState(gid), crate::types::EscrowState) {
+            env.storage().persistent().set(&DataKey::Escrow(EscrowKey::State(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::EscrowAccount(gid), crate::types::EscrowAccount) {
+            env.storage().persistent().set(&DataKey::Escrow(EscrowKey::Account(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::EscrowFundersList(gid), soroban_sdk::Vec<soroban_sdk::Address>) {
+            env.storage().persistent().set(&DataKey::Escrow(EscrowKey::FundersList(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::GrantTags(gid), crate::types::GrantTag) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::Tags(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::RenewalProposal(gid), crate::types::RenewalProposal) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::Renewal(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::RenewalHistory(gid), u64) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::RenewalHistory(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::ForkRecord(gid), crate::types::ForkRecord) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::Fork(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::ForkChildren(gid), soroban_sdk::Vec<u64>) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::ForkChildren(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::TransferProposal(gid), crate::types::TransferProposal) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::Transfer(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::SyndicateGrant(gid), crate::types::SyndicateGrant) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::Syndicate(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::SyndicateMembers(gid), soroban_sdk::Vec<soroban_sdk::Address>) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::SyndicateMembers(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::MilestoneDag(gid), crate::types::MilestoneDag) {
+            env.storage().persistent().set(&DataKey::Milestone(MilestoneKey::Dag(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::CollateralRequirement(gid), crate::types::CollateralRequirement) {
+            env.storage().persistent().set(&DataKey::Collateral(CollateralKey::Requirement(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::PerformanceBond(gid), crate::types::PerformanceBond) {
+            env.storage().persistent().set(&DataKey::Bond(BondKey::Bond(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::AmendmentHistory(gid), soroban_sdk::Vec<u32>) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::AmendmentHistory(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::CurrentVersion(gid), u32) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::CurrentVersion(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::ExtensionHistory(gid), soroban_sdk::Vec<crate::types::ExtensionRequest>) {
+            env.storage().persistent().set(&DataKey::Milestone(MilestoneKey::ExtensionHistory(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::InsurancePolicy(gid), crate::types::InsurancePolicy) {
+            env.storage().persistent().set(&DataKey::Insurance(InsuranceKey::Policy(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::MultisigSigners(gid), soroban_sdk::Vec<soroban_sdk::Address>) {
+            env.storage().persistent().set(&DataKey::Voting(VotingKey::MultisigSigners(gid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::VotingMechanism(gid), crate::types::VotingMechanism) {
+            env.storage().persistent().set(&DataKey::Voting(VotingKey::Mechanism(gid)), &v);
+        }
+    }
+
+    // ── Streams (1..=stream_counter) ──────────────────────────────────────────
+
+    let stream_counter: u32 = read_legacy!(LegacyDataKey::StreamCounter, u32).unwrap_or(0);
+    for sid in 1..=stream_counter {
+        if let Some(v) = read_legacy!(LegacyDataKey::Stream(sid), crate::types::PaymentStream) {
+            env.storage().persistent().set(&DataKey::Stream(sid), &v);
+        }
+    }
+
+    // ── Insurance claims (1..=claim_counter) ─────────────────────────────────
+
+    let claim_counter: u32 = read_legacy!(LegacyDataKey::InsuranceClaimCounter, u32).unwrap_or(0);
+    for cid in 1..=claim_counter {
+        if let Some(v) = read_legacy!(LegacyDataKey::InsuranceClaim(cid), crate::types::InsuranceClaim) {
+            env.storage().persistent().set(&DataKey::Insurance(InsuranceKey::Claim(cid)), &v);
+        }
+    }
+
+    // ── Multisig proposals (1..=proposal_counter) ────────────────────────────
+
+    let proposal_counter: u32 =
+        read_legacy!(LegacyDataKey::MultisigProposalCounter, u32).unwrap_or(0);
+    for pid in 1..=proposal_counter {
+        if let Some(v) = read_legacy!(LegacyDataKey::MultisigProposal(pid), crate::types::MultisigProposal) {
+            env.storage().persistent().set(&DataKey::Voting(VotingKey::Proposal(pid)), &v);
+        }
+    }
+
+    // ── Crowdfund campaigns (1..=crowdfund_counter) ───────────────────────────
+
+    let cf_counter: u64 = read_legacy!(LegacyDataKey::CrowdfundCounter, u64).unwrap_or(0);
+    for cid in 1..=cf_counter {
+        if let Some(v) = read_legacy!(LegacyDataKey::CrowdfundCampaign(cid), crate::types::CrowdfundCampaign) {
+            env.storage().persistent().set(&DataKey::Crowdfund(CrowdfundKey::Campaign(cid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::CrowdfundBackers(cid), soroban_sdk::Vec<soroban_sdk::Address>) {
+            env.storage().persistent().set(&DataKey::Crowdfund(CrowdfundKey::Backers(cid)), &v);
+        }
+    }
+
+    // ── Arbitration cases (1..=case_counter) ─────────────────────────────────
+
+    let case_counter: u32 =
+        read_legacy!(LegacyDataKey::ArbitrationCaseCounter, u32).unwrap_or(0);
+    for cid in 1..=case_counter {
+        if let Some(v) = read_legacy!(LegacyDataKey::ArbitrationCase(cid), crate::types::ArbitrationCase) {
+            env.storage().persistent().set(&DataKey::Arbitration(ArbitrationKey::Case(cid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::ArbitrationSettled(cid), bool) {
+            env.storage().persistent().set(&DataKey::Arbitration(ArbitrationKey::Settled(cid)), &v);
+        }
+    }
+
+    // ── Bond index (1..=bond_counter) ────────────────────────────────────────
+
+    let bond_counter: u32 = read_legacy!(LegacyDataKey::BondCounter, u32).unwrap_or(0);
+    for bid in 1..=bond_counter {
+        if let Some(v) = read_legacy!(LegacyDataKey::BondGrant(bid), u64) {
+            env.storage().persistent().set(&DataKey::Bond(BondKey::BondGrant(bid)), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::BondClaim(bid), crate::types::BondClaim) {
+            env.storage().persistent().set(&DataKey::Bond(BondKey::BondClaim(bid)), &v);
+        }
+    }
+
+    // ── Scoring rubrics (1..=rubric_counter) ─────────────────────────────────
+
+    let rubric_counter: u32 =
+        read_legacy!(LegacyDataKey::ScoringRubricCounter, u32).unwrap_or(0);
+    for rid in 1..=rubric_counter {
+        if let Some(v) = read_legacy!(LegacyDataKey::ScoringRubric(rid), crate::types::ScoringRubric) {
+            env.storage().persistent().set(&DataKey::ScoringRubric(rid), &v);
+        }
+    }
+
+    // ── Per-address data discovered from the global contributor registry ──────
+    //
+    // We use ContributorIndex (the existing registry) as a source of known
+    // contributor addresses, and ReviewerAllowlist for reviewer addresses.
+    // Data keyed only by address (e.g. RateLimit, ReferralRewards) that has
+    // no index is lazily re-written by the application on first access.
+
+    let contributor_index = Storage::get_contributor_index(env);
+    for entry in contributor_index.iter() {
+        let addr = entry.address.clone();
+        if let Some(v) = read_legacy!(LegacyDataKey::Contributor(addr.clone()), crate::types::ContributorProfile) {
+            env.storage().persistent().set(&DataKey::User(UserKey::Profile(addr.clone())), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::ContributorGrantIds(addr.clone()), soroban_sdk::Vec<u64>) {
+            env.storage().persistent().set(&DataKey::User(UserKey::GrantIds(addr.clone())), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::FunderGrantIndex(addr.clone()), soroban_sdk::Vec<u64>) {
+            env.storage().persistent().set(&DataKey::User(UserKey::FunderGrants(addr.clone())), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::ReviewerReputation(addr.clone()), u32) {
+            env.storage().persistent().set(&DataKey::User(UserKey::ReviewerRep(addr.clone())), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::ReviewerProfile(addr.clone()), crate::types::ReviewerProfile) {
+            env.storage().persistent().set(&DataKey::User(UserKey::ReviewerProfile(addr.clone())), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::NftsByAddress(addr.clone()), soroban_sdk::Vec<u32>) {
+            env.storage().persistent().set(&DataKey::Milestone(MilestoneKey::NftsByOwner(addr.clone())), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::IndexByOwner(addr.clone()), soroban_sdk::Vec<u64>) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::OwnerIndex(addr.clone())), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::IndexByContributor(addr.clone()), soroban_sdk::Vec<u64>) {
+            env.storage().persistent().set(&DataKey::Grant(GrantKey::ContribIndex(addr.clone())), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::ReferralRecord(addr.clone()), crate::types::ReferralRecord) {
+            env.storage().persistent().set(&DataKey::ReferralRecord(addr.clone()), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::ComplianceAttestation(addr.clone()), crate::types::ComplianceAttestation) {
+            env.storage().persistent().set(&DataKey::ComplianceAttestation(addr.clone()), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::RelayAllowance(addr.clone()), crate::types::RelayAllowance) {
+            env.storage().persistent().set(&DataKey::RelayAllowance(addr.clone()), &v);
+        }
+        if let Some(v) = read_legacy!(LegacyDataKey::RelayNonce(addr.clone()), u32) {
+            env.storage().persistent().set(&DataKey::RelayNonce(addr.clone()), &v);
+        }
+    }
+
+    // Mark migration complete — idempotent guard for future calls
+    env.storage().persistent().set(&DataKey::V2KeysMigrated, &true);
+    Ok(())
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage/helpers.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage/helpers.rs
@@ -1,217 +1,34 @@
+use super::keys::{
+    ArbitrationKey, BondKey, CollateralKey, CrowdfundKey, DataKey, EscrowKey, GrantKey,
+    InsuranceKey, MilestoneKey, UserKey, VotingKey,
+};
 use crate::types::{
-    AcceptanceCriteria, Amendment, AnalyticsSnapshot, AuditEntry, BreakerState, CategoryStats, ChecklistSubmission, ComplianceAttestation,
-    ContractError, ContractVersion, ContributorProfile, CrowdfundCampaign, CrowdfundPledge, DexConfig, Dispute, EscrowAccount,
-    EscrowState, EvidenceSchema, FunderLedger, Grant, GrantCategory, GrantTag, GrantVersion, HookEvent, HookRegistration,
-    InsuranceClaim, InsurancePolicy, Invoice, LicenseRecord, MerkleCommitment, MigrationRecord, Milestone,
-    MilestoneDag, MilestoneNft, MultisigProposal, OracleConfig, ParamRecord, PauseRecord, PaymentSplit, PaymentStream,
-    ProtocolConfig, ProtocolMetrics, ProtocolModule, PublicReview, QuadraticVoteRecord,
-    RateLimitAction, RateLimitRecord, RegistryEntry, RelayAllowance, RelayConfig, RenewalProposal,
-    ReviewerProfile, ReviewerRequest, Role, RoleAssignment, RollingWindow, ScoringRubric, StructuredEvidence, SyndicateGrant,
-    SyndicateMember, TokenMetric, TransferProposal, VoiceCredits, VotingMechanism,
+    AcceptanceCriteria, Amendment, AnalyticsSnapshot, AuditEntry, BreakerState, ChecklistSubmission,
+    ComplianceAttestation, ContractError, ContractVersion,
+    ContributorProfile, CrowdfundCampaign, CrowdfundPledge, DexConfig, Dispute, EscrowAccount,
+    EscrowState, EvidenceSchema, FunderLedger, Grant, GrantCategory, GrantTag, GrantVersion,
+    HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy, Invoice, LicenseRecord,
+    MerkleCommitment, MigrationRecord, Milestone, MilestoneDag, MilestoneNft, MultisigProposal,
+    OracleConfig, ParamRecord, PauseRecord, PaymentSplit, PaymentStream, ProtocolConfig,
+    ProtocolMetrics, ProtocolModule, PublicReview, QuadraticVoteRecord, RateLimitAction,
+    RateLimitRecord, RegistryEntry, RelayAllowance, RelayConfig, RenewalProposal, ReviewerProfile,
+    ReviewerRequest, Role, RoleAssignment, RollingWindow, ScoringRubric, StructuredEvidence,
+    SyndicateGrant, SyndicateMember, TokenMetric, TransferProposal, VoiceCredits, VotingMechanism,
 };
 use crate::types::{
     Arbiter, ArbiterVote, ArbitrationCase, BondClaim, CollateralDeposit, CollateralRequirement,
-    ExtensionRequest, PerformanceBond,
-    ReferralCode, ReferralRecord,
-    WhitelistEntry, WhitelistMode, WhitelistScope,
+    ExtensionRequest, PerformanceBond, ReferralCode, ReferralRecord, WhitelistEntry, WhitelistMode,
+    WhitelistScope,
 };
-use soroban_sdk::{contracttype, Address, Bytes, Env, Symbol, Vec};
+use soroban_sdk::{Address, Bytes, Env, Symbol, Vec};
 
-#[contracttype]
-pub enum DataKey {
-    Admin,
-    Grant(u64),
-    Milestone(u64, u32),
-    ReviewerStake(u64, Address),
-    MinReviewerStake,
-    Treasury,
-    IdentityOracle,
-    GlobalAdmin,
-    Council,
-    Contributor(Address),
-    GrantCounter,
-    EscrowState(u64),
-    MultisigSigners(u64),
-    ReleaseApproval(u64, Address),
-    ReviewerReputation(Address),
-    // Contract version tracking (#527)
-    ContractVersion,
-    MigrationLog,
-    // Global registry (#520)
-    ContributorIndex,
-    ReviewerAllowlist,
-    // Immutable audit trail (#523)
-    AuditLog(u64),
-    // Emergency pause (#521)
-    IsPaused,
-    PauseHistory,
-    // Streaming payments (#531)
-    Stream(u32),
-    StreamCounter,
-    // Quadratic voting (#537)
-    VoiceCredits(Address, u64),
-    VotingMechanism(u64),
-    QvVotes(u64, u32),
-    // Insurance pool (#538)
-    InsurancePool(Address),
-    InsurancePolicy(u64),
-    InsuranceClaim(u32),
-    InsuranceClaimCounter,
-    // External hooks (#539)
-    HookRegistry(u32),
-    // Issue #151: milestone reputation tracking
-    MilestoneReputationApplied(u64, u32),
-    // Issue #514: arbiter-based dispute record
-    DisputeRecord(u64, u32),
-    // Issue #516: runtime protocol configuration
-    ProtocolConfig,
-    // Issue #517: cumulative fees per token
-    FeesCollected(Address),
-    // Issue #524: price oracle configuration
-    OracleConfig,
-    // Issue #529: escrow module
-    EscrowAccount(u64),
-    FunderContribution(u64, Address),
-    EscrowFundersList(u64),
-    // Issue #530: multisig module
-    MultisigProposal(u32),
-    MultisigProposalCounter,
-    // Issue #540: protocol metrics
-    ProtocolMetrics,
-    TokenMetrics(Address),
-    // Issue #548: compliance module
-    ComplianceAttestation(Address),
-    ComplianceVerifier,
-    // Issue #585: relay module
-    RelayConfig,
-    RelayAllowance(Address),
-    RelayNonce(Address),
-    // Issue #567: reviewer pool module
-    ReviewerProfile(Address),
-    ReviewerRequest(u64, Address),
-    // Issue #571: grant tags module
-    GrantTags(u64),
-    TagIndex(u32),
-    CategoryList,
-    // Issue #577: grant renewal module
-    RenewalProposal(u64),
-    RenewalHistory(u64),
-    // Issue #576: token swap DEX config
-    DexConfig,
-    // Issue #581: milestone checklist
-    MilestoneChecklist(u64, u32),
-    ChecklistSubmission(u64, u32),
-    // Issue #589: scoring rubric
-    ScoringRubric(u32),
-    ScoringRubricCounter,
-    // Issue #594: circuit breaker
-    BreakerState(ProtocolModule),
-    // Issue #545: Merkle evidence commitments
-    MerkleCommitment(u64, u32),
-    // Issue #544: per-address rate limits
-    RateLimit(Address, RateLimitAction),
-    // Issue #566: invoice billing
-    Invoice(u64, u32),
-    // Issue #582: analytics
-    RollingWindow(Symbol),
-    AnalyticsSnapshot,
-    // Issue #596: dynamic params
-    Param(Symbol),
-    ParamHistory(Symbol),
-    ParamKeys,
-    // Issue #593: RBAC
-    RoleAssignment(Address, Role),
-    RoleMembers(Role),
-    // Crowdfund module
-    CrowdfundCampaign(u64),
-    CrowdfundPledge(u64, Address),
-    CrowdfundBackers(u64),
-    CrowdfundCounter,
-    // Issue #579: IP License Tracking
-    LicenseRecord(u64, u32),
-    // Issue #592: Multi-Recipient Payment Splitting
-    PaymentSplit(u64, u32),
-    // Issue #578: Cross-protocol syndication
-    SyndicateGrant(u64),
-    SyndicateMember(u64, Address),
-    SyndicateMembers(u64),
-    SyndicatePayouts(u64, u32),
-    // Issue #591: Grant specification versioning
-    GrantVersion(u64, u32),
-    CurrentVersion(u64),
-    Amendment(u64, u32),
-    AmendmentHistory(u64),
-    // Issue #568: Grant Transfer
-    TransferProposal(u64),
-    // Issue #583: Typed Evidence Schemas
-    EvidenceSchema(u64, u32),
-    StructuredEvidence(u64, u32),
-    // Issue #590: public review
-    PublicReviews(u64, u32),
-    PublicReviewerRecord(Address, u64, u32),
-    // Issue #595: milestone DAG
-    MilestoneDag(u64),
-    // Issue #570: milestone NFT
-    MilestoneNft(u64, u32),
-    NftsByAddress(Address),
-    NftCounter,
-    NftTokenIndex(u32),
-    // Issue #565: contributor portfolio grant index
-    ContributorGrantIds(Address),
-    // Issue #569: referral system
-    ReferralCode(Bytes),
-    ReferralRecord(Address),
-    ReferralRewards(Address, Address), // (referrer, token) -> pending amount
-    // Issue #572: deadline extension requests
-    ExtensionRequest(u64, u32),
-    ExtensionHistory(u64),
-    // Issue #573: community arbitration pool
-    ArbiterPool,
-    ArbiterPoolToken,
-    Arbiter(Address),
-    ArbiterActiveCases(Address),
-    ArbitrationCase(u32),
-    ArbitrationCaseByDispute(u32),
-    ArbitrationCaseCounter,
-    ArbitrationSettled(u32),
-    ArbiterVote(u32, Address),
-    // Issue #574: performance bonds
-    PerformanceBond(u64),
-    BondGrant(u32),
-    BondClaim(u32),
-    BondCounter,
-    // Issue #528: math helpers — no storage keys needed (pure functions)
-    // Issue #564: collateral escrow
-    CollateralRequirement(u64),
-    CollateralDeposit(u64, Address),
-    // Issue #512: whitelist
-    WhitelistEntries(WhitelistScope),
-    WhitelistMode(WhitelistScope),
-    // Issue #598: funder report — leverages existing escrow/insurance keys
-    FunderGrantIndex(Address),
-    MatchingContribution(Address),
-    GrantCounterValue,
-    // Issue #597: efficient grant index
-    IndexByOwner(Address),
-    IndexByStatus(u32),
-    IndexByToken(Address),
-    IndexByContributor(Address),
-    GlobalGrantOrder,
-    // Issue #587: grant forking
-    ForkRecord(u64),
-    ForkChildren(u64),
-    // Issue #580: notification subscriptions
-    NotifSub(Address, u32, u32, u128),
-    NotifSubList(u32, u32),
-}
-
-const PERSISTENT_TTL_THRESHOLD: u32 = 100_000;
-const PERSISTENT_TTL_EXTEND_TO: u32 = 1_000_000;
+pub(crate) const PERSISTENT_TTL_THRESHOLD: u32 = 100_000;
+pub(crate) const PERSISTENT_TTL_EXTEND_TO: u32 = 1_000_000;
 
 pub struct Storage;
 
 impl Storage {
-    fn bump_persistent_ttl(env: &Env, key: &DataKey) {
+    fn bump(env: &Env, key: &DataKey) {
         env.storage().persistent().extend_ttl(
             key,
             PERSISTENT_TTL_THRESHOLD,
@@ -220,15 +37,10 @@ impl Storage {
     }
 
     pub fn increment_grant_counter(env: &Env) -> u64 {
-        let mut count: u64 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::GrantCounter)
-            .unwrap_or(0);
+        let key = DataKey::Grant(GrantKey::Counter);
+        let mut count: u64 = env.storage().persistent().get(&key).unwrap_or(0);
         count += 1;
-        env.storage()
-            .persistent()
-            .set(&DataKey::GrantCounter, &count);
+        env.storage().persistent().set(&key, &count);
         count
     }
 
@@ -240,16 +52,18 @@ impl Storage {
         env.storage().persistent().set(&DataKey::GlobalAdmin, admin);
     }
 
-    pub fn get_council(env: &Env) -> Option<soroban_sdk::Address> {
+    pub fn get_council(env: &Env) -> Option<Address> {
         env.storage().persistent().get(&DataKey::Council)
     }
 
-    pub fn set_council(env: &Env, council: &soroban_sdk::Address) {
+    pub fn set_council(env: &Env, council: &Address) {
         env.storage().persistent().set(&DataKey::Council, council);
     }
 
     pub fn get_grant(env: &Env, grant_id: u64) -> Option<Grant> {
-        env.storage().persistent().get(&DataKey::Grant(grant_id))
+        env.storage()
+            .persistent()
+            .get(&DataKey::Grant(GrantKey::Data(grant_id)))
     }
 
     pub fn get_grant_v(env: &Env, grant_id: u64) -> Grant {
@@ -261,17 +75,19 @@ impl Storage {
     pub fn set_grant(env: &Env, grant_id: u64, grant: &Grant) {
         env.storage()
             .persistent()
-            .set(&DataKey::Grant(grant_id), grant);
+            .set(&DataKey::Grant(GrantKey::Data(grant_id)), grant);
     }
 
     pub fn has_grant(env: &Env, grant_id: u64) -> bool {
-        env.storage().persistent().has(&DataKey::Grant(grant_id))
+        env.storage()
+            .persistent()
+            .has(&DataKey::Grant(GrantKey::Data(grant_id)))
     }
 
     pub fn get_milestone(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<Milestone> {
         env.storage()
             .persistent()
-            .get(&DataKey::Milestone(grant_id, milestone_idx))
+            .get(&DataKey::Milestone(MilestoneKey::Data(grant_id, milestone_idx)))
     }
 
     pub fn get_milestone_v(env: &Env, grant_id: u64, milestone_idx: u32) -> Milestone {
@@ -281,27 +97,28 @@ impl Storage {
     }
 
     pub fn set_milestone(env: &Env, grant_id: u64, milestone_idx: u32, milestone: &Milestone) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::Milestone(grant_id, milestone_idx), milestone);
+        env.storage().persistent().set(
+            &DataKey::Milestone(MilestoneKey::Data(grant_id, milestone_idx)),
+            milestone,
+        );
     }
 
     pub fn get_contributor(env: &Env, contributor: Address) -> Option<ContributorProfile> {
         env.storage()
             .persistent()
-            .get(&DataKey::Contributor(contributor))
+            .get(&DataKey::User(UserKey::Profile(contributor)))
     }
 
     pub fn set_contributor(env: &Env, contributor: Address, profile: &ContributorProfile) {
         env.storage()
             .persistent()
-            .set(&DataKey::Contributor(contributor), profile);
+            .set(&DataKey::User(UserKey::Profile(contributor)), profile);
     }
 
     pub fn get_escrow_state(env: &Env, grant_id: u64) -> EscrowState {
         env.storage()
             .persistent()
-            .get(&DataKey::EscrowState(grant_id))
+            .get(&DataKey::Escrow(EscrowKey::State(grant_id)))
             .unwrap_or_else(|| {
                 env.panic_with_error(ContractError::InvalidState);
             })
@@ -310,32 +127,35 @@ impl Storage {
     pub fn set_escrow_state(env: &Env, grant_id: u64, state: &EscrowState) {
         env.storage()
             .persistent()
-            .set(&DataKey::EscrowState(grant_id), state);
+            .set(&DataKey::Escrow(EscrowKey::State(grant_id)), state);
     }
 
     pub fn get_multisig_signers(env: &Env, grant_id: u64) -> Vec<Address> {
         env.storage()
             .persistent()
-            .get(&DataKey::MultisigSigners(grant_id))
+            .get(&DataKey::Voting(VotingKey::MultisigSigners(grant_id)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_multisig_signers(env: &Env, grant_id: u64, signers: &Vec<Address>) {
         env.storage()
             .persistent()
-            .set(&DataKey::MultisigSigners(grant_id), signers);
+            .set(&DataKey::Voting(VotingKey::MultisigSigners(grant_id)), signers);
     }
 
     pub fn has_release_approval(env: &Env, grant_id: u64, signer: &Address) -> bool {
         env.storage()
             .persistent()
-            .get(&DataKey::ReleaseApproval(grant_id, signer.clone()))
+            .get(&DataKey::Voting(VotingKey::ReleaseApproval(
+                grant_id,
+                signer.clone(),
+            )))
             .unwrap_or(false)
     }
 
     pub fn set_release_approval(env: &Env, grant_id: u64, signer: &Address, approved: bool) {
         env.storage().persistent().set(
-            &DataKey::ReleaseApproval(grant_id, signer.clone()),
+            &DataKey::Voting(VotingKey::ReleaseApproval(grant_id, signer.clone())),
             &approved,
         );
     }
@@ -343,27 +163,31 @@ impl Storage {
     pub fn get_reviewer_reputation(env: &Env, reviewer: Address) -> u32 {
         env.storage()
             .persistent()
-            .get(&DataKey::ReviewerReputation(reviewer))
+            .get(&DataKey::User(UserKey::ReviewerRep(reviewer)))
             .unwrap_or(1)
     }
 
     pub fn set_reviewer_reputation(env: &Env, reviewer: Address, reputation: u32) {
         env.storage()
             .persistent()
-            .set(&DataKey::ReviewerReputation(reviewer), &reputation);
+            .set(&DataKey::User(UserKey::ReviewerRep(reviewer)), &reputation);
     }
 
     pub fn get_reviewer_stake(env: &Env, grant_id: u64, reviewer: &Address) -> i128 {
         env.storage()
             .persistent()
-            .get(&DataKey::ReviewerStake(grant_id, reviewer.clone()))
+            .get(&DataKey::User(UserKey::ReviewerStake(
+                grant_id,
+                reviewer.clone(),
+            )))
             .unwrap_or(0)
     }
 
     pub fn set_reviewer_stake(env: &Env, grant_id: u64, reviewer: &Address, amount: i128) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::ReviewerStake(grant_id, reviewer.clone()), &amount);
+        env.storage().persistent().set(
+            &DataKey::User(UserKey::ReviewerStake(grant_id, reviewer.clone())),
+            &amount,
+        );
     }
 
     pub fn get_min_reviewer_stake(env: &Env) -> i128 {
@@ -413,27 +237,27 @@ impl Storage {
     pub fn get_contributor_index(env: &Env) -> Vec<RegistryEntry> {
         env.storage()
             .persistent()
-            .get(&DataKey::ContributorIndex)
+            .get(&DataKey::User(UserKey::RegistryIndex))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_contributor_index(env: &Env, index: &Vec<RegistryEntry>) {
         env.storage()
             .persistent()
-            .set(&DataKey::ContributorIndex, index);
+            .set(&DataKey::User(UserKey::RegistryIndex), index);
     }
 
     pub fn get_reviewer_allowlist(env: &Env) -> Vec<Address> {
         env.storage()
             .persistent()
-            .get(&DataKey::ReviewerAllowlist)
+            .get(&DataKey::User(UserKey::ReviewerAllowlist))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_reviewer_allowlist(env: &Env, list: &Vec<Address>) {
         env.storage()
             .persistent()
-            .set(&DataKey::ReviewerAllowlist, list);
+            .set(&DataKey::User(UserKey::ReviewerAllowlist), list);
     }
 
     // ── Immutable Audit Trail (#523) ──────────────────────────────────
@@ -444,12 +268,12 @@ impl Storage {
     pub fn get_audit_log(env: &Env, grant_id: u64) -> Vec<AuditEntry> {
         env.storage()
             .persistent()
-            .get(&DataKey::AuditLog(grant_id))
+            .get(&DataKey::Grant(GrantKey::AuditLog(grant_id)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn append_audit_entry(env: &Env, grant_id: u64, entry: &AuditEntry) {
-        let key = DataKey::AuditLog(grant_id);
+        let key = DataKey::Grant(GrantKey::AuditLog(grant_id));
         let mut log = Self::get_audit_log(env, grant_id);
         log.push_back(entry.clone());
         env.storage().persistent().set(&key, &log);
@@ -519,7 +343,9 @@ impl Storage {
     }
 
     pub fn get_stream(env: &Env, stream_id: u32) -> Option<PaymentStream> {
-        env.storage().persistent().get(&DataKey::Stream(stream_id))
+        env.storage()
+            .persistent()
+            .get(&DataKey::Stream(stream_id))
     }
 
     pub fn set_stream(env: &Env, stream: &PaymentStream) {
@@ -533,12 +359,18 @@ impl Storage {
     pub fn get_voice_credits(env: &Env, voter: &Address, grant_id: u64) -> Option<VoiceCredits> {
         env.storage()
             .persistent()
-            .get(&DataKey::VoiceCredits(voter.clone(), grant_id))
+            .get(&DataKey::Voting(VotingKey::VoiceCredits(
+                voter.clone(),
+                grant_id,
+            )))
     }
 
     pub fn set_voice_credits(env: &Env, credits: &VoiceCredits) {
         env.storage().persistent().set(
-            &DataKey::VoiceCredits(credits.voter.clone(), credits.grant_id),
+            &DataKey::Voting(VotingKey::VoiceCredits(
+                credits.voter.clone(),
+                credits.grant_id,
+            )),
             credits,
         );
     }
@@ -546,20 +378,20 @@ impl Storage {
     pub fn get_voting_mechanism(env: &Env, grant_id: u64) -> VotingMechanism {
         env.storage()
             .persistent()
-            .get(&DataKey::VotingMechanism(grant_id))
+            .get(&DataKey::Voting(VotingKey::Mechanism(grant_id)))
             .unwrap_or(VotingMechanism::SimpleMajority)
     }
 
     pub fn set_voting_mechanism(env: &Env, grant_id: u64, mechanism: &VotingMechanism) {
         env.storage()
             .persistent()
-            .set(&DataKey::VotingMechanism(grant_id), mechanism);
+            .set(&DataKey::Voting(VotingKey::Mechanism(grant_id)), mechanism);
     }
 
     pub fn get_qv_votes(env: &Env, grant_id: u64, milestone_idx: u32) -> Vec<QuadraticVoteRecord> {
         env.storage()
             .persistent()
-            .get(&DataKey::QvVotes(grant_id, milestone_idx))
+            .get(&DataKey::Voting(VotingKey::QvVotes(grant_id, milestone_idx)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
@@ -569,9 +401,10 @@ impl Storage {
         milestone_idx: u32,
         votes: &Vec<QuadraticVoteRecord>,
     ) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::QvVotes(grant_id, milestone_idx), votes);
+        env.storage().persistent().set(
+            &DataKey::Voting(VotingKey::QvVotes(grant_id, milestone_idx)),
+            votes,
+        );
     }
 
     // ── Insurance Pool (#538) ─────────────────────────────────────────────────
@@ -579,51 +412,52 @@ impl Storage {
     pub fn get_insurance_pool(env: &Env, token: &Address) -> i128 {
         env.storage()
             .persistent()
-            .get(&DataKey::InsurancePool(token.clone()))
+            .get(&DataKey::Insurance(InsuranceKey::Pool(token.clone())))
             .unwrap_or(0)
     }
 
     pub fn set_insurance_pool(env: &Env, token: &Address, balance: i128) {
         env.storage()
             .persistent()
-            .set(&DataKey::InsurancePool(token.clone()), &balance);
+            .set(&DataKey::Insurance(InsuranceKey::Pool(token.clone())), &balance);
     }
 
     pub fn get_insurance_policy(env: &Env, grant_id: u64) -> Option<InsurancePolicy> {
         env.storage()
             .persistent()
-            .get(&DataKey::InsurancePolicy(grant_id))
+            .get(&DataKey::Insurance(InsuranceKey::Policy(grant_id)))
     }
 
     pub fn set_insurance_policy(env: &Env, policy: &InsurancePolicy) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::InsurancePolicy(policy.grant_id), policy);
+        env.storage().persistent().set(
+            &DataKey::Insurance(InsuranceKey::Policy(policy.grant_id)),
+            policy,
+        );
     }
 
     pub fn next_claim_id(env: &Env) -> u32 {
         let mut id: u32 = env
             .storage()
             .persistent()
-            .get(&DataKey::InsuranceClaimCounter)
+            .get(&DataKey::Insurance(InsuranceKey::ClaimCounter))
             .unwrap_or(0);
         id += 1;
         env.storage()
             .persistent()
-            .set(&DataKey::InsuranceClaimCounter, &id);
+            .set(&DataKey::Insurance(InsuranceKey::ClaimCounter), &id);
         id
     }
 
     pub fn get_insurance_claim(env: &Env, claim_id: u32) -> Option<InsuranceClaim> {
         env.storage()
             .persistent()
-            .get(&DataKey::InsuranceClaim(claim_id))
+            .get(&DataKey::Insurance(InsuranceKey::Claim(claim_id)))
     }
 
     pub fn set_insurance_claim(env: &Env, claim: &InsuranceClaim) {
         env.storage()
             .persistent()
-            .set(&DataKey::InsuranceClaim(claim.id), claim);
+            .set(&DataKey::Insurance(InsuranceKey::Claim(claim.id)), claim);
     }
 
     // ── External Hooks (#539) ─────────────────────────────────────────────────
@@ -645,58 +479,55 @@ impl Storage {
     // ── Issue #151: milestone reputation tracking ─────────────────────────────
 
     pub fn has_milestone_reputation_applied(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
-        env.storage()
-            .persistent()
-            .has(&DataKey::MilestoneReputationApplied(
-                grant_id,
-                milestone_idx,
-            ))
+        env.storage().persistent().has(&DataKey::Milestone(
+            MilestoneKey::ReputationApplied(grant_id, milestone_idx),
+        ))
     }
 
     pub fn mark_milestone_reputation_applied(env: &Env, grant_id: u64, milestone_idx: u32) {
-        let key = DataKey::MilestoneReputationApplied(grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::ReputationApplied(grant_id, milestone_idx));
         env.storage().persistent().set(&key, &true);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #514: arbiter-based dispute record ──────────────────────────────
 
     pub fn get_dispute(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<Dispute> {
-        let key = DataKey::DisputeRecord(grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::Dispute(grant_id, milestone_idx));
         let d = env.storage().persistent().get(&key);
         if d.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         d
     }
 
     pub fn set_dispute(env: &Env, grant_id: u64, milestone_idx: u32, dispute: &Dispute) {
-        let key = DataKey::DisputeRecord(grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::Dispute(grant_id, milestone_idx));
         env.storage().persistent().set(&key, dispute);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn remove_dispute(env: &Env, grant_id: u64, milestone_idx: u32) {
-        env.storage()
-            .persistent()
-            .remove(&DataKey::DisputeRecord(grant_id, milestone_idx));
+        env.storage().persistent().remove(&DataKey::Milestone(
+            MilestoneKey::Dispute(grant_id, milestone_idx),
+        ));
     }
 
     // ── Issue #516: ProtocolConfig ────────────────────────────────────────────
 
     pub fn get_protocol_config(env: &Env) -> Option<ProtocolConfig> {
-        let key = DataKey::ProtocolConfig;
+        let key = DataKey::Config;
         let cfg = env.storage().persistent().get(&key);
         if cfg.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         cfg
     }
 
     pub fn set_protocol_config(env: &Env, cfg: &ProtocolConfig) {
-        let key = DataKey::ProtocolConfig;
+        let key = DataKey::Config;
         env.storage().persistent().set(&key, cfg);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #517: cumulative fees per token ─────────────────────────────────
@@ -714,7 +545,7 @@ impl Storage {
         env.storage()
             .persistent()
             .set(&key, &current.saturating_add(amount));
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #524: Price oracle configuration ────────────────────────────────
@@ -723,7 +554,7 @@ impl Storage {
         let key = DataKey::OracleConfig;
         let config = env.storage().persistent().get(&key);
         if config.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         config
     }
@@ -731,49 +562,49 @@ impl Storage {
     pub fn set_oracle_config(env: &Env, config: &OracleConfig) {
         let key = DataKey::OracleConfig;
         env.storage().persistent().set(&key, config);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #529: Escrow Module ─────────────────────────────────────────────
 
     pub fn get_escrow_account(env: &Env, grant_id: u64) -> Option<EscrowAccount> {
-        let key = DataKey::EscrowAccount(grant_id);
+        let key = DataKey::Escrow(EscrowKey::Account(grant_id));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_escrow_account(env: &Env, grant_id: u64, account: &EscrowAccount) {
-        let key = DataKey::EscrowAccount(grant_id);
+        let key = DataKey::Escrow(EscrowKey::Account(grant_id));
         env.storage().persistent().set(&key, account);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_funder_ledger(env: &Env, grant_id: u64, funder: &Address) -> Option<FunderLedger> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::FunderContribution(grant_id, funder.clone()))
+        env.storage().persistent().get(&DataKey::Escrow(
+            EscrowKey::FunderContrib(grant_id, funder.clone()),
+        ))
     }
 
     pub fn set_funder_ledger(env: &Env, grant_id: u64, funder: &Address, ledger: &FunderLedger) {
-        let key = DataKey::FunderContribution(grant_id, funder.clone());
+        let key = DataKey::Escrow(EscrowKey::FunderContrib(grant_id, funder.clone()));
         env.storage().persistent().set(&key, ledger);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_escrow_funders_list(env: &Env, grant_id: u64) -> Vec<Address> {
         env.storage()
             .persistent()
-            .get(&DataKey::EscrowFundersList(grant_id))
+            .get(&DataKey::Escrow(EscrowKey::FundersList(grant_id)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_escrow_funders_list(env: &Env, grant_id: u64, list: &Vec<Address>) {
-        let key = DataKey::EscrowFundersList(grant_id);
+        let key = DataKey::Escrow(EscrowKey::FundersList(grant_id));
         env.storage().persistent().set(&key, list);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #530: Multisig Module ───────────────────────────────────────────
@@ -782,40 +613,38 @@ impl Storage {
         let mut id: u32 = env
             .storage()
             .persistent()
-            .get(&DataKey::MultisigProposalCounter)
+            .get(&DataKey::Voting(VotingKey::ProposalCounter))
             .unwrap_or(0);
         id += 1;
         env.storage()
             .persistent()
-            .set(&DataKey::MultisigProposalCounter, &id);
+            .set(&DataKey::Voting(VotingKey::ProposalCounter), &id);
         id
     }
 
     pub fn get_multisig_proposal(env: &Env, proposal_id: u32) -> Option<MultisigProposal> {
-        let key = DataKey::MultisigProposal(proposal_id);
+        let key = DataKey::Voting(VotingKey::Proposal(proposal_id));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_multisig_proposal(env: &Env, proposal: &MultisigProposal) {
-        let key = DataKey::MultisigProposal(proposal.id);
+        let key = DataKey::Voting(VotingKey::Proposal(proposal.id));
         env.storage().persistent().set(&key, proposal);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #540: Protocol Metrics ──────────────────────────────────────────
 
     pub fn get_protocol_metrics(env: &Env) -> Option<ProtocolMetrics> {
-        env.storage().persistent().get(&DataKey::ProtocolMetrics)
+        env.storage().persistent().get(&DataKey::Metrics)
     }
 
     pub fn set_protocol_metrics(env: &Env, metrics: &ProtocolMetrics) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::ProtocolMetrics, metrics);
+        env.storage().persistent().set(&DataKey::Metrics, metrics);
     }
 
     pub fn get_token_metrics(env: &Env, token: &Address) -> Option<TokenMetric> {
@@ -844,7 +673,7 @@ impl Storage {
     pub fn set_compliance_attestation(env: &Env, attestation: &ComplianceAttestation) {
         let key = DataKey::ComplianceAttestation(attestation.subject.clone());
         env.storage().persistent().set(&key, attestation);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn remove_compliance_attestation(env: &Env, address: &Address) {
@@ -854,7 +683,9 @@ impl Storage {
     }
 
     pub fn get_compliance_verifier(env: &Env) -> Option<Address> {
-        env.storage().persistent().get(&DataKey::ComplianceVerifier)
+        env.storage()
+            .persistent()
+            .get(&DataKey::ComplianceVerifier)
     }
 
     pub fn set_compliance_verifier(env: &Env, verifier: &Address) {
@@ -904,25 +735,32 @@ impl Storage {
     pub fn get_reviewer_profile(env: &Env, reviewer: &Address) -> Option<ReviewerProfile> {
         env.storage()
             .persistent()
-            .get(&DataKey::ReviewerProfile(reviewer.clone()))
+            .get(&DataKey::User(UserKey::ReviewerProfile(reviewer.clone())))
     }
 
     pub fn set_reviewer_profile(env: &Env, profile: &ReviewerProfile) {
         env.storage().persistent().set(
-            &DataKey::ReviewerProfile(profile.reviewer.clone()),
+            &DataKey::User(UserKey::ReviewerProfile(profile.reviewer.clone())),
             profile,
         );
     }
 
-    pub fn get_reviewer_request(env: &Env, grant_id: u64, reviewer: &Address) -> Option<ReviewerRequest> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::ReviewerRequest(grant_id, reviewer.clone()))
+    pub fn get_reviewer_request(
+        env: &Env,
+        grant_id: u64,
+        reviewer: &Address,
+    ) -> Option<ReviewerRequest> {
+        env.storage().persistent().get(&DataKey::User(
+            UserKey::ReviewerRequest(grant_id, reviewer.clone()),
+        ))
     }
 
     pub fn set_reviewer_request(env: &Env, request: &ReviewerRequest) {
         env.storage().persistent().set(
-            &DataKey::ReviewerRequest(request.grant_id, request.reviewer.clone()),
+            &DataKey::User(UserKey::ReviewerRequest(
+                request.grant_id,
+                request.reviewer.clone(),
+            )),
             request,
         );
     }
@@ -930,37 +768,41 @@ impl Storage {
     // ── Issue #571: Grant Tags Module ─────────────────────────────────────────
 
     pub fn get_grant_tags(env: &Env, grant_id: u64) -> Option<GrantTag> {
-        env.storage().persistent().get(&DataKey::GrantTags(grant_id))
+        env.storage()
+            .persistent()
+            .get(&DataKey::Grant(GrantKey::Tags(grant_id)))
     }
 
     pub fn set_grant_tags(env: &Env, tags: &GrantTag) {
         env.storage()
             .persistent()
-            .set(&DataKey::GrantTags(tags.grant_id), tags);
+            .set(&DataKey::Grant(GrantKey::Tags(tags.grant_id)), tags);
     }
 
     pub fn get_tag_index(env: &Env, tag_hash: u32) -> Vec<u64> {
         env.storage()
             .persistent()
-            .get(&DataKey::TagIndex(tag_hash))
+            .get(&DataKey::Grant(GrantKey::TagIndex(tag_hash)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_tag_index(env: &Env, tag_hash: u32, grant_ids: &Vec<u64>) {
         env.storage()
             .persistent()
-            .set(&DataKey::TagIndex(tag_hash), grant_ids);
+            .set(&DataKey::Grant(GrantKey::TagIndex(tag_hash)), grant_ids);
     }
 
     pub fn get_category_list(env: &Env) -> Vec<GrantCategory> {
         env.storage()
             .persistent()
-            .get(&DataKey::CategoryList)
+            .get(&DataKey::Grant(GrantKey::CategoryList))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_category_list(env: &Env, categories: &Vec<GrantCategory>) {
-        env.storage().persistent().set(&DataKey::CategoryList, categories);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Grant(GrantKey::CategoryList), categories);
     }
 
     // ── Issue #577: Grant Renewal Module ──────────────────────────────────────
@@ -968,12 +810,12 @@ impl Storage {
     pub fn get_renewal_proposal(env: &Env, original_grant_id: u64) -> Option<RenewalProposal> {
         env.storage()
             .persistent()
-            .get(&DataKey::RenewalProposal(original_grant_id))
+            .get(&DataKey::Grant(GrantKey::Renewal(original_grant_id)))
     }
 
     pub fn set_renewal_proposal(env: &Env, proposal: &RenewalProposal) {
         env.storage().persistent().set(
-            &DataKey::RenewalProposal(proposal.original_grant_id),
+            &DataKey::Grant(GrantKey::Renewal(proposal.original_grant_id)),
             proposal,
         );
     }
@@ -981,16 +823,17 @@ impl Storage {
     pub fn get_renewal_history(env: &Env, grant_id: u64) -> Option<u64> {
         env.storage()
             .persistent()
-            .get(&DataKey::RenewalHistory(grant_id))
+            .get(&DataKey::Grant(GrantKey::RenewalHistory(grant_id)))
     }
 
     pub fn set_renewal_history(env: &Env, grant_id: u64, original_grant_id: u64) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::RenewalHistory(grant_id), &original_grant_id);
+        env.storage().persistent().set(
+            &DataKey::Grant(GrantKey::RenewalHistory(grant_id)),
+            &original_grant_id,
+        );
     }
 
-    // ── Issue #576: Token Swap ──────────────────────────────────────────────────
+    // ── Issue #576: Token Swap ────────────────────────────────────────────────
 
     pub fn get_dex_config(env: &Env) -> Option<DexConfig> {
         env.storage().persistent().get(&DataKey::DexConfig)
@@ -1000,33 +843,49 @@ impl Storage {
         env.storage().persistent().set(&DataKey::DexConfig, config);
     }
 
-    // ── Issue #581: Milestone Checklist ─────────────────────────────────────────
+    // ── Issue #581: Milestone Checklist ──────────────────────────────────────
 
-    pub fn get_milestone_checklist(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<Vec<AcceptanceCriteria>> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::MilestoneChecklist(grant_id, milestone_idx))
+    pub fn get_milestone_checklist(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<Vec<AcceptanceCriteria>> {
+        env.storage().persistent().get(&DataKey::Milestone(
+            MilestoneKey::Checklist(grant_id, milestone_idx),
+        ))
     }
 
-    pub fn set_milestone_checklist(env: &Env, grant_id: u64, milestone_idx: u32, criteria: &Vec<AcceptanceCriteria>) {
-        let key = DataKey::MilestoneChecklist(grant_id, milestone_idx);
+    pub fn set_milestone_checklist(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        criteria: &Vec<AcceptanceCriteria>,
+    ) {
+        let key = DataKey::Milestone(MilestoneKey::Checklist(grant_id, milestone_idx));
         env.storage().persistent().set(&key, criteria);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    pub fn get_checklist_submission(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<ChecklistSubmission> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::ChecklistSubmission(grant_id, milestone_idx))
+    pub fn get_checklist_submission(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<ChecklistSubmission> {
+        env.storage().persistent().get(&DataKey::Milestone(
+            MilestoneKey::Submission(grant_id, milestone_idx),
+        ))
     }
 
     pub fn set_checklist_submission(env: &Env, submission: &ChecklistSubmission) {
-        let key = DataKey::ChecklistSubmission(submission.grant_id, submission.milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::Submission(
+            submission.grant_id,
+            submission.milestone_idx,
+        ));
         env.storage().persistent().set(&key, submission);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    // ── Issue #589: Scoring ─────────────────────────────────────────────────────
+    // ── Issue #589: Scoring ───────────────────────────────────────────────────
 
     pub fn next_rubric_id(env: &Env) -> u32 {
         let mut id: u32 = env
@@ -1053,7 +912,7 @@ impl Storage {
             .set(&DataKey::ScoringRubric(rubric.id), rubric);
     }
 
-    // ── Issue #594: Circuit Breaker ─────────────────────────────────────────────
+    // ── Issue #594: Circuit Breaker ───────────────────────────────────────────
 
     pub fn get_breaker_state(env: &Env, module: &ProtocolModule) -> Option<BreakerState> {
         env.storage()
@@ -1073,16 +932,16 @@ impl Storage {
             .remove(&DataKey::BreakerState(module.clone()));
     }
 
-    // ── Issue #545: Merkle commitments ────────────────────────────────────────
+    // ── Issue #545: Merkle commitments ───────────────────────────────────────
 
     pub fn get_merkle_commitment(
         env: &Env,
         grant_id: u64,
         milestone_idx: u32,
     ) -> Option<MerkleCommitment> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::MerkleCommitment(grant_id, milestone_idx))
+        env.storage().persistent().get(&DataKey::Milestone(
+            MilestoneKey::MerkleCommit(grant_id, milestone_idx),
+        ))
     }
 
     pub fn set_merkle_commitment(
@@ -1091,12 +950,12 @@ impl Storage {
         milestone_idx: u32,
         commitment: &MerkleCommitment,
     ) {
-        let key = DataKey::MerkleCommitment(grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::MerkleCommit(grant_id, milestone_idx));
         env.storage().persistent().set(&key, commitment);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    // ── Issue #544: Rate limits ─────────────────────────────────────────────────
+    // ── Issue #544: Rate limits ───────────────────────────────────────────────
 
     pub fn get_rate_limit_record(
         env: &Env,
@@ -1116,26 +975,24 @@ impl Storage {
     ) {
         let key = DataKey::RateLimit(address.clone(), action.clone());
         env.storage().persistent().set(&key, record);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
-}
 
-impl Storage {
-    // ── Issue #566: Invoice Billing ─────────────────────────────────────────────
+    // ── Issue #566: Invoice Billing ───────────────────────────────────────────
 
     pub fn get_invoice(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<Invoice> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Invoice(grant_id, milestone_idx))
+        env.storage().persistent().get(&DataKey::Milestone(
+            MilestoneKey::Invoice(grant_id, milestone_idx),
+        ))
     }
 
     pub fn set_invoice(env: &Env, grant_id: u64, milestone_idx: u32, invoice: &Invoice) {
-        let key = DataKey::Invoice(grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::Invoice(grant_id, milestone_idx));
         env.storage().persistent().set(&key, invoice);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    // ── Issue #582: Analytics ────────────────────────────────────────────────────
+    // ── Issue #582: Analytics ─────────────────────────────────────────────────
 
     pub fn get_rolling_window(env: &Env, metric: &Symbol) -> Option<RollingWindow> {
         env.storage()
@@ -1146,11 +1003,13 @@ impl Storage {
     pub fn set_rolling_window(env: &Env, metric: &Symbol, window: &RollingWindow) {
         let key = DataKey::RollingWindow(metric.clone());
         env.storage().persistent().set(&key, window);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_analytics_snapshot(env: &Env) -> Option<AnalyticsSnapshot> {
-        env.storage().persistent().get(&DataKey::AnalyticsSnapshot)
+        env.storage()
+            .persistent()
+            .get(&DataKey::AnalyticsSnapshot)
     }
 
     pub fn set_analytics_snapshot(env: &Env, snapshot: &AnalyticsSnapshot) {
@@ -1159,7 +1018,7 @@ impl Storage {
             .set(&DataKey::AnalyticsSnapshot, snapshot);
     }
 
-    // ── Issue #596: Dynamic Params ────────────────────────────────────────────────
+    // ── Issue #596: Dynamic Params ────────────────────────────────────────────
 
     pub fn get_param(env: &Env, key: &Symbol) -> Option<ParamRecord> {
         env.storage()
@@ -1170,9 +1029,8 @@ impl Storage {
     pub fn set_param(env: &Env, key: &Symbol, record: &ParamRecord) {
         let data_key = DataKey::Param(key.clone());
         env.storage().persistent().set(&data_key, record);
-        Self::bump_persistent_ttl(env, &data_key);
+        Self::bump(env, &data_key);
 
-        // Add to param keys list if not exists
         let mut keys = Self::list_param_keys(env);
         if !keys.contains(key.clone()) {
             keys.push_back(key.clone());
@@ -1190,7 +1048,7 @@ impl Storage {
     pub fn set_param_history(env: &Env, key: &Symbol, history: &Vec<ParamRecord>) {
         let data_key = DataKey::ParamHistory(key.clone());
         env.storage().persistent().set(&data_key, history);
-        Self::bump_persistent_ttl(env, &data_key);
+        Self::bump(env, &data_key);
     }
 
     pub fn list_param_keys(env: &Env) -> Vec<Symbol> {
@@ -1200,18 +1058,27 @@ impl Storage {
             .unwrap_or_else(|| Vec::new(env))
     }
 
-    // ── Issue #593: RBAC ──────────────────────────────────────────────────────────
+    // ── Issue #593: RBAC ──────────────────────────────────────────────────────
 
-    pub fn get_role_assignment(env: &Env, address: &Address, role: &Role) -> Option<RoleAssignment> {
+    pub fn get_role_assignment(
+        env: &Env,
+        address: &Address,
+        role: &Role,
+    ) -> Option<RoleAssignment> {
         env.storage()
             .persistent()
             .get(&DataKey::RoleAssignment(address.clone(), role.clone()))
     }
 
-    pub fn set_role_assignment(env: &Env, address: &Address, role: &Role, assignment: &RoleAssignment) {
+    pub fn set_role_assignment(
+        env: &Env,
+        address: &Address,
+        role: &Role,
+        assignment: &RoleAssignment,
+    ) {
         let key = DataKey::RoleAssignment(address.clone(), role.clone());
         env.storage().persistent().set(&key, assignment);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_role_members(env: &Env, role: &Role) -> Vec<Address> {
@@ -1224,7 +1091,7 @@ impl Storage {
     pub fn set_role_members(env: &Env, role: &Role, members: &Vec<Address>) {
         let key = DataKey::RoleMembers(role.clone());
         env.storage().persistent().set(&key, members);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Crowdfund Module ──────────────────────────────────────────────────────
@@ -1233,28 +1100,28 @@ impl Storage {
         let mut id: u64 = env
             .storage()
             .persistent()
-            .get(&DataKey::CrowdfundCounter)
+            .get(&DataKey::Crowdfund(CrowdfundKey::Counter))
             .unwrap_or(0);
         id += 1;
         env.storage()
             .persistent()
-            .set(&DataKey::CrowdfundCounter, &id);
+            .set(&DataKey::Crowdfund(CrowdfundKey::Counter), &id);
         id
     }
 
     pub fn get_crowdfund_campaign(env: &Env, id: u64) -> Option<CrowdfundCampaign> {
-        let key = DataKey::CrowdfundCampaign(id);
+        let key = DataKey::Crowdfund(CrowdfundKey::Campaign(id));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_crowdfund_campaign(env: &Env, campaign: &CrowdfundCampaign) {
-        let key = DataKey::CrowdfundCampaign(campaign.id);
+        let key = DataKey::Crowdfund(CrowdfundKey::Campaign(campaign.id));
         env.storage().persistent().set(&key, campaign);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_crowdfund_pledge(
@@ -1262,227 +1129,270 @@ impl Storage {
         campaign_id: u64,
         backer: &Address,
     ) -> Option<CrowdfundPledge> {
-        let key = DataKey::CrowdfundPledge(campaign_id, backer.clone());
+        let key = DataKey::Crowdfund(CrowdfundKey::Pledge(campaign_id, backer.clone()));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_crowdfund_pledge(env: &Env, pledge: &CrowdfundPledge) {
-        let key = DataKey::CrowdfundPledge(pledge.campaign_id, pledge.backer.clone());
+        let key = DataKey::Crowdfund(CrowdfundKey::Pledge(pledge.campaign_id, pledge.backer.clone()));
         env.storage().persistent().set(&key, pledge);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_crowdfund_backers(env: &Env, campaign_id: u64) -> Vec<Address> {
         env.storage()
             .persistent()
-            .get(&DataKey::CrowdfundBackers(campaign_id))
+            .get(&DataKey::Crowdfund(CrowdfundKey::Backers(campaign_id)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_crowdfund_backers(env: &Env, campaign_id: u64, backers: &Vec<Address>) {
-        let key = DataKey::CrowdfundBackers(campaign_id);
+        let key = DataKey::Crowdfund(CrowdfundKey::Backers(campaign_id));
         env.storage().persistent().set(&key, backers);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #579: IP License Tracking ──────────────────────────────────────
 
-    pub fn get_license_record(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<LicenseRecord> {
-        let key = DataKey::LicenseRecord(grant_id, milestone_idx);
+    pub fn get_license_record(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<LicenseRecord> {
+        let key = DataKey::Milestone(MilestoneKey::License(grant_id, milestone_idx));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
-    pub fn set_license_record(env: &Env, grant_id: u64, milestone_idx: u32, record: &LicenseRecord) {
-        let key = DataKey::LicenseRecord(grant_id, milestone_idx);
+    pub fn set_license_record(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        record: &LicenseRecord,
+    ) {
+        let key = DataKey::Milestone(MilestoneKey::License(grant_id, milestone_idx));
         env.storage().persistent().set(&key, record);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #592: Multi-Recipient Payment Splitting ─────────────────────────
 
     pub fn get_payment_split(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<PaymentSplit> {
-        let key = DataKey::PaymentSplit(grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::PaymentSplit(grant_id, milestone_idx));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_payment_split(env: &Env, grant_id: u64, milestone_idx: u32, split: &PaymentSplit) {
-        let key = DataKey::PaymentSplit(grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::PaymentSplit(grant_id, milestone_idx));
         env.storage().persistent().set(&key, split);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #578: Cross-Protocol Grant Syndication ─────────────────────────
 
     pub fn get_syndicate_grant(env: &Env, grant_id: u64) -> Option<SyndicateGrant> {
-        let key = DataKey::SyndicateGrant(grant_id);
+        let key = DataKey::Grant(GrantKey::Syndicate(grant_id));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_syndicate_grant(env: &Env, grant_id: u64, syndicate: &SyndicateGrant) {
-        let key = DataKey::SyndicateGrant(grant_id);
+        let key = DataKey::Grant(GrantKey::Syndicate(grant_id));
         env.storage().persistent().set(&key, syndicate);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    pub fn get_syndicate_member(env: &Env, grant_id: u64, member: &Address) -> Option<SyndicateMember> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::SyndicateMember(grant_id, member.clone()))
+    pub fn get_syndicate_member(
+        env: &Env,
+        grant_id: u64,
+        member: &Address,
+    ) -> Option<SyndicateMember> {
+        env.storage().persistent().get(&DataKey::Grant(
+            GrantKey::SyndicateMember(grant_id, member.clone()),
+        ))
     }
 
-    pub fn set_syndicate_member(env: &Env, grant_id: u64, member: &Address, record: &SyndicateMember) {
-        let key = DataKey::SyndicateMember(grant_id, member.clone());
+    pub fn set_syndicate_member(
+        env: &Env,
+        grant_id: u64,
+        member: &Address,
+        record: &SyndicateMember,
+    ) {
+        let key = DataKey::Grant(GrantKey::SyndicateMember(grant_id, member.clone()));
         env.storage().persistent().set(&key, record);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn remove_syndicate_member(env: &Env, grant_id: u64, member: &Address) {
-        env.storage()
-            .persistent()
-            .remove(&DataKey::SyndicateMember(grant_id, member.clone()));
+        env.storage().persistent().remove(&DataKey::Grant(
+            GrantKey::SyndicateMember(grant_id, member.clone()),
+        ));
     }
 
     pub fn get_syndicate_member_index(env: &Env, grant_id: u64) -> Vec<Address> {
         env.storage()
             .persistent()
-            .get(&DataKey::SyndicateMembers(grant_id))
+            .get(&DataKey::Grant(GrantKey::SyndicateMembers(grant_id)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_syndicate_member_index(env: &Env, grant_id: u64, members: &Vec<Address>) {
-        let key = DataKey::SyndicateMembers(grant_id);
+        let key = DataKey::Grant(GrantKey::SyndicateMembers(grant_id));
         env.storage().persistent().set(&key, members);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    pub fn set_syndicate_payouts(env: &Env, grant_id: u64, milestone_idx: u32, payouts: &Vec<(Address, i128)>) {
-        let key = DataKey::SyndicatePayouts(grant_id, milestone_idx);
+    pub fn set_syndicate_payouts(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        payouts: &Vec<(Address, i128)>,
+    ) {
+        let key = DataKey::Grant(GrantKey::SyndicatePayouts(grant_id, milestone_idx));
         env.storage().persistent().set(&key, payouts);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #591: Grant Specification Versioning ───────────────────────────
 
     pub fn get_grant_version(env: &Env, grant_id: u64, version: u32) -> Option<GrantVersion> {
-        let key = DataKey::GrantVersion(grant_id, version);
+        let key = DataKey::Grant(GrantKey::SpecVersion(grant_id, version));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_grant_version(env: &Env, grant_id: u64, version: u32, snapshot: &GrantVersion) {
-        let key = DataKey::GrantVersion(grant_id, version);
+        let key = DataKey::Grant(GrantKey::SpecVersion(grant_id, version));
         env.storage().persistent().set(&key, snapshot);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_current_version(env: &Env, grant_id: u64) -> u32 {
         env.storage()
             .persistent()
-            .get(&DataKey::CurrentVersion(grant_id))
+            .get(&DataKey::Grant(GrantKey::CurrentVersion(grant_id)))
             .unwrap_or(0)
     }
 
     pub fn set_current_version(env: &Env, grant_id: u64, version: u32) {
-        let key = DataKey::CurrentVersion(grant_id);
+        let key = DataKey::Grant(GrantKey::CurrentVersion(grant_id));
         env.storage().persistent().set(&key, &version);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_amendment(env: &Env, grant_id: u64, version: u32) -> Option<Amendment> {
         env.storage()
             .persistent()
-            .get(&DataKey::Amendment(grant_id, version))
+            .get(&DataKey::Grant(GrantKey::Amendment(grant_id, version)))
     }
 
     pub fn set_amendment(env: &Env, grant_id: u64, version: u32, amendment: &Amendment) {
-        let key = DataKey::Amendment(grant_id, version);
+        let key = DataKey::Grant(GrantKey::Amendment(grant_id, version));
         env.storage().persistent().set(&key, amendment);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_amendment_history(env: &Env, grant_id: u64) -> Vec<u32> {
         env.storage()
             .persistent()
-            .get(&DataKey::AmendmentHistory(grant_id))
+            .get(&DataKey::Grant(GrantKey::AmendmentHistory(grant_id)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_amendment_history(env: &Env, grant_id: u64, history: &Vec<u32>) {
-        let key = DataKey::AmendmentHistory(grant_id);
+        let key = DataKey::Grant(GrantKey::AmendmentHistory(grant_id));
         env.storage().persistent().set(&key, history);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #568: Grant Transfer ────────────────────────────────────────────
 
     pub fn get_transfer_proposal(env: &Env, grant_id: u64) -> Option<TransferProposal> {
-        let key = DataKey::TransferProposal(grant_id);
+        let key = DataKey::Grant(GrantKey::Transfer(grant_id));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_transfer_proposal(env: &Env, grant_id: u64, proposal: &TransferProposal) {
-        let key = DataKey::TransferProposal(grant_id);
+        let key = DataKey::Grant(GrantKey::Transfer(grant_id));
         env.storage().persistent().set(&key, proposal);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn remove_transfer_proposal(env: &Env, grant_id: u64) {
-        env.storage().persistent().remove(&DataKey::TransferProposal(grant_id));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Grant(GrantKey::Transfer(grant_id)));
     }
 
     // ── Issue #583: Typed Evidence Schemas ───────────────────────────────────
 
-    pub fn get_evidence_schema(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<EvidenceSchema> {
-        let key = DataKey::EvidenceSchema(grant_id, milestone_idx);
+    pub fn get_evidence_schema(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<EvidenceSchema> {
+        let key = DataKey::Milestone(MilestoneKey::EvidenceSchema(grant_id, milestone_idx));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
-    pub fn set_evidence_schema(env: &Env, grant_id: u64, milestone_idx: u32, schema: &EvidenceSchema) {
-        let key = DataKey::EvidenceSchema(grant_id, milestone_idx);
+    pub fn set_evidence_schema(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        schema: &EvidenceSchema,
+    ) {
+        let key = DataKey::Milestone(MilestoneKey::EvidenceSchema(grant_id, milestone_idx));
         env.storage().persistent().set(&key, schema);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    pub fn get_structured_evidence(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<StructuredEvidence> {
-        let key = DataKey::StructuredEvidence(grant_id, milestone_idx);
+    pub fn get_structured_evidence(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<StructuredEvidence> {
+        let key = DataKey::Milestone(MilestoneKey::StructuredEvidence(grant_id, milestone_idx));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
-    pub fn set_structured_evidence(env: &Env, grant_id: u64, milestone_idx: u32, evidence: &StructuredEvidence) {
-        let key = DataKey::StructuredEvidence(grant_id, milestone_idx);
+    pub fn set_structured_evidence(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        evidence: &StructuredEvidence,
+    ) {
+        let key = DataKey::Milestone(MilestoneKey::StructuredEvidence(grant_id, milestone_idx));
         env.storage().persistent().set(&key, evidence);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #590: Public Review ─────────────────────────────────────────────
@@ -1490,7 +1400,10 @@ impl Storage {
     pub fn get_public_reviews(env: &Env, grant_id: u64, milestone_idx: u32) -> Vec<PublicReview> {
         env.storage()
             .persistent()
-            .get(&DataKey::PublicReviews(grant_id, milestone_idx))
+            .get(&DataKey::Milestone(MilestoneKey::PublicReviews(
+                grant_id,
+                milestone_idx,
+            )))
             .unwrap_or_else(|| Vec::new(env))
     }
 
@@ -1500,9 +1413,9 @@ impl Storage {
         milestone_idx: u32,
         reviews: &Vec<PublicReview>,
     ) {
-        let key = DataKey::PublicReviews(grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::PublicReviews(grant_id, milestone_idx));
         env.storage().persistent().set(&key, reviews);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_public_reviewer_record(
@@ -1511,13 +1424,9 @@ impl Storage {
         grant_id: u64,
         milestone_idx: u32,
     ) -> Option<PublicReview> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::PublicReviewerRecord(
-                reviewer.clone(),
-                grant_id,
-                milestone_idx,
-            ))
+        env.storage().persistent().get(&DataKey::Milestone(
+            MilestoneKey::ReviewerRecord(reviewer.clone(), grant_id, milestone_idx),
+        ))
     }
 
     pub fn set_public_reviewer_record(
@@ -1527,26 +1436,30 @@ impl Storage {
         milestone_idx: u32,
         review: &PublicReview,
     ) {
-        let key = DataKey::PublicReviewerRecord(reviewer.clone(), grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::ReviewerRecord(
+            reviewer.clone(),
+            grant_id,
+            milestone_idx,
+        ));
         env.storage().persistent().set(&key, review);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #595: Milestone DAG ─────────────────────────────────────────────
 
     pub fn get_milestone_dag(env: &Env, grant_id: u64) -> Option<MilestoneDag> {
-        let key = DataKey::MilestoneDag(grant_id);
+        let key = DataKey::Milestone(MilestoneKey::Dag(grant_id));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_milestone_dag(env: &Env, grant_id: u64, dag: &MilestoneDag) {
-        let key = DataKey::MilestoneDag(grant_id);
+        let key = DataKey::Milestone(MilestoneKey::Dag(grant_id));
         env.storage().persistent().set(&key, dag);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #570: Milestone NFT ─────────────────────────────────────────────
@@ -1555,53 +1468,59 @@ impl Storage {
         let mut id: u32 = env
             .storage()
             .persistent()
-            .get(&DataKey::NftCounter)
+            .get(&DataKey::Milestone(MilestoneKey::NftCounter))
             .unwrap_or(0);
         id += 1;
-        env.storage().persistent().set(&DataKey::NftCounter, &id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Milestone(MilestoneKey::NftCounter), &id);
         id
     }
 
     pub fn get_milestone_nft(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<MilestoneNft> {
-        let key = DataKey::MilestoneNft(grant_id, milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::Nft(grant_id, milestone_idx));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
     pub fn set_milestone_nft(env: &Env, nft: &MilestoneNft) {
-        let key = DataKey::MilestoneNft(nft.grant_id, nft.milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::Nft(nft.grant_id, nft.milestone_idx));
         env.storage().persistent().set(&key, nft);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_nft_by_token_id(env: &Env, token_id: u32) -> Option<MilestoneNft> {
         let index: Option<(u64, u32)> = env
             .storage()
             .persistent()
-            .get(&DataKey::NftTokenIndex(token_id));
-        index.and_then(|(grant_id, milestone_idx)| Self::get_milestone_nft(env, grant_id, milestone_idx))
+            .get(&DataKey::Milestone(MilestoneKey::NftTokenIndex(token_id)));
+        index.and_then(|(grant_id, milestone_idx)| {
+            Self::get_milestone_nft(env, grant_id, milestone_idx)
+        })
     }
 
     pub fn set_nft_token_index(env: &Env, token_id: u32, grant_id: u64, milestone_idx: u32) {
-        let key = DataKey::NftTokenIndex(token_id);
-        env.storage().persistent().set(&key, &(grant_id, milestone_idx));
-        Self::bump_persistent_ttl(env, &key);
+        let key = DataKey::Milestone(MilestoneKey::NftTokenIndex(token_id));
+        env.storage()
+            .persistent()
+            .set(&key, &(grant_id, milestone_idx));
+        Self::bump(env, &key);
     }
 
     pub fn get_nfts_by_owner(env: &Env, owner: &Address) -> Vec<u32> {
         env.storage()
             .persistent()
-            .get(&DataKey::NftsByAddress(owner.clone()))
+            .get(&DataKey::Milestone(MilestoneKey::NftsByOwner(owner.clone())))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_nfts_by_owner(env: &Env, owner: &Address, token_ids: &Vec<u32>) {
-        let key = DataKey::NftsByAddress(owner.clone());
+        let key = DataKey::Milestone(MilestoneKey::NftsByOwner(owner.clone()));
         env.storage().persistent().set(&key, token_ids);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #565: Contributor Portfolio Grant Index ────────────────────────
@@ -1609,12 +1528,12 @@ impl Storage {
     pub fn get_contributor_grant_ids(env: &Env, contributor: &Address) -> Vec<u64> {
         env.storage()
             .persistent()
-            .get(&DataKey::ContributorGrantIds(contributor.clone()))
+            .get(&DataKey::User(UserKey::GrantIds(contributor.clone())))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn push_contributor_grant_id(env: &Env, contributor: &Address, grant_id: u64) {
-        let key = DataKey::ContributorGrantIds(contributor.clone());
+        let key = DataKey::User(UserKey::GrantIds(contributor.clone()));
         let mut ids: Vec<u64> = env
             .storage()
             .persistent()
@@ -1623,7 +1542,7 @@ impl Storage {
         if !ids.contains(grant_id) {
             ids.push_back(grant_id);
             env.storage().persistent().set(&key, &ids);
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
     }
 
@@ -1638,7 +1557,7 @@ impl Storage {
     pub fn set_referral_code(env: &Env, code: &ReferralCode) {
         let key = DataKey::ReferralCode(code.code_hash.clone());
         env.storage().persistent().set(&key, code);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_referral_record(env: &Env, referred: &Address) -> Option<ReferralRecord> {
@@ -1650,7 +1569,7 @@ impl Storage {
     pub fn set_referral_record(env: &Env, record: &ReferralRecord) {
         let key = DataKey::ReferralRecord(record.referred.clone());
         env.storage().persistent().set(&key, record);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_referral_rewards(env: &Env, referrer: &Address, token: &Address) -> i128 {
@@ -1663,7 +1582,7 @@ impl Storage {
     pub fn set_referral_rewards(env: &Env, referrer: &Address, token: &Address, amount: i128) {
         let key = DataKey::ReferralRewards(referrer.clone(), token.clone());
         env.storage().persistent().set(&key, &amount);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #572: Deadline Extension Requests ──────────────────────────────
@@ -1673,36 +1592,36 @@ impl Storage {
         grant_id: u64,
         milestone_idx: u32,
     ) -> Option<ExtensionRequest> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::ExtensionRequest(grant_id, milestone_idx))
+        env.storage().persistent().get(&DataKey::Milestone(
+            MilestoneKey::Extension(grant_id, milestone_idx),
+        ))
     }
 
     pub fn set_extension_request(env: &Env, req: &ExtensionRequest) {
-        let key = DataKey::ExtensionRequest(req.grant_id, req.milestone_idx);
+        let key = DataKey::Milestone(MilestoneKey::Extension(req.grant_id, req.milestone_idx));
         env.storage().persistent().set(&key, req);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn remove_extension_request(env: &Env, grant_id: u64, milestone_idx: u32) {
-        env.storage()
-            .persistent()
-            .remove(&DataKey::ExtensionRequest(grant_id, milestone_idx));
+        env.storage().persistent().remove(&DataKey::Milestone(
+            MilestoneKey::Extension(grant_id, milestone_idx),
+        ));
     }
 
     pub fn get_extension_history(env: &Env, grant_id: u64) -> Vec<ExtensionRequest> {
         env.storage()
             .persistent()
-            .get(&DataKey::ExtensionHistory(grant_id))
+            .get(&DataKey::Milestone(MilestoneKey::ExtensionHistory(grant_id)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn push_extension_history(env: &Env, req: &ExtensionRequest) {
-        let key = DataKey::ExtensionHistory(req.grant_id);
+        let key = DataKey::Milestone(MilestoneKey::ExtensionHistory(req.grant_id));
         let mut history = Self::get_extension_history(env, req.grant_id);
         history.push_back(req.clone());
         env.storage().persistent().set(&key, &history);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #573: Community Arbitration Pool ───────────────────────────────
@@ -1710,110 +1629,123 @@ impl Storage {
     pub fn get_arbiter_pool(env: &Env) -> Vec<Address> {
         env.storage()
             .persistent()
-            .get(&DataKey::ArbiterPool)
+            .get(&DataKey::Arbitration(ArbitrationKey::Pool))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_arbiter_pool(env: &Env, pool: &Vec<Address>) {
-        env.storage().persistent().set(&DataKey::ArbiterPool, pool);
-        Self::bump_persistent_ttl(env, &DataKey::ArbiterPool);
+        let key = DataKey::Arbitration(ArbitrationKey::Pool);
+        env.storage().persistent().set(&key, pool);
+        Self::bump(env, &key);
     }
 
     pub fn get_arbiter(env: &Env, address: &Address) -> Option<Arbiter> {
         env.storage()
             .persistent()
-            .get(&DataKey::Arbiter(address.clone()))
+            .get(&DataKey::Arbitration(ArbitrationKey::Arbiter(
+                address.clone(),
+            )))
     }
 
     pub fn set_arbiter(env: &Env, arbiter: &Arbiter) {
-        let key = DataKey::Arbiter(arbiter.address.clone());
+        let key = DataKey::Arbitration(ArbitrationKey::Arbiter(arbiter.address.clone()));
         env.storage().persistent().set(&key, arbiter);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_arbiter_pool_token(env: &Env) -> Option<Address> {
-        env.storage().persistent().get(&DataKey::ArbiterPoolToken)
+        env.storage()
+            .persistent()
+            .get(&DataKey::Arbitration(ArbitrationKey::PoolToken))
     }
 
     pub fn set_arbiter_pool_token(env: &Env, token: &Address) {
         env.storage()
             .persistent()
-            .set(&DataKey::ArbiterPoolToken, token);
+            .set(&DataKey::Arbitration(ArbitrationKey::PoolToken), token);
     }
 
     pub fn get_arbiter_active_cases(env: &Env, arbiter: &Address) -> u32 {
         env.storage()
             .persistent()
-            .get(&DataKey::ArbiterActiveCases(arbiter.clone()))
+            .get(&DataKey::Arbitration(ArbitrationKey::ActiveCases(
+                arbiter.clone(),
+            )))
             .unwrap_or(0)
     }
 
     pub fn set_arbiter_active_cases(env: &Env, arbiter: &Address, count: u32) {
-        let key = DataKey::ArbiterActiveCases(arbiter.clone());
+        let key = DataKey::Arbitration(ArbitrationKey::ActiveCases(arbiter.clone()));
         env.storage().persistent().set(&key, &count);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn next_arbitration_case_id(env: &Env) -> u32 {
         let mut id: u32 = env
             .storage()
             .persistent()
-            .get(&DataKey::ArbitrationCaseCounter)
+            .get(&DataKey::Arbitration(ArbitrationKey::CaseCounter))
             .unwrap_or(0);
         id += 1;
         env.storage()
             .persistent()
-            .set(&DataKey::ArbitrationCaseCounter, &id);
+            .set(&DataKey::Arbitration(ArbitrationKey::CaseCounter), &id);
         id
     }
 
     pub fn get_arbitration_case(env: &Env, case_id: u32) -> Option<ArbitrationCase> {
         env.storage()
             .persistent()
-            .get(&DataKey::ArbitrationCase(case_id))
+            .get(&DataKey::Arbitration(ArbitrationKey::Case(case_id)))
     }
 
     pub fn set_arbitration_case(env: &Env, case: &ArbitrationCase) {
-        let key = DataKey::ArbitrationCase(case.id);
+        let key = DataKey::Arbitration(ArbitrationKey::Case(case.id));
         env.storage().persistent().set(&key, case);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_case_id_by_dispute(env: &Env, dispute_id: u32) -> Option<u32> {
         env.storage()
             .persistent()
-            .get(&DataKey::ArbitrationCaseByDispute(dispute_id))
+            .get(&DataKey::Arbitration(ArbitrationKey::CaseByDispute(
+                dispute_id,
+            )))
     }
 
     pub fn set_case_id_by_dispute(env: &Env, dispute_id: u32, case_id: u32) {
-        let key = DataKey::ArbitrationCaseByDispute(dispute_id);
+        let key = DataKey::Arbitration(ArbitrationKey::CaseByDispute(dispute_id));
         env.storage().persistent().set(&key, &case_id);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn is_arbitration_settled(env: &Env, case_id: u32) -> bool {
         env.storage()
             .persistent()
-            .get(&DataKey::ArbitrationSettled(case_id))
+            .get(&DataKey::Arbitration(ArbitrationKey::Settled(case_id)))
             .unwrap_or(false)
     }
 
     pub fn set_arbitration_settled(env: &Env, case_id: u32) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::ArbitrationSettled(case_id), &true);
+        env.storage().persistent().set(
+            &DataKey::Arbitration(ArbitrationKey::Settled(case_id)),
+            &true,
+        );
     }
 
     pub fn get_arbiter_vote(env: &Env, case_id: u32, arbiter: &Address) -> Option<ArbiterVote> {
         env.storage()
             .persistent()
-            .get(&DataKey::ArbiterVote(case_id, arbiter.clone()))
+            .get(&DataKey::Arbitration(ArbitrationKey::Vote(
+                case_id,
+                arbiter.clone(),
+            )))
     }
 
     pub fn set_arbiter_vote(env: &Env, case_id: u32, vote: &ArbiterVote) {
-        let key = DataKey::ArbiterVote(case_id, vote.arbiter.clone());
+        let key = DataKey::Arbitration(ArbitrationKey::Vote(case_id, vote.arbiter.clone()));
         env.storage().persistent().set(&key, vote);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     // ── Issue #574: Performance Bonds ────────────────────────────────────────
@@ -1821,63 +1753,74 @@ impl Storage {
     pub fn get_performance_bond(env: &Env, grant_id: u64) -> Option<PerformanceBond> {
         env.storage()
             .persistent()
-            .get(&DataKey::PerformanceBond(grant_id))
+            .get(&DataKey::Bond(BondKey::Bond(grant_id)))
     }
 
     pub fn set_performance_bond(env: &Env, bond: &PerformanceBond) {
-        let key = DataKey::PerformanceBond(bond.grant_id);
+        let key = DataKey::Bond(BondKey::Bond(bond.grant_id));
         env.storage().persistent().set(&key, bond);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn next_bond_id(env: &Env) -> u32 {
         let mut id: u32 = env
             .storage()
             .persistent()
-            .get(&DataKey::BondCounter)
+            .get(&DataKey::Bond(BondKey::Counter))
             .unwrap_or(0);
         id += 1;
-        env.storage().persistent().set(&DataKey::BondCounter, &id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Bond(BondKey::Counter), &id);
         id
     }
 
     pub fn get_bond_grant(env: &Env, bond_id: u32) -> Option<u64> {
-        env.storage().persistent().get(&DataKey::BondGrant(bond_id))
+        env.storage()
+            .persistent()
+            .get(&DataKey::Bond(BondKey::BondGrant(bond_id)))
     }
 
     pub fn set_bond_grant(env: &Env, bond_id: u32, grant_id: u64) {
-        let key = DataKey::BondGrant(bond_id);
+        let key = DataKey::Bond(BondKey::BondGrant(bond_id));
         env.storage().persistent().set(&key, &grant_id);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_bond_claim(env: &Env, bond_id: u32) -> Option<BondClaim> {
         env.storage()
             .persistent()
-            .get(&DataKey::BondClaim(bond_id))
+            .get(&DataKey::Bond(BondKey::BondClaim(bond_id)))
     }
 
     pub fn set_bond_claim(env: &Env, claim: &BondClaim) {
-        let key = DataKey::BondClaim(claim.bond_id);
+        let key = DataKey::Bond(BondKey::BondClaim(claim.bond_id));
         env.storage().persistent().set(&key, claim);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    // ── Issue #564: Collateral Escrow ───────────────────────────────────────
+    // ── Issue #564: Collateral Escrow ─────────────────────────────────────────
 
-    pub fn get_collateral_requirement(env: &Env, grant_id: u64) -> Option<CollateralRequirement> {
-        let key = DataKey::CollateralRequirement(grant_id);
+    pub fn get_collateral_requirement(
+        env: &Env,
+        grant_id: u64,
+    ) -> Option<CollateralRequirement> {
+        let key = DataKey::Collateral(CollateralKey::Requirement(grant_id));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
 
-    pub fn set_collateral_requirement(env: &Env, grant_id: u64, req: &CollateralRequirement) {
-        let key = DataKey::CollateralRequirement(grant_id);
+    pub fn set_collateral_requirement(
+        env: &Env,
+        grant_id: u64,
+        req: &CollateralRequirement,
+    ) {
+        let key = DataKey::Collateral(CollateralKey::Requirement(grant_id));
         env.storage().persistent().set(&key, req);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn get_collateral_deposit(
@@ -1885,10 +1828,10 @@ impl Storage {
         grant_id: u64,
         contributor: &Address,
     ) -> Option<CollateralDeposit> {
-        let key = DataKey::CollateralDeposit(grant_id, contributor.clone());
+        let key = DataKey::Collateral(CollateralKey::Deposit(grant_id, contributor.clone()));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
         v
     }
@@ -1899,12 +1842,12 @@ impl Storage {
         contributor: &Address,
         deposit: &CollateralDeposit,
     ) {
-        let key = DataKey::CollateralDeposit(grant_id, contributor.clone());
+        let key = DataKey::Collateral(CollateralKey::Deposit(grant_id, contributor.clone()));
         env.storage().persistent().set(&key, deposit);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    // ── Issue #512: Whitelist ───────────────────────────────────────────────
+    // ── Issue #512: Whitelist ─────────────────────────────────────────────────
 
     pub fn get_whitelist_entries(env: &Env, scope: &WhitelistScope) -> Vec<WhitelistEntry> {
         env.storage()
@@ -1913,10 +1856,14 @@ impl Storage {
             .unwrap_or_else(|| Vec::new(env))
     }
 
-    pub fn set_whitelist_entries(env: &Env, scope: &WhitelistScope, entries: &Vec<WhitelistEntry>) {
+    pub fn set_whitelist_entries(
+        env: &Env,
+        scope: &WhitelistScope,
+        entries: &Vec<WhitelistEntry>,
+    ) {
         let key = DataKey::WhitelistEntries(scope.clone());
         env.storage().persistent().set(&key, entries);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
     pub fn push_whitelist_entry(env: &Env, scope: &WhitelistScope, entry: &WhitelistEntry) {
@@ -1934,20 +1881,20 @@ impl Storage {
     pub fn set_whitelist_mode(env: &Env, scope: &WhitelistScope, mode: WhitelistMode) {
         let key = DataKey::WhitelistMode(scope.clone());
         env.storage().persistent().set(&key, &mode);
-        Self::bump_persistent_ttl(env, &key);
+        Self::bump(env, &key);
     }
 
-    // ── Issue #598: Funder Report ───────────────────────────────────────────
+    // ── Issue #598: Funder Report ─────────────────────────────────────────────
 
     pub fn get_funder_grant_index(env: &Env, funder: &Address) -> Vec<u64> {
         env.storage()
             .persistent()
-            .get(&DataKey::FunderGrantIndex(funder.clone()))
+            .get(&DataKey::User(UserKey::FunderGrants(funder.clone())))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn push_funder_grant_index(env: &Env, funder: &Address, grant_id: u64) {
-        let key = DataKey::FunderGrantIndex(funder.clone());
+        let key = DataKey::User(UserKey::FunderGrants(funder.clone()));
         let mut ids: Vec<u64> = env
             .storage()
             .persistent()
@@ -1956,47 +1903,51 @@ impl Storage {
         if !ids.contains(grant_id) {
             ids.push_back(grant_id);
             env.storage().persistent().set(&key, &ids);
-            Self::bump_persistent_ttl(env, &key);
+            Self::bump(env, &key);
         }
     }
 
     pub fn get_matching_contribution(env: &Env, funder: &Address) -> Option<i128> {
         env.storage()
             .persistent()
-            .get(&DataKey::MatchingContribution(funder.clone()))
+            .get(&DataKey::User(UserKey::MatchingContrib(funder.clone())))
     }
 
     pub fn get_grant_counter(env: &Env) -> u64 {
         env.storage()
             .persistent()
-            .get(&DataKey::GrantCounter)
+            .get(&DataKey::Grant(GrantKey::Counter))
             .unwrap_or(0)
     }
 
     // ── Issue #587: Fork Record ───────────────────────────────────────────────
 
-    pub fn get_fork_record(env: &Env, grant_id: u64) -> Option<super::types::ForkRecord> {
+    pub fn get_fork_record(env: &Env, grant_id: u64) -> Option<super::super::types::ForkRecord> {
         env.storage()
             .persistent()
-            .get(&DataKey::ForkRecord(grant_id))
+            .get(&DataKey::Grant(GrantKey::Fork(grant_id)))
     }
 
-    pub fn set_fork_record(env: &Env, grant_id: u64, record: &super::types::ForkRecord) {
+    pub fn set_fork_record(
+        env: &Env,
+        grant_id: u64,
+        record: &super::super::types::ForkRecord,
+    ) {
         env.storage()
             .persistent()
-            .set(&DataKey::ForkRecord(grant_id), record);
+            .set(&DataKey::Grant(GrantKey::Fork(grant_id)), record);
     }
 
     pub fn get_fork_children(env: &Env, grant_id: u64) -> Vec<u64> {
         env.storage()
             .persistent()
-            .get(&DataKey::ForkChildren(grant_id))
+            .get(&DataKey::Grant(GrantKey::ForkChildren(grant_id)))
             .unwrap_or_else(|| Vec::new(env))
     }
 
     pub fn set_fork_children(env: &Env, grant_id: u64, children: &Vec<u64>) {
         env.storage()
             .persistent()
-            .set(&DataKey::ForkChildren(grant_id), children);
+            .set(&DataKey::Grant(GrantKey::ForkChildren(grant_id)), children);
     }
 }

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage/keys.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage/keys.rs
@@ -1,0 +1,357 @@
+use crate::types::{ProtocolModule, RateLimitAction, Role, WhitelistScope};
+use soroban_sdk::{contracttype, Address, Bytes, Symbol};
+
+// ── Domain sub-enums ─────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub enum GrantKey {
+    Data(u64),
+    Counter,
+    CounterValue,
+    AuditLog(u64),
+    Tags(u64),
+    TagIndex(u32),
+    CategoryList,
+    SpecVersion(u64, u32),
+    CurrentVersion(u64),
+    Amendment(u64, u32),
+    AmendmentHistory(u64),
+    Transfer(u64),
+    Renewal(u64),
+    RenewalHistory(u64),
+    Fork(u64),
+    ForkChildren(u64),
+    Syndicate(u64),
+    SyndicateMember(u64, Address),
+    SyndicateMembers(u64),
+    SyndicatePayouts(u64, u32),
+    OwnerIndex(Address),
+    StatusIndex(u32),
+    TokenIndex(Address),
+    ContribIndex(Address),
+    GlobalOrder,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum MilestoneKey {
+    Data(u64, u32),
+    Checklist(u64, u32),
+    Submission(u64, u32),
+    Dag(u64),
+    Nft(u64, u32),
+    NftCounter,
+    NftsByOwner(Address),
+    NftTokenIndex(u32),
+    ReputationApplied(u64, u32),
+    MerkleCommit(u64, u32),
+    Extension(u64, u32),
+    ExtensionHistory(u64),
+    Invoice(u64, u32),
+    PaymentSplit(u64, u32),
+    EvidenceSchema(u64, u32),
+    StructuredEvidence(u64, u32),
+    PublicReviews(u64, u32),
+    ReviewerRecord(Address, u64, u32),
+    License(u64, u32),
+    Dispute(u64, u32),
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum EscrowKey {
+    Account(u64),
+    State(u64),
+    FunderContrib(u64, Address),
+    FundersList(u64),
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum UserKey {
+    Profile(Address),
+    RegistryIndex,
+    GrantIds(Address),
+    ReviewerProfile(Address),
+    ReviewerRequest(u64, Address),
+    ReviewerRep(Address),
+    ReviewerStake(u64, Address),
+    ReviewerAllowlist,
+    FunderGrants(Address),
+    MatchingContrib(Address),
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum VotingKey {
+    VoiceCredits(Address, u64),
+    Mechanism(u64),
+    QvVotes(u64, u32),
+    MultisigSigners(u64),
+    ReleaseApproval(u64, Address),
+    Proposal(u32),
+    ProposalCounter,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum InsuranceKey {
+    Pool(Address),
+    Policy(u64),
+    Claim(u32),
+    ClaimCounter,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum CrowdfundKey {
+    Campaign(u64),
+    Pledge(u64, Address),
+    Backers(u64),
+    Counter,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum ArbitrationKey {
+    Pool,
+    PoolToken,
+    Arbiter(Address),
+    ActiveCases(Address),
+    Case(u32),
+    CaseByDispute(u32),
+    CaseCounter,
+    Settled(u32),
+    Vote(u32, Address),
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum BondKey {
+    Bond(u64),
+    BondGrant(u32),
+    BondClaim(u32),
+    Counter,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum CollateralKey {
+    Requirement(u64),
+    Deposit(u64, Address),
+}
+
+// ── Structured DataKey ────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    // Domain sub-enums
+    Grant(GrantKey),
+    Milestone(MilestoneKey),
+    Escrow(EscrowKey),
+    User(UserKey),
+    Voting(VotingKey),
+    Insurance(InsuranceKey),
+    Crowdfund(CrowdfundKey),
+    Arbitration(ArbitrationKey),
+    Bond(BondKey),
+    Collateral(CollateralKey),
+
+    // Streaming
+    Stream(u32),
+    StreamCounter,
+
+    // Protocol singletons
+    Admin,
+    GlobalAdmin,
+    Treasury,
+    Council,
+    IdentityOracle,
+    MinReviewerStake,
+    ContractVersion,
+    MigrationLog,
+    IsPaused,
+    PauseHistory,
+    Config,
+    OracleConfig,
+    Metrics,
+    AnalyticsSnapshot,
+    ParamKeys,
+    ComplianceVerifier,
+    ScoringRubricCounter,
+    DexConfig,
+    RelayConfig,
+
+    // Per-address
+    TokenMetrics(Address),
+    FeesCollected(Address),
+    RelayAllowance(Address),
+    RelayNonce(Address),
+    ComplianceAttestation(Address),
+    ReferralRecord(Address),
+    ReferralRewards(Address, Address),
+
+    // Domain-keyed singletons
+    HookRegistry(u32),
+    ScoringRubric(u32),
+    BreakerState(ProtocolModule),
+    RateLimit(Address, RateLimitAction),
+    RollingWindow(Symbol),
+    Param(Symbol),
+    ParamHistory(Symbol),
+    RoleAssignment(Address, Role),
+    RoleMembers(Role),
+    ReferralCode(Bytes),
+    WhitelistEntries(WhitelistScope),
+    WhitelistMode(WhitelistScope),
+
+    // Notifications
+    NotifSub(Address, u32, u32, u128),
+    NotifSubList(u32, u32),
+
+    // Migration guard
+    V2KeysMigrated,
+}
+
+// ── Legacy DataKey (v1) — used only by migrate_storage_keys_v2 ───────────────
+//
+// Variant names and positions MUST match the original DataKey exactly so that
+// Soroban's discriminant-based XDR encoding resolves to the same storage keys.
+
+#[contracttype]
+#[derive(Clone)]
+pub enum LegacyDataKey {
+    Admin,
+    Grant(u64),
+    Milestone(u64, u32),
+    ReviewerStake(u64, Address),
+    MinReviewerStake,
+    Treasury,
+    IdentityOracle,
+    GlobalAdmin,
+    Council,
+    Contributor(Address),
+    GrantCounter,
+    EscrowState(u64),
+    MultisigSigners(u64),
+    ReleaseApproval(u64, Address),
+    ReviewerReputation(Address),
+    ContractVersion,
+    MigrationLog,
+    ContributorIndex,
+    ReviewerAllowlist,
+    AuditLog(u64),
+    IsPaused,
+    PauseHistory,
+    Stream(u32),
+    StreamCounter,
+    VoiceCredits(Address, u64),
+    VotingMechanism(u64),
+    QvVotes(u64, u32),
+    InsurancePool(Address),
+    InsurancePolicy(u64),
+    InsuranceClaim(u32),
+    InsuranceClaimCounter,
+    HookRegistry(u32),
+    MilestoneReputationApplied(u64, u32),
+    DisputeRecord(u64, u32),
+    ProtocolConfig,
+    FeesCollected(Address),
+    OracleConfig,
+    EscrowAccount(u64),
+    FunderContribution(u64, Address),
+    EscrowFundersList(u64),
+    MultisigProposal(u32),
+    MultisigProposalCounter,
+    ProtocolMetrics,
+    TokenMetrics(Address),
+    ComplianceAttestation(Address),
+    ComplianceVerifier,
+    RelayConfig,
+    RelayAllowance(Address),
+    RelayNonce(Address),
+    ReviewerProfile(Address),
+    ReviewerRequest(u64, Address),
+    GrantTags(u64),
+    TagIndex(u32),
+    CategoryList,
+    RenewalProposal(u64),
+    RenewalHistory(u64),
+    DexConfig,
+    MilestoneChecklist(u64, u32),
+    ChecklistSubmission(u64, u32),
+    ScoringRubric(u32),
+    ScoringRubricCounter,
+    BreakerState(ProtocolModule),
+    MerkleCommitment(u64, u32),
+    RateLimit(Address, RateLimitAction),
+    Invoice(u64, u32),
+    RollingWindow(Symbol),
+    AnalyticsSnapshot,
+    Param(Symbol),
+    ParamHistory(Symbol),
+    ParamKeys,
+    RoleAssignment(Address, Role),
+    RoleMembers(Role),
+    CrowdfundCampaign(u64),
+    CrowdfundPledge(u64, Address),
+    CrowdfundBackers(u64),
+    CrowdfundCounter,
+    LicenseRecord(u64, u32),
+    PaymentSplit(u64, u32),
+    SyndicateGrant(u64),
+    SyndicateMember(u64, Address),
+    SyndicateMembers(u64),
+    SyndicatePayouts(u64, u32),
+    GrantVersion(u64, u32),
+    CurrentVersion(u64),
+    Amendment(u64, u32),
+    AmendmentHistory(u64),
+    TransferProposal(u64),
+    EvidenceSchema(u64, u32),
+    StructuredEvidence(u64, u32),
+    PublicReviews(u64, u32),
+    PublicReviewerRecord(Address, u64, u32),
+    MilestoneDag(u64),
+    MilestoneNft(u64, u32),
+    NftsByAddress(Address),
+    NftCounter,
+    NftTokenIndex(u32),
+    ContributorGrantIds(Address),
+    ReferralCode(Bytes),
+    ReferralRecord(Address),
+    ReferralRewards(Address, Address),
+    ExtensionRequest(u64, u32),
+    ExtensionHistory(u64),
+    ArbiterPool,
+    ArbiterPoolToken,
+    Arbiter(Address),
+    ArbiterActiveCases(Address),
+    ArbitrationCase(u32),
+    ArbitrationCaseByDispute(u32),
+    ArbitrationCaseCounter,
+    ArbitrationSettled(u32),
+    ArbiterVote(u32, Address),
+    PerformanceBond(u64),
+    BondGrant(u32),
+    BondClaim(u32),
+    BondCounter,
+    CollateralRequirement(u64),
+    CollateralDeposit(u64, Address),
+    WhitelistEntries(WhitelistScope),
+    WhitelistMode(WhitelistScope),
+    FunderGrantIndex(Address),
+    MatchingContribution(Address),
+    GrantCounterValue,
+    IndexByOwner(Address),
+    IndexByStatus(u32),
+    IndexByToken(Address),
+    IndexByContributor(Address),
+    GlobalGrantOrder,
+    ForkRecord(u64),
+    ForkChildren(u64),
+    NotifSub(Address, u32, u32, u128),
+    NotifSubList(u32, u32),
+}

--- a/stellargrant-contracts/contracts/stellar-grants/src/storage/mod.rs
+++ b/stellargrant-contracts/contracts/stellar-grants/src/storage/mod.rs
@@ -1,0 +1,9 @@
+pub mod helpers;
+pub mod keys;
+
+pub use helpers::Storage;
+pub use keys::{
+    ArbitrationKey, BondKey, CollateralKey, CrowdfundKey, DataKey, EscrowKey, GrantKey,
+    InsuranceKey, MilestoneKey, UserKey, VotingKey,
+};
+pub(crate) use keys::LegacyDataKey;


### PR DESCRIPTION

---
What was implemented

New files created

storage/keys.rs (357 lines)
- LegacyDataKey — exact copy of the old flat DataKey in the same variant order, so Soroban's discriminant-based XDR encoding matches for migration reads
- 10 domain sub-enums: GrantKey, MilestoneKey, EscrowKey, UserKey, VotingKey, InsuranceKey, CrowdfundKey, ArbitrationKey, BondKey, CollateralKey
- New structured DataKey with one top-level variant per domain, plus ~40 remaining singletons and simple keys at the top level
- DataKey::V2KeysMigrated sentinel for the idempotent guard

storage/helpers.rs (1953 lines)
- Same Storage struct with all ~90 methods, now using the new nested key paths (e.g. DataKey::Grant(GrantKey::Data(id)) instead of DataKey::Grant(id))

storage/mod.rs (9 lines)
- Re-exports Storage, all sub-enums, and pub(crate) LegacyDataKey

Files deleted

- storage.rs — replaced by the storage/ directory

Files modified

migration.rs
- Added migrate_storage_keys_v2(env) — reads every known key via LegacyDataKey (old XDR encoding) and writes to new DataKey (new encoding)
- Covers: all singletons, grant-indexed data (iterates 1..=counter), streams, claims, proposals, crowdfund, arbitration cases, bonds, rubrics, and per-address data discovered from the contributor registry
- Idempotent: sets DataKey::V2KeysMigrated on completion; returns immediately on subsequent calls
- Wired into migrate_v1_to_v2 so it runs as part of the normal version migration path

grant_index.rs
- Updated 10 direct DataKey::IndexBy* / DataKey::GlobalGrantOrder references to use DataKey::Grant(GrantKey::OwnerIndex(...)) etc.

Pre-existing errors not introduced by this refactor

The two errors that appear in storage/helpers.rs (AnalyticsSnapshot: TryFromVal) are identical in nature to what existed in the original storage.rs — they're caused by a pre-existing bug in types.rs where AnalyticsSnapshot has field names longer than Soroban's 30-character limit. The migration function skips AnalyticsSnapshot with an inline note.


Closes #621 
Closes #620 
Closes #615 
Closes #610