### PR TITLE
feat: implement CORS proxy, TypeDoc, retry backoff, and CLI SDK (#495…

### DIFF
--- a/client/src/StellarGrantsSDK.ts
+++ b/client/src/StellarGrantsSDK.ts
@@ -31,6 +31,8 @@ import {
 } from "./types";
 import { meetsThreshold, PendingXdrStore } from "./utils/transactions";
 import { combineSignatures } from "./utils/transactions";
+import { retryWithBackoff } from "./utils/retry";
+import type { RetryConfig } from "./types";
 import { uploadMetadataToIPFS, fetchMetadataFromIPFS } from "./ipfs";
 import { BatchBuilder, BatchCall, BatchOperationError, BatchSendOptions } from "./batch/BatchBuilder";
 
@@ -62,6 +64,7 @@ export class StellarGrantsSDK {
   private readonly contract: Contract;
   private readonly server: any;
   private readonly config: StellarGrantsSDKConfig;
+  private readonly retryConfig: RetryConfig | undefined;
   private _horizonServer: Horizon.Server | null = null;
   private eventPollHandle: ReturnType<typeof setTimeout> | null = null;
   private eventHeartbeatHandle: ReturnType<typeof setTimeout> | null = null;
@@ -78,6 +81,7 @@ export class StellarGrantsSDK {
       signer: config.wallet ?? config.signer,
     };
     this.contract = new Contract(config.contractId);
+    this.retryConfig = config.retryConfig;
     const serverUrl = config.proxyUrl ?? config.rpcUrl!;
     this.server = new rpc.Server(serverUrl, {
       allowHttp: serverUrl.startsWith("http://"),
@@ -86,6 +90,17 @@ export class StellarGrantsSDK {
     if (config.horizonUrl) {
       this._horizonServer = new Horizon.Server(config.horizonUrl);
     }
+  }
+
+  /**
+   * Wraps a server call with the configured exponential-backoff retry strategy
+   * (Issue #502). All `this.server.*` invocations go through this helper so
+   * transient failures (rate-limits, timeouts, network blips) are automatically
+   * retried without callers needing to handle the logic themselves.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private serverCall(fn: () => Promise<any>): Promise<any> {
+    return retryWithBackoff(fn, this.retryConfig);
   }
 
   private get horizonServer(): Horizon.Server {
@@ -427,7 +442,7 @@ export class StellarGrantsSDK {
   }
 
   async getAccountSigners(accountId: string): Promise<any> {
-    return this.server.getAccount(accountId);
+    return this.serverCall(() => this.server.getAccount(accountId));
   }
 
   subscribeToEvents(
@@ -722,7 +737,8 @@ export class StellarGrantsSDK {
 
 
   async estimateFees(method: string, args: xdr.ScVal[], options?: { horizonUrl?: string; feePriority?: "low" | "medium" | "high"; simulatedFee?: string }): Promise<any> {
-    const simulation = await this.server.simulateTransaction(await this.buildTx(method, args, options));
+    const _txForEstimate = await this.buildTx(method, args, options);
+    const simulation = await this.serverCall(() => this.server.simulateTransaction(_txForEstimate));
     if (simulation?.error) {
       throw new StellarGrantsError(String(simulation.error));
     }
@@ -1108,7 +1124,7 @@ export class StellarGrantsSDK {
   private async invokeRead(method: string, args: xdr.ScVal[]): Promise<unknown> {
     try {
       const tx = await this.buildTx(method, args);
-      const simulation = await this.server.simulateTransaction(tx);
+      const simulation = await this.serverCall(() => this.server.simulateTransaction(tx));
       this.ensureSimulationSuccess(simulation);
       return this.parseSimulationResult(simulation);
     } catch (error) {
@@ -1123,7 +1139,7 @@ export class StellarGrantsSDK {
   ): Promise<unknown> {
     try {
       const tx = await this.buildTx(method, args, options);
-      const simulation = await this.server.simulateTransaction(tx);
+      const simulation = await this.serverCall(() => this.server.simulateTransaction(tx));
       this.ensureSimulationSuccess(simulation);
 
       const minResourceFee = BigInt(simulation?.minResourceFee ?? "0");
@@ -1140,7 +1156,7 @@ export class StellarGrantsSDK {
         ? await this.buildTx(method, args, { ...options, simulatedFee: desiredFee })
         : tx;
 
-      const prepared = await this.server.prepareTransaction(txForSending);
+      const prepared = await this.serverCall(() => this.server.prepareTransaction(txForSending));
 
       if (options?.returnUnsignedXdr) {
         const id =
@@ -1161,7 +1177,7 @@ export class StellarGrantsSDK {
       );
       const signedTx = TransactionBuilder.fromXDR(signedXdr, this.config.networkPassphrase);
 
-      const sent = await this.server.sendTransaction(signedTx);
+      const sent = await this.serverCall(() => this.server.sendTransaction(signedTx));
       if (sent.status === "ERROR") {
         throw new StellarGrantsError(`Send failed: ${sent.errorResult ?? "unknown error"}`);
       }
@@ -1196,7 +1212,7 @@ export class StellarGrantsSDK {
   async simulateFootprint(method: string, args: xdr.ScVal[]): Promise<any> {
     try {
       const tx = await this.buildTx(method, args);
-      const simulation = await this.server.simulateTransaction(tx);
+      const simulation = await this.serverCall(() => this.server.simulateTransaction(tx));
       this.ensureSimulationSuccess(simulation);
       return simulation?.transactionData ?? simulation?.footprint ?? null;
     } catch (error) {
@@ -1233,7 +1249,7 @@ export class StellarGrantsSDK {
     }
 
     const source = await signer.getPublicKey();
-    const account = await this.server.getAccount(source);
+    const account = await this.serverCall(() => this.server.getAccount(source));
     const fee = options?.fee ?? options?.simulatedFee ?? this.config.defaultFee ?? "100";
 
     let builder = new TransactionBuilder(account, {
@@ -1272,7 +1288,7 @@ export class StellarGrantsSDK {
   async __simulateBatch(calls: BatchCall[], options?: Omit<BatchSendOptions, "waitForConfirmation" | "returnUnsignedXdr">): Promise<any> {
     try {
       const tx = await this.__buildBatchTx(calls, options);
-      const simulation = await this.server.simulateTransaction(tx);
+      const simulation = await this.serverCall(() => this.server.simulateTransaction(tx));
       this.ensureSimulationSuccess(simulation);
 
       // Best-effort: if the RPC returns per-op results, surface the failing index.
@@ -1301,7 +1317,7 @@ export class StellarGrantsSDK {
   async __sendBatch(calls: BatchCall[], options?: BatchSendOptions): Promise<any> {
     try {
       const tx = await this.__buildBatchTx(calls, options);
-      const simulation = await this.server.simulateTransaction(tx);
+      const simulation = await this.serverCall(() => this.server.simulateTransaction(tx));
       this.ensureSimulationSuccess(simulation);
 
       const minResourceFee = BigInt(simulation?.minResourceFee ?? "0");
@@ -1316,7 +1332,7 @@ export class StellarGrantsSDK {
         ? await this.__buildBatchTx(calls, { ...options, simulatedFee: desiredFee })
         : tx;
 
-      const prepared = await this.server.prepareTransaction(txForSending);
+      const prepared = await this.serverCall(() => this.server.prepareTransaction(txForSending));
 
       if (options?.returnUnsignedXdr) {
         const id =
@@ -1336,7 +1352,7 @@ export class StellarGrantsSDK {
         this.config.networkPassphrase,
       );
       const signedTx = TransactionBuilder.fromXDR(signedXdr, this.config.networkPassphrase);
-      const sent = await this.server.sendTransaction(signedTx);
+      const sent = await this.serverCall(() => this.server.sendTransaction(signedTx));
       if (sent.status === "ERROR") {
         throw new StellarGrantsError(`Send failed: ${sent.errorResult ?? "unknown error"}`);
       }
@@ -1364,7 +1380,7 @@ export class StellarGrantsSDK {
     }
 
     const source = await signer.getPublicKey();
-    const account = await this.server.getAccount(source);
+    const account = await this.serverCall(() => this.server.getAccount(source));
     const fee = options?.fee ?? options?.simulatedFee ?? this.config.defaultFee ?? "100";
 
     let builder = new TransactionBuilder(account, {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -58,6 +58,20 @@ export type StellarGrantsSDKConfig = {
    */
   wallet?: WalletAdapter;
   defaultFee?: string;
+  /**
+   * Retry configuration for RPC calls (Issue #502).
+   * Controls exponential back-off behaviour when the Soroban RPC returns
+   * rate-limit (429) or transient timeout errors.
+   *
+   * @example
+   * ```ts
+   * const sdk = new StellarGrantsSDK({
+   *   retryConfig: { maxAttempts: 5, initialDelayMs: 500 },
+   *   ...
+   * });
+   * ```
+   */
+  retryConfig?: RetryConfig;
 };
 
 export type GrantCreateInput = {

--- a/client/src/utils/retry.ts
+++ b/client/src/utils/retry.ts
@@ -11,7 +11,11 @@ const DEFAULT_RETRY_CONFIG: Required<RetryConfig> = {
   retryOnRateLimit: true,
   retryOnTimeout: true,
   retryOnNetworkError: true,
-  onRetry: () => {},
+  onRetry: (attempt: number, error: Error, delayMs: number) => {
+    console.debug(
+      `[StellarGrants] RPC retry attempt ${attempt} after ${delayMs}ms — ${error.message}`,
+    );
+  },
 };
 
 /**

--- a/client/tests/sdk-proxy-retry.test.ts
+++ b/client/tests/sdk-proxy-retry.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for CORS/RPC proxy support (#495) and exponential back-off retry
+ * integration (#502) in StellarGrantsSDK.
+ */
+import { StellarGrantsSDK } from "../src/StellarGrantsSDK";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  class MockServer {
+    constructor() {}
+    async getAccount() {
+      return { accountId: "GTEST", sequence: "1" };
+    }
+    async simulateTransaction() {
+      return { result: { retval: { _mock: "ok" } } };
+    }
+    async prepareTransaction(tx: any) {
+      return tx;
+    }
+    async sendTransaction() {
+      return { status: "PENDING", hash: "abc123" };
+    }
+  }
+
+  return {
+    rpc: { Server: MockServer },
+    Horizon: {
+      Server: class {
+        constructor() {}
+      },
+    },
+    Contract: class {
+      constructor() {}
+      call(method: string, ...args: unknown[]) {
+        return { method, args };
+      }
+    },
+    TransactionBuilder: class {
+      static fromXDR() {
+        return { toXDR: () => "SIGNED_XDR", sign: () => {} };
+      }
+      constructor() {}
+      addOperation() {
+        return this;
+      }
+      setTimeout() {
+        return this;
+      }
+      build() {
+        return { toXDR: () => "TX_XDR" };
+      }
+    },
+    nativeToScVal: (value: unknown) => ({ value }),
+    scValToNative: () => ({ ok: true }),
+    xdr: {},
+  };
+});
+
+const TEST_CONTRACT = "CTEST_CONTRACT";
+const TEST_PASSPHRASE = "Test SDF Network ; September 2015";
+
+// ── CORS / Proxy (#495) ──────────────────────────────────────────────────────
+
+describe("CORS and RPC proxy support (#495)", () => {
+  it("constructs with rpcUrl alone", () => {
+    expect(
+      () =>
+        new StellarGrantsSDK({
+          contractId: TEST_CONTRACT,
+          rpcUrl: "https://soroban-testnet.stellar.org",
+          networkPassphrase: TEST_PASSPHRASE,
+        }),
+    ).not.toThrow();
+  });
+
+  it("constructs with proxyUrl instead of rpcUrl", () => {
+    expect(
+      () =>
+        new StellarGrantsSDK({
+          contractId: TEST_CONTRACT,
+          proxyUrl: "https://my-proxy.example.com/rpc",
+          networkPassphrase: TEST_PASSPHRASE,
+        }),
+    ).not.toThrow();
+  });
+
+  it("constructs with both proxyUrl and rpcUrl (proxy takes precedence)", () => {
+    expect(
+      () =>
+        new StellarGrantsSDK({
+          contractId: TEST_CONTRACT,
+          rpcUrl: "https://soroban-testnet.stellar.org",
+          proxyUrl: "https://proxy.corp.internal/stellar-rpc",
+          networkPassphrase: TEST_PASSPHRASE,
+        }),
+    ).not.toThrow();
+  });
+
+  it("constructs with customHeaders for authenticated RPC", () => {
+    expect(
+      () =>
+        new StellarGrantsSDK({
+          contractId: TEST_CONTRACT,
+          rpcUrl: "https://soroban-testnet.stellar.org",
+          customHeaders: {
+            Authorization: "Bearer my-jwt-token",
+            "X-Api-Key": "enterprise-key",
+          },
+          networkPassphrase: TEST_PASSPHRASE,
+        }),
+    ).not.toThrow();
+  });
+
+  it("allows http:// endpoints for CORS-proxy scenarios", () => {
+    expect(
+      () =>
+        new StellarGrantsSDK({
+          contractId: TEST_CONTRACT,
+          rpcUrl: "http://localhost:8000/rpc",
+          networkPassphrase: TEST_PASSPHRASE,
+        }),
+    ).not.toThrow();
+  });
+
+  it("throws when neither rpcUrl nor proxyUrl is provided", () => {
+    expect(
+      () =>
+        new StellarGrantsSDK({
+          contractId: TEST_CONTRACT,
+          networkPassphrase: TEST_PASSPHRASE,
+        } as any),
+    ).toThrow("Either rpcUrl or proxyUrl must be provided");
+  });
+});
+
+// ── Retry config (#502) ──────────────────────────────────────────────────────
+
+describe("Exponential backoff retry config (#502)", () => {
+  it("constructs when retryConfig is provided", () => {
+    expect(
+      () =>
+        new StellarGrantsSDK({
+          contractId: TEST_CONTRACT,
+          rpcUrl: "https://soroban-testnet.stellar.org",
+          networkPassphrase: TEST_PASSPHRASE,
+          retryConfig: { maxAttempts: 5, initialDelayMs: 500 },
+        }),
+    ).not.toThrow();
+  });
+
+  it("constructs without retryConfig (uses defaults)", () => {
+    expect(
+      () =>
+        new StellarGrantsSDK({
+          contractId: TEST_CONTRACT,
+          rpcUrl: "https://soroban-testnet.stellar.org",
+          networkPassphrase: TEST_PASSPHRASE,
+        }),
+    ).not.toThrow();
+  });
+
+  it("serverCall retries on 429 then succeeds", async () => {
+    const sdk = new StellarGrantsSDK({
+      contractId: TEST_CONTRACT,
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      networkPassphrase: TEST_PASSPHRASE,
+      retryConfig: { maxAttempts: 3, initialDelayMs: 0 },
+    });
+
+    let calls = 0;
+    const fn = jest.fn().mockImplementation(() => {
+      calls++;
+      if (calls < 2) return Promise.reject(new Error("429 Too Many Requests"));
+      return Promise.resolve("ok");
+    });
+
+    const result = await (sdk as any).serverCall(fn);
+    expect(result).toBe("ok");
+    expect(calls).toBe(2);
+  });
+
+  it("serverCall propagates hard failures immediately without retrying", async () => {
+    const sdk = new StellarGrantsSDK({
+      contractId: TEST_CONTRACT,
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      networkPassphrase: TEST_PASSPHRASE,
+      retryConfig: { maxAttempts: 3, initialDelayMs: 0 },
+    });
+
+    const fn = jest.fn().mockRejectedValue(new Error("Invalid signature"));
+    await expect((sdk as any).serverCall(fn)).rejects.toThrow("Invalid signature");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("serverCall exhausts retries and re-throws the last error", async () => {
+    const sdk = new StellarGrantsSDK({
+      contractId: TEST_CONTRACT,
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      networkPassphrase: TEST_PASSPHRASE,
+      retryConfig: { maxAttempts: 2, initialDelayMs: 0 },
+    });
+
+    const fn = jest.fn().mockRejectedValue(new Error("Server Busy"));
+    await expect((sdk as any).serverCall(fn)).rejects.toThrow("Server Busy");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/typedoc.json
+++ b/client/typedoc.json
@@ -4,5 +4,12 @@
   "tsconfig": "tsconfig.json",
   "plugin": [],
   "includeVersion": true,
-  "exclude": ["**/tests/**"]
+  "exclude": ["**/tests/**"],
+  "validation": {
+    "notExported": true,
+    "invalidLink": true,
+    "notDocumented": false
+  },
+  "treatWarningsAsErrors": false,
+  "readme": "none"
 }


### PR DESCRIPTION
… #499 #502 #505)

## Summary

This PR implements four SDK issues in the `client/` TypeScript SDK package:

- **#495 — CORS & RPC Proxy Support**: `proxyUrl` and `customHeaders` fields in `StellarGrantsSDKConfig` let the SDK work behind a CORS-proxy or authenticated RPC endpoint, with `http://` support for localhost proxy scenarios.
- **#499 — Automated SDK Documentation Generation**: `typedoc` added to devDependencies, `typedoc.json` configured with `src/index.ts` as the entry point and validation for exported symbols. The existing `client-docs` CI job builds and deploys docs on release.
- **#502 — Exponential Backoff & Retry Strategy for RPC**: `retryWithBackoff` and `withRetry` utilities in `src/utils/retry.ts` wrap every `this.server.*` invocation via the private `serverCall()` helper. Configurable via `retryConfig` in the SDK constructor. Default `onRetry` logs with `console.debug` for clear visibility during retries.
- **#505 — CLI for Developer Tasks**: `sg` binary powered by `commander`. Commands: `init` (scaffold `.env`), `grant-status` (read on-chain state), `fund-grant` (sign + submit fund tx). Credentials load from `.env` via `dotenv`; all overridable with flags. JSON and table output formats. Publishable via `npx`.

## Changes

```
client/
├── jest.config.js              # jest + ts-jest test runner
├── package.json                # SDK package with bin.sg, typedoc, commander, dotenv
├── tsconfig.json               # TypeScript strict config
├── typedoc.json                # TSDoc generation config with validation (#499)
├── src/
│   ├── index.ts                # Public exports
│   ├── StellarGrantsSDK.ts     # SDK class — proxyUrl, customHeaders, serverCall (#495 #502)
│   ├── cli.ts                  # Developer CLI (#505)
│   ├── types/index.ts          # StellarGrantsSDKConfig with proxyUrl, customHeaders, retryConfig
│   ├── utils/retry.ts          # retryWithBackoff + withRetry utilities (#502)
│   └── errors/StellarGrantsError.ts
└── tests/
    ├── sdk.test.ts             # CORS/proxy + retry config tests (#495 #502)
    ├── retry.test.ts           # Unit tests for retry utility (#502)
    └── cli.test.ts             # CLI config resolution tests (#505)
```

## Test plan

- [ ] `cd client && npm install && npm test` — all 30 tests pass
- [ ] Verify `sg init` creates a `.env` template
- [ ] Verify `StellarGrantsSDK` constructor accepts `proxyUrl`, `customHeaders`, and `retryConfig` without error
- [ ] Verify retry debug logs appear in console on transient RPC failures
- [ ] CI `client-sdk` job: `npm install` + `npm run test` passes
- [ ] CI `client-docs` job (release-only): `npx typedoc --options typedoc.json` builds docs to `docs/`

## Closes

Closes #495
Closes #499
Closes #502
Closes #505
