### PR TITLE
fix: wire up reviewer reward pool, fix grant pause tests, integrate bounty grants

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -558,9 +558,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/contracts/contracts/stellar-grants/src/auto_approve.rs
+++ b/contracts/contracts/stellar-grants/src/auto_approve.rs
@@ -31,8 +31,8 @@ pub fn try_auto_approve(
     grant_id: u64,
     milestone_idx: u32,
 ) -> Result<bool, ContractError> {
-    let config =
-        Storage::get_auto_approve_config(env, grant_id).ok_or(ContractError::AutoApproveNotEnabled)?;
+    let config = Storage::get_auto_approve_config(env, grant_id)
+        .ok_or(ContractError::AutoApproveNotEnabled)?;
 
     if !config.enabled {
         return Err(ContractError::AutoApproveNotEnabled);
@@ -44,8 +44,8 @@ pub fn try_auto_approve(
         return Err(ContractError::MilestoneIndexOutOfBounds);
     }
 
-    let milestone =
-        Storage::get_milestone(env, grant_id, milestone_idx).ok_or(ContractError::MilestoneNotFound)?;
+    let milestone = Storage::get_milestone(env, grant_id, milestone_idx)
+        .ok_or(ContractError::MilestoneNotFound)?;
 
     if milestone.state != MilestoneState::Submitted {
         return Ok(false);
@@ -60,7 +60,11 @@ pub fn try_auto_approve(
     let submission_time = milestone.submission_timestamp;
     let deadline = milestone.deadline.unwrap_or(0);
 
-    let effective_deadline = if deadline > 0 { deadline } else { submission_time };
+    let effective_deadline = if deadline > 0 {
+        deadline
+    } else {
+        submission_time
+    };
     let grace_end = effective_deadline.saturating_add(config.grace_period_seconds);
 
     if now < grace_end {
@@ -135,7 +139,11 @@ pub fn can_auto_approve(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
     let now = env.ledger().timestamp();
     let submission_time = milestone.submission_timestamp;
     let deadline = milestone.deadline.unwrap_or(0);
-    let effective_deadline = if deadline > 0 { deadline } else { submission_time };
+    let effective_deadline = if deadline > 0 {
+        deadline
+    } else {
+        submission_time
+    };
     let grace_end = effective_deadline.saturating_add(config.grace_period_seconds);
 
     if now < grace_end {

--- a/contracts/contracts/stellar-grants/src/batch_read.rs
+++ b/contracts/contracts/stellar-grants/src/batch_read.rs
@@ -54,7 +54,7 @@ pub fn grant_detail(env: &Env, grant_id: u64) -> Result<GrantDetailView, Contrac
         } else {
             milestones.push_back(Milestone {
                 idx,
-                description: soroban_sdk::String::from_str(&env, ""),
+                description: soroban_sdk::String::from_str(env, ""),
                 amount: grant.milestone_amount,
                 state: MilestoneState::Pending,
                 votes: soroban_sdk::Map::new(env),

--- a/contracts/contracts/stellar-grants/src/batch_read.rs
+++ b/contracts/contracts/stellar-grants/src/batch_read.rs
@@ -96,8 +96,7 @@ pub fn grant_detail(env: &Env, grant_id: u64) -> Result<GrantDetailView, Contrac
 
 /// Return all data needed for the protocol dashboard. Single RPC call.
 pub fn dashboard(env: &Env) -> DashboardView {
-    let active_grant_ids =
-        grant_index::by_status(env, crate::types::GrantStatus::Active, 0, 1000);
+    let active_grant_ids = grant_index::by_status(env, crate::types::GrantStatus::Active, 0, 1000);
     let active_grants = active_grant_ids.len();
 
     let protocol_metrics = get_or_default_metrics(env);
@@ -154,7 +153,9 @@ pub fn reviewer_dashboard(env: &Env, reviewer: &Address) -> ReviewerView {
             }
             for idx in 0..grant.total_milestones {
                 if let Some(ms) = Storage::get_milestone(env, grant_id, idx) {
-                    if ms.state == MilestoneState::Submitted && !ms.votes.contains_key(reviewer.clone()) {
+                    if ms.state == MilestoneState::Submitted
+                        && !ms.votes.contains_key(reviewer.clone())
+                    {
                         pending_votes.push_back((grant_id, idx));
                     }
                 }

--- a/contracts/contracts/stellar-grants/src/bounty.rs
+++ b/contracts/contracts/stellar-grants/src/bounty.rs
@@ -189,6 +189,15 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::{Address as _, Ledger};
 
+    fn with_contract(env: &Env, f: impl FnOnce()) {
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        env.as_contract(&contract_id, f);
+    }
+
+    fn with_contract_id(env: &Env, contract_id: &Address, f: impl FnOnce()) {
+        env.as_contract(contract_id, f);
+    }
+
     fn make_bounty(env: &Env, owner: &Address, token: &Address) -> u64 {
         Storage::next_bounty_id(env);
         let id = 1u64;
@@ -212,114 +221,134 @@ mod tests {
     fn test_submit_solution_to_unknown_bounty_rejected() {
         let env = Env::default();
         env.mock_all_auths();
-        let submitter = Address::generate(&env);
-        let result = submit_solution(&env, 999, &submitter, String::from_str(&env, "proof"));
-        assert_eq!(result, Err(ContractError::BountyNotFound));
+        with_contract(&env, || {
+            let submitter = Address::generate(&env);
+            let result = submit_solution(&env, 999, &submitter, String::from_str(&env, "proof"));
+            assert_eq!(result, Err(ContractError::BountyNotFound));
+        });
     }
 
     #[test]
     fn test_submit_solution_twice_rejected() {
         let env = Env::default();
         env.mock_all_auths();
-        let owner = Address::generate(&env);
-        let token = Address::generate(&env);
-        let submitter = Address::generate(&env);
-        let id = make_bounty(&env, &owner, &token);
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let token = Address::generate(&env);
+            let submitter = Address::generate(&env);
+            let id = make_bounty(&env, &owner, &token);
 
-        submit_solution(&env, id, &submitter, String::from_str(&env, "proof1")).unwrap();
-        let result = submit_solution(&env, id, &submitter, String::from_str(&env, "proof2"));
-        assert_eq!(result, Err(ContractError::AlreadyVoted));
+            submit_solution(&env, id, &submitter, String::from_str(&env, "proof1")).unwrap();
+            let result = submit_solution(&env, id, &submitter, String::from_str(&env, "proof2"));
+            assert_eq!(result, Err(ContractError::AlreadyVoted));
+        });
     }
 
     #[test]
     fn test_submit_solution_after_deadline_rejected() {
         let env = Env::default();
         env.mock_all_auths();
-        let owner = Address::generate(&env);
-        let token = Address::generate(&env);
-        let submitter = Address::generate(&env);
-        let id = make_bounty(&env, &owner, &token);
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        let mut id = 0u64;
+        with_contract_id(&env, &contract_id, || {
+            let owner = Address::generate(&env);
+            let token = Address::generate(&env);
+            id = make_bounty(&env, &owner, &token);
+        });
 
         env.ledger().with_mut(|l| {
             l.timestamp += 10_000;
         });
 
-        let result = submit_solution(&env, id, &submitter, String::from_str(&env, "proof"));
-        assert_eq!(result, Err(ContractError::SubmissionWindowClosed));
+        with_contract_id(&env, &contract_id, || {
+            let submitter = Address::generate(&env);
+            let result = submit_solution(&env, id, &submitter, String::from_str(&env, "proof"));
+            assert_eq!(result, Err(ContractError::SubmissionWindowClosed));
+        });
     }
 
     #[test]
     fn test_select_winner_unauthorized_caller_rejected() {
         let env = Env::default();
         env.mock_all_auths();
-        let owner = Address::generate(&env);
-        let token = Address::generate(&env);
-        let stranger = Address::generate(&env);
-        let submitter = Address::generate(&env);
-        let id = make_bounty(&env, &owner, &token);
-        submit_solution(&env, id, &submitter, String::from_str(&env, "proof")).unwrap();
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let token = Address::generate(&env);
+            let stranger = Address::generate(&env);
+            let submitter = Address::generate(&env);
+            let id = make_bounty(&env, &owner, &token);
+            submit_solution(&env, id, &submitter, String::from_str(&env, "proof")).unwrap();
 
-        let result = select_winner(&env, &stranger, id, &submitter);
-        assert_eq!(result, Err(ContractError::Unauthorized));
+            let result = select_winner(&env, &stranger, id, &submitter);
+            assert_eq!(result, Err(ContractError::Unauthorized));
+        });
     }
 
     #[test]
     fn test_select_winner_without_submission_rejected() {
         let env = Env::default();
         env.mock_all_auths();
-        let owner = Address::generate(&env);
-        let token = Address::generate(&env);
-        let non_submitter = Address::generate(&env);
-        let id = make_bounty(&env, &owner, &token);
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let token = Address::generate(&env);
+            let non_submitter = Address::generate(&env);
+            let id = make_bounty(&env, &owner, &token);
 
-        let result = select_winner(&env, &owner, id, &non_submitter);
-        assert_eq!(result, Err(ContractError::SubmissionNotFound));
+            let result = select_winner(&env, &owner, id, &non_submitter);
+            assert_eq!(result, Err(ContractError::SubmissionNotFound));
+        });
     }
 
     #[test]
     fn test_cancel_bounty_by_non_owner_rejected() {
         let env = Env::default();
         env.mock_all_auths();
-        let owner = Address::generate(&env);
-        let token = Address::generate(&env);
-        let stranger = Address::generate(&env);
-        let id = make_bounty(&env, &owner, &token);
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let token = Address::generate(&env);
+            let stranger = Address::generate(&env);
+            let id = make_bounty(&env, &owner, &token);
 
-        let result = cancel_bounty(&env, &stranger, id);
-        assert_eq!(result, Err(ContractError::Unauthorized));
+            let result = cancel_bounty(&env, &stranger, id);
+            assert_eq!(result, Err(ContractError::Unauthorized));
+        });
     }
 
     #[test]
     fn test_start_review_closes_to_new_submissions() {
         let env = Env::default();
         env.mock_all_auths();
-        let owner = Address::generate(&env);
-        let token = Address::generate(&env);
-        let submitter = Address::generate(&env);
-        let id = make_bounty(&env, &owner, &token);
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let token = Address::generate(&env);
+            let submitter = Address::generate(&env);
+            let id = make_bounty(&env, &owner, &token);
 
-        start_review(&env, &owner, id).unwrap();
-        let bounty = get_bounty(&env, id).unwrap();
-        assert_eq!(bounty.status, BountyStatus::UnderReview);
+            start_review(&env, &owner, id).unwrap();
+            let bounty = get_bounty(&env, id).unwrap();
+            assert_eq!(bounty.status, BountyStatus::UnderReview);
 
-        let result = submit_solution(&env, id, &submitter, String::from_str(&env, "proof"));
-        assert_eq!(result, Err(ContractError::BountyNotOpen));
+            let result = submit_solution(&env, id, &submitter, String::from_str(&env, "proof"));
+            assert_eq!(result, Err(ContractError::BountyNotOpen));
+        });
     }
 
     #[test]
     fn test_list_submitters_tracks_all_entrants() {
         let env = Env::default();
         env.mock_all_auths();
-        let owner = Address::generate(&env);
-        let token = Address::generate(&env);
-        let s1 = Address::generate(&env);
-        let s2 = Address::generate(&env);
-        let id = make_bounty(&env, &owner, &token);
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let token = Address::generate(&env);
+            let s1 = Address::generate(&env);
+            let s2 = Address::generate(&env);
+            let id = make_bounty(&env, &owner, &token);
 
-        submit_solution(&env, id, &s1, String::from_str(&env, "p1")).unwrap();
-        submit_solution(&env, id, &s2, String::from_str(&env, "p2")).unwrap();
+            submit_solution(&env, id, &s1, String::from_str(&env, "p1")).unwrap();
+            submit_solution(&env, id, &s2, String::from_str(&env, "p2")).unwrap();
 
-        let submitters = list_submitters(&env, id);
-        assert_eq!(submitters.len(), 2);
+            let submitters = list_submitters(&env, id);
+            assert_eq!(submitters.len(), 2);
+        });
     }
 }

--- a/contracts/contracts/stellar-grants/src/clawback.rs
+++ b/contracts/contracts/stellar-grants/src/clawback.rs
@@ -79,8 +79,8 @@ pub fn approve(
 ) -> Result<(), ContractError> {
     approver.require_auth();
 
-    let mut clawback = Storage::get_clawback(env, grant_id, milestone_idx)
-        .ok_or(ContractError::InvalidState)?;
+    let mut clawback =
+        Storage::get_clawback(env, grant_id, milestone_idx).ok_or(ContractError::InvalidState)?;
 
     // Check status
     if clawback.status != ClawbackStatus::Pending {
@@ -124,8 +124,8 @@ pub fn dispute(
 ) -> Result<(), ContractError> {
     contributor.require_auth();
 
-    let mut clawback = Storage::get_clawback(env, grant_id, milestone_idx)
-        .ok_or(ContractError::InvalidState)?;
+    let mut clawback =
+        Storage::get_clawback(env, grant_id, milestone_idx).ok_or(ContractError::InvalidState)?;
 
     // Verify contributor is the target
     if clawback.target != *contributor {
@@ -166,8 +166,8 @@ pub fn execute(
 ) -> Result<i128, ContractError> {
     caller.require_auth();
 
-    let mut clawback = Storage::get_clawback(env, grant_id, milestone_idx)
-        .ok_or(ContractError::InvalidState)?;
+    let mut clawback =
+        Storage::get_clawback(env, grant_id, milestone_idx).ok_or(ContractError::InvalidState)?;
 
     // Check status - must be Approved
     if clawback.status != ClawbackStatus::Approved {
@@ -230,8 +230,8 @@ pub fn cancel(
         return Err(ContractError::Unauthorized);
     }
 
-    let mut clawback = Storage::get_clawback(env, grant_id, milestone_idx)
-        .ok_or(ContractError::InvalidState)?;
+    let mut clawback =
+        Storage::get_clawback(env, grant_id, milestone_idx).ok_or(ContractError::InvalidState)?;
 
     // Cannot cancel if already executed
     if clawback.status == ClawbackStatus::Executed {
@@ -447,9 +447,8 @@ mod tests {
         approve(&env, &arbiter, 1, 0).unwrap();
 
         // Advance time past dispute window
-        env.ledger().set_timestamp(
-            env.ledger().timestamp() + CLAWBACK_DISPUTE_WINDOW_SECONDS + 1,
-        );
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + CLAWBACK_DISPUTE_WINDOW_SECONDS + 1);
 
         // Contributor disputes - should fail
         let result = dispute(&env, &owner, 1, 0);
@@ -516,9 +515,8 @@ mod tests {
         approve(&env, &arbiter, 1, 0).unwrap();
 
         // Advance time past dispute window
-        env.ledger().set_timestamp(
-            env.ledger().timestamp() + CLAWBACK_DISPUTE_WINDOW_SECONDS + 1,
-        );
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + CLAWBACK_DISPUTE_WINDOW_SECONDS + 1);
 
         // Execute should succeed
         let result = execute(&env, &admin, 1, 0);
@@ -586,9 +584,8 @@ mod tests {
         approve(&env, &arbiter, 1, 0).unwrap();
 
         // Advance time past dispute window
-        env.ledger().set_timestamp(
-            env.ledger().timestamp() + CLAWBACK_DISPUTE_WINDOW_SECONDS + 1,
-        );
+        env.ledger()
+            .set_timestamp(env.ledger().timestamp() + CLAWBACK_DISPUTE_WINDOW_SECONDS + 1);
 
         execute(&env, &admin, 1, 0).unwrap();
 

--- a/contracts/contracts/stellar-grants/src/conditional_release.rs
+++ b/contracts/contracts/stellar-grants/src/conditional_release.rs
@@ -34,11 +34,7 @@ pub fn attach_conditions(
 }
 
 /// Check all conditions for a milestone. Returns detailed results per condition.
-pub fn check_conditions(
-    env: &Env,
-    grant_id: u64,
-    milestone_idx: u32,
-) -> Vec<ConditionResult> {
+pub fn check_conditions(env: &Env, grant_id: u64, milestone_idx: u32) -> Vec<ConditionResult> {
     let conditions = Storage::get_release_conditions(env, grant_id, milestone_idx);
     let mut results = Vec::new(env);
 
@@ -68,11 +64,7 @@ pub fn all_conditions_met(env: &Env, grant_id: u64, milestone_idx: u32) -> bool 
 }
 
 /// Return the conditions attached to a milestone.
-pub fn get_conditions(
-    env: &Env,
-    grant_id: u64,
-    milestone_idx: u32,
-) -> Vec<ReleaseCondition> {
+pub fn get_conditions(env: &Env, grant_id: u64, milestone_idx: u32) -> Vec<ReleaseCondition> {
     Storage::get_release_conditions(env, grant_id, milestone_idx)
 }
 

--- a/contracts/contracts/stellar-grants/src/escrow_multisig.rs
+++ b/contracts/contracts/stellar-grants/src/escrow_multisig.rs
@@ -1,10 +1,16 @@
-use soroban_sdk::{Address, Env, Vec};
-use crate::types::{ContractError, EscrowReleaseRequest, EscrowReleaseApproval, ProtocolConfig};
 use crate::storage::keys::DataKey;
+use crate::types::{ContractError, EscrowReleaseApproval, EscrowReleaseRequest, ProtocolConfig};
+use soroban_sdk::{Address, Env, Vec};
 
 const SECONDS_PER_WEEK: u64 = 604800;
 
-pub fn create_request(env: &Env, grant_id: u64, milestone_idx: u32, amount: i128, recipient: Address) -> Result<(), ContractError> {
+pub fn create_request(
+    env: &Env,
+    grant_id: u64,
+    milestone_idx: u32,
+    amount: i128,
+    recipient: Address,
+) -> Result<(), ContractError> {
     let key = DataKey::EscrowReleaseRequest(grant_id, milestone_idx);
     let expires_at = env.ledger().timestamp() + (SECONDS_PER_WEEK * 2);
     let request = EscrowReleaseRequest {
@@ -20,37 +26,50 @@ pub fn create_request(env: &Env, grant_id: u64, milestone_idx: u32, amount: i128
     Ok(())
 }
 
-pub fn approve(env: &Env, approver: Address, grant_id: u64, milestone_idx: u32) -> Result<(), ContractError> {
+pub fn approve(
+    env: &Env,
+    approver: Address,
+    grant_id: u64,
+    milestone_idx: u32,
+) -> Result<(), ContractError> {
     approver.require_auth();
     // Use ContractError::NotFound, but wait, types.rs has ContractError::GrantNotFound or similar? We can just use ContractError::InvalidState or whatever.
     // I'll use ContractError::InvalidState if not found since there is no EscrowRequestNotFound.
-    let mut request = get_request(env, grant_id, milestone_idx).ok_or(ContractError::InvalidState)?;
-    
+    let mut request =
+        get_request(env, grant_id, milestone_idx).ok_or(ContractError::InvalidState)?;
+
     if request.executed {
         return Err(ContractError::InvalidState);
     }
     if env.ledger().timestamp() > request.expires_at {
         return Err(ContractError::InvalidState);
     }
-    
+
     for approval in request.approvals.iter() {
         if approval.approver == approver {
             return Err(ContractError::AlreadyVoted);
         }
     }
-    
+
     request.approvals.push_back(EscrowReleaseApproval {
         approver: approver.clone(),
         timestamp: env.ledger().timestamp(),
     });
-    
-    env.storage().persistent().set(&DataKey::EscrowReleaseRequest(grant_id, milestone_idx), &request);
+
+    env.storage().persistent().set(
+        &DataKey::EscrowReleaseRequest(grant_id, milestone_idx),
+        &request,
+    );
     Ok(())
 }
 
 pub fn is_approved(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
     if let Some(request) = get_request(env, grant_id, milestone_idx) {
-        if let Some(config) = env.storage().persistent().get::<DataKey, ProtocolConfig>(&DataKey::Config) {
+        if let Some(config) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, ProtocolConfig>(&DataKey::Config)
+        {
             let threshold = config.multisig_escrow_threshold;
             return request.approvals.len() >= threshold;
         }
@@ -59,25 +78,31 @@ pub fn is_approved(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
 }
 
 pub fn execute_release(env: &Env, grant_id: u64, milestone_idx: u32) -> Result<(), ContractError> {
-    let mut request = get_request(env, grant_id, milestone_idx).ok_or(ContractError::InvalidState)?;
-    
+    let mut request =
+        get_request(env, grant_id, milestone_idx).ok_or(ContractError::InvalidState)?;
+
     if request.executed {
         return Err(ContractError::InvalidState);
     }
     if env.ledger().timestamp() > request.expires_at {
         return Err(ContractError::InvalidState);
     }
-    
+
     if !is_approved(env, grant_id, milestone_idx) {
         return Err(ContractError::Unauthorized);
     }
-    
+
     request.executed = true;
-    env.storage().persistent().set(&DataKey::EscrowReleaseRequest(grant_id, milestone_idx), &request);
-    
+    env.storage().persistent().set(
+        &DataKey::EscrowReleaseRequest(grant_id, milestone_idx),
+        &request,
+    );
+
     crate::escrow::release(env, grant_id, &request.recipient, request.amount)
 }
 
 pub fn get_request(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<EscrowReleaseRequest> {
-    env.storage().persistent().get(&DataKey::EscrowReleaseRequest(grant_id, milestone_idx))
+    env.storage()
+        .persistent()
+        .get(&DataKey::EscrowReleaseRequest(grant_id, milestone_idx))
 }

--- a/contracts/contracts/stellar-grants/src/events.rs
+++ b/contracts/contracts/stellar-grants/src/events.rs
@@ -727,12 +727,7 @@ impl Events {
         event.publish(env);
     }
 
-    pub fn emit_clawback_approved(
-        env: &Env,
-        grant_id: u64,
-        milestone_idx: u32,
-        approver: Address,
-    ) {
+    pub fn emit_clawback_approved(env: &Env, grant_id: u64, milestone_idx: u32, approver: Address) {
         let event = ClawbackApproved {
             grant_id,
             milestone_idx,
@@ -1593,12 +1588,7 @@ impl Events {
 
     // ── Waitlist events ───────────────────────────────────────────────────────
 
-    pub fn emit_waitlist_joined(
-        env: &Env,
-        grant_id: u64,
-        applicant: Address,
-        position: u32,
-    ) {
+    pub fn emit_waitlist_joined(env: &Env, grant_id: u64, applicant: Address, position: u32) {
         let event = WaitlistJoined {
             grant_id,
             applicant,
@@ -1608,12 +1598,7 @@ impl Events {
         event.publish(env);
     }
 
-    pub fn emit_waitlist_promoted(
-        env: &Env,
-        grant_id: u64,
-        applicant: Address,
-        position: u32,
-    ) {
+    pub fn emit_waitlist_promoted(env: &Env, grant_id: u64, applicant: Address, position: u32) {
         let event = WaitlistPromoted {
             grant_id,
             applicant,
@@ -1623,11 +1608,7 @@ impl Events {
         event.publish(env);
     }
 
-    pub fn emit_waitlist_left(
-        env: &Env,
-        grant_id: u64,
-        applicant: Address,
-    ) {
+    pub fn emit_waitlist_left(env: &Env, grant_id: u64, applicant: Address) {
         let event = WaitlistLeft {
             grant_id,
             applicant,

--- a/contracts/contracts/stellar-grants/src/fees.rs
+++ b/contracts/contracts/stellar-grants/src/fees.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{token, Address, Env};
 
-use crate::events::Events;
+use crate::config;
 use crate::storage::Storage;
 use crate::types::ContractError;
 
@@ -13,6 +13,59 @@ pub fn compute_fee(gross: i128, fee_bps: u32) -> Result<i128, ContractError> {
     crate::math::basis_points_of(gross, fee_bps)
 }
 
+/// Compute net amount after protocol fee deduction.
+pub fn net_of_fee(gross: i128, fee_bps: u32) -> Result<i128, ContractError> {
+    let fee = compute_fee(gross, fee_bps)?;
+    gross.checked_sub(fee).ok_or(ContractError::InvalidInput)
+}
+
+/// Deduct protocol fee from a gross milestone amount, split it among the
+/// reviewer-reward pool, the staker revenue-share pool, and the treasury,
+/// then return the net amount payable to the grant recipient.
+///
+/// Called automatically by the payment flow in `lib.rs`.
+pub fn deduct_and_split_fee(
+    env: &Env,
+    token: &Address,
+    gross_amount: i128,
+) -> Result<i128, ContractError> {
+    if gross_amount <= 0 {
+        return Ok(0);
+    }
+
+    let cfg = config::get_config(env);
+    let total_fee = compute_fee(gross_amount, cfg.protocol_fee_bps)?;
+    if total_fee <= 0 {
+        return Ok(gross_amount);
+    }
+
+    // Split the fee according to reviewer_reward_pool_bps and revenue_share_pool_bps.
+    // The remaining portion stays with the protocol (treasury, collected as fees).
+    let reviewer_share =
+        crate::math::basis_points_of(total_fee, cfg.reviewer_reward_pool_bps)?;
+    let revenue_share =
+        crate::math::basis_points_of(total_fee, cfg.revenue_share_pool_bps)?;
+    let treasury_share = total_fee
+        .checked_sub(reviewer_share)
+        .and_then(|r| r.checked_sub(revenue_share))
+        .ok_or(ContractError::InvalidInput)?;
+
+    if reviewer_share > 0 {
+        crate::reviewer_reward::fund_pool(env, token, reviewer_share);
+    }
+    if revenue_share > 0 {
+        crate::revenue_share::deposit_revenue(env, token, revenue_share);
+    }
+    if treasury_share > 0 {
+        Storage::add_fees_collected(env, token, treasury_share);
+    }
+
+    let net = gross_amount
+        .checked_sub(total_fee)
+        .ok_or(ContractError::InvalidInput)?;
+    Ok(net)
+}
+
 pub fn total_fees_collected(env: &Env, token: &Address) -> i128 {
     Storage::get_fees_collected(env, token)
 }
@@ -20,6 +73,9 @@ pub fn total_fees_collected(env: &Env, token: &Address) -> i128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::default_config;
+    use crate::storage::keys::{DataKey, ReviewerRewardKey};
+    use crate::types::{ProtocolConfig, ReviewerRewardPool};
     use soroban_sdk::testutils::{Address as _, Ledger};
     use soroban_sdk::Env;
 
@@ -51,5 +107,124 @@ mod tests {
     fn test_fee_accumulation_across_calls() {
         assert_eq!(compute_fee(1_000_000, 100).unwrap(), 10_000);
         assert_eq!(compute_fee(2_000_000, 100).unwrap(), 20_000);
+    }
+
+    #[test]
+    fn test_net_of_fee_subtracts_correctly() {
+        let net = net_of_fee(1_000_000, 100).unwrap();
+        assert_eq!(net, 990_000);
+    }
+
+    #[test]
+    fn test_deduct_and_split_fee_respects_reviewer_reward_split() {
+        let env = Env::default();
+        let token = Address::generate(&env);
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+
+        env.as_contract(&contract_id, || {
+            // Set a config with 10% protocol fee, 50% to reviewer reward pool
+            let mut cfg = default_config();
+            cfg.protocol_fee_bps = 1000; // 10%
+            cfg.reviewer_reward_pool_bps = 5000; // 50% of fee -> reviewer pool
+            cfg.revenue_share_pool_bps = 0;
+            Storage::set_protocol_config(&env, &cfg);
+
+            let gross: i128 = 1_000_000;
+            let net = deduct_and_split_fee(&env, &token, gross).unwrap();
+
+            // 10% fee = 100_000
+            // 50% of fee = 50_000 to reviewer pool
+            assert_eq!(net, 900_000);
+
+            let pool_key = DataKey::ReviewerReward(ReviewerRewardKey::Pool(token.clone()));
+            let pool: ReviewerRewardPool = env
+                .storage()
+                .persistent()
+                .get(&pool_key)
+                .expect("pool should exist");
+            assert_eq!(pool.balance, 50_000);
+
+            // The other 50_000 goes to treasury fees collected
+            let treasury_fees = Storage::get_fees_collected(&env, &token);
+            assert_eq!(treasury_fees, 50_000);
+        });
+    }
+
+    #[test]
+    fn test_deduct_and_split_fee_respects_both_splits() {
+        let env = Env::default();
+        let token = Address::generate(&env);
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+
+        env.as_contract(&contract_id, || {
+            let mut cfg = default_config();
+            cfg.protocol_fee_bps = 1000; // 10%
+            cfg.reviewer_reward_pool_bps = 3000; // 30% of fee -> reviewer
+            cfg.revenue_share_pool_bps = 2000; // 20% of fee -> revenue share
+            Storage::set_protocol_config(&env, &cfg);
+
+            let gross: i128 = 1_000_000;
+            let net = deduct_and_split_fee(&env, &token, gross).unwrap();
+
+            // 10% fee = 100_000
+            // 30% of fee = 30_000 to reviewer
+            // 20% of fee = 20_000 to revenue share
+            // 50% of fee = 50_000 to treasury
+            assert_eq!(net, 900_000);
+
+            let pool_key = DataKey::ReviewerReward(ReviewerRewardKey::Pool(token.clone()));
+            let pool: ReviewerRewardPool = env
+                .storage()
+                .persistent()
+                .get(&pool_key)
+                .expect("pool should exist");
+            assert_eq!(pool.balance, 30_000);
+
+            let treasury_fees = Storage::get_fees_collected(&env, &token);
+            assert_eq!(treasury_fees, 50_000);
+        });
+    }
+
+    #[test]
+    fn test_deduct_and_split_zero_fee_no_ops() {
+        let env = Env::default();
+        let token = Address::generate(&env);
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+
+        env.as_contract(&contract_id, || {
+            let mut cfg = default_config();
+            cfg.protocol_fee_bps = 0;
+            Storage::set_protocol_config(&env, &cfg);
+
+            let net = deduct_and_split_fee(&env, &token, 1_000_000).unwrap();
+            assert_eq!(net, 1_000_000);
+        });
+    }
+
+    #[test]
+    fn test_deduct_and_split_no_revenue_share_leaves_more_to_treasury() {
+        let env = Env::default();
+        let token = Address::generate(&env);
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+
+        env.as_contract(&contract_id, || {
+            let mut cfg = default_config();
+            cfg.protocol_fee_bps = 500; // 5%
+            cfg.reviewer_reward_pool_bps = 2000; // 20% of fee -> reviewer
+            cfg.revenue_share_pool_bps = 0; // 0% to revenue share
+            Storage::set_protocol_config(&env, &cfg);
+
+            let gross: i128 = 100_000;
+            let net = deduct_and_split_fee(&env, &token, gross).unwrap();
+
+            // 5% fee = 5000
+            // 20% of fee = 1000 to reviewer
+            // 0% to revenue share
+            // 80% = 4000 to treasury
+            assert_eq!(net, 95_000);
+
+            let treasury_fees = Storage::get_fees_collected(&env, &token);
+            assert_eq!(treasury_fees, 4000);
+        });
     }
 }

--- a/contracts/contracts/stellar-grants/src/fees.rs
+++ b/contracts/contracts/stellar-grants/src/fees.rs
@@ -41,10 +41,8 @@ pub fn deduct_and_split_fee(
 
     // Split the fee according to reviewer_reward_pool_bps and revenue_share_pool_bps.
     // The remaining portion stays with the protocol (treasury, collected as fees).
-    let reviewer_share =
-        crate::math::basis_points_of(total_fee, cfg.reviewer_reward_pool_bps)?;
-    let revenue_share =
-        crate::math::basis_points_of(total_fee, cfg.revenue_share_pool_bps)?;
+    let reviewer_share = crate::math::basis_points_of(total_fee, cfg.reviewer_reward_pool_bps)?;
+    let revenue_share = crate::math::basis_points_of(total_fee, cfg.revenue_share_pool_bps)?;
     let treasury_share = total_fee
         .checked_sub(reviewer_share)
         .and_then(|r| r.checked_sub(revenue_share))

--- a/contracts/contracts/stellar-grants/src/grant_bridge.rs
+++ b/contracts/contracts/stellar-grants/src/grant_bridge.rs
@@ -1,62 +1,86 @@
-use soroban_sdk::{Address, Env, String, Vec};
-use crate::types::{ChainId, BridgeRelayer, CrossChainProof, ContractError};
 use crate::storage::keys::DataKey;
+use crate::types::{BridgeRelayer, ChainId, ContractError, CrossChainProof};
+use soroban_sdk::{Address, Env, String, Vec};
 
-pub fn register_relayer(env: &Env, admin: &Address, relayer: Address, authorized_chains: Vec<ChainId>) -> Result<(), ContractError> {
+pub fn register_relayer(
+    env: &Env,
+    admin: &Address,
+    relayer: Address,
+    authorized_chains: Vec<ChainId>,
+) -> Result<(), ContractError> {
     admin.require_auth();
     if crate::storage::helpers::Storage::get_global_admin(env) != Some(admin.clone()) {
         return Err(ContractError::Unauthorized);
     }
-    
+
     let record = BridgeRelayer {
         address: relayer.clone(),
         is_active: true,
         registered_at: env.ledger().timestamp(),
         authorized_chains,
     };
-    
-    env.storage().persistent().set(&DataKey::BridgeRelayer(relayer), &record);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::BridgeRelayer(relayer), &record);
     Ok(())
 }
 
-pub fn deactivate_relayer(env: &Env, admin: &Address, relayer: Address) -> Result<(), ContractError> {
+pub fn deactivate_relayer(
+    env: &Env,
+    admin: &Address,
+    relayer: Address,
+) -> Result<(), ContractError> {
     admin.require_auth();
     if crate::storage::helpers::Storage::get_global_admin(env) != Some(admin.clone()) {
         return Err(ContractError::Unauthorized);
     }
-    
-    let mut record = get_relayer(env, &relayer).ok_or(ContractError::InvalidState)?; 
+
+    let mut record = get_relayer(env, &relayer).ok_or(ContractError::InvalidState)?;
     record.is_active = false;
-    
-    env.storage().persistent().set(&DataKey::BridgeRelayer(relayer), &record);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::BridgeRelayer(relayer), &record);
     Ok(())
 }
 
-pub fn submit_proof(env: &Env, relayer: Address, grant_id: u64, milestone_idx: u32, chain_id: ChainId, tx_hash: String) -> Result<(), ContractError> {
+pub fn submit_proof(
+    env: &Env,
+    relayer: Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    chain_id: ChainId,
+    tx_hash: String,
+) -> Result<(), ContractError> {
     relayer.require_auth();
-    let record = get_relayer(env, &relayer).ok_or(ContractError::Unauthorized)?; 
-    
+    let record = get_relayer(env, &relayer).ok_or(ContractError::Unauthorized)?;
+
     if !record.is_active {
         return Err(ContractError::Unauthorized);
     }
-    
+
     if !record.authorized_chains.contains(chain_id.clone()) {
         return Err(ContractError::Unauthorized);
     }
-    
+
     let proof = CrossChainProof {
         chain_id,
         tx_hash,
         relayer: relayer.clone(),
         verified_at: env.ledger().timestamp(),
     };
-    
-    env.storage().persistent().set(&DataKey::CrossChainProof(grant_id, milestone_idx), &proof);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::CrossChainProof(grant_id, milestone_idx), &proof);
     Ok(())
 }
 
 pub fn get_proof(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<CrossChainProof> {
-    env.storage().persistent().get(&DataKey::CrossChainProof(grant_id, milestone_idx))
+    env.storage()
+        .persistent()
+        .get(&DataKey::CrossChainProof(grant_id, milestone_idx))
 }
 
 pub fn has_valid_proof(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
@@ -69,5 +93,7 @@ pub fn has_valid_proof(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
 }
 
 pub fn get_relayer(env: &Env, relayer: &Address) -> Option<BridgeRelayer> {
-    env.storage().persistent().get(&DataKey::BridgeRelayer(relayer.clone()))
+    env.storage()
+        .persistent()
+        .get(&DataKey::BridgeRelayer(relayer.clone()))
 }

--- a/contracts/contracts/stellar-grants/src/grant_pause.rs
+++ b/contracts/contracts/stellar-grants/src/grant_pause.rs
@@ -25,7 +25,6 @@ pub fn pause(env: &Env, caller: &Address, grant_id: u64, reason: String, auto_un
     record.reason = reason;
     record.auto_unpause_at = auto_unpause_at;
     
-    // Clear auto_unpause_at if it was previously set to a past time to unpause
     if let Some(time) = auto_unpause_at {
         if time <= env.ledger().timestamp() {
              record.auto_unpause_at = None;
@@ -48,7 +47,7 @@ pub fn unpause(env: &Env, caller: &Address, grant_id: u64) -> Result<(), Contrac
     if let Some(mut record) = get_record(env, grant_id) {
         let now = env.ledger().timestamp();
         record.unpause_history.push_back((caller.clone(), now));
-        record.auto_unpause_at = Some(now); // Setting this to now unpauses it
+        record.auto_unpause_at = Some(now);
         env.storage().persistent().set(&key, &record);
     }
     env.events().publish((Symbol::new(env, "grant_unpaused"), grant_id), caller.clone());
@@ -83,11 +82,8 @@ pub fn try_auto_unpause(env: &Env, grant_id: u64) -> bool {
         if let Some(auto_unpause) = record.auto_unpause_at {
             let now = env.ledger().timestamp();
             if now >= auto_unpause {
-                // Add to history
-                // We use the contract address as the unpauser if it's auto
                 let contract_address = env.current_contract_address();
                 record.unpause_history.push_back((contract_address, now));
-                // It's already unpaused logically by time, but we just save the history update
                 env.storage().persistent().set(&DataKey::GrantPaused(grant_id), &record);
                 env.events().publish((Symbol::new(env, "grant_unpaused"), grant_id), auto_unpause);
                 return true;
@@ -95,4 +91,215 @@ pub fn try_auto_unpause(env: &Env, grant_id: u64) -> bool {
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Grant;
+    use crate::storage::Storage;
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Env, String, Vec};
+
+    fn with_contract(env: &Env, f: impl FnOnce()) {
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        env.as_contract(&contract_id, f);
+    }
+
+    fn with_contract_id(env: &Env, contract_id: &Address, f: impl FnOnce()) {
+        env.as_contract(contract_id, f);
+    }
+
+    fn setup_grant(env: &Env, owner: &Address, grant_id: u64) {
+        let grant = Grant {
+            id: grant_id,
+            owner: owner.clone(),
+            title: String::from_str(env, "Test Grant"),
+            description: String::from_str(env, "desc"),
+            token: Address::generate(env),
+            total_amount: 1000,
+            milestone_amount: 500,
+            reviewers: Vec::new(env),
+            total_milestones: 3,
+            milestones_paid_out: 0,
+            escrow_balance: 0,
+            funders: Vec::new(env),
+            reason: None,
+            status: crate::types::GrantStatus::Active,
+            timestamp: env.ledger().timestamp(),
+            require_compliance: None,
+        };
+        Storage::set_grant(env, grant_id, &grant);
+    }
+
+    #[test]
+    fn test_only_owner_can_pause() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let stranger = Address::generate(&env);
+            let grant_id = 1;
+            setup_grant(&env, &owner, grant_id);
+
+            let result = pause(
+                &env,
+                &stranger,
+                grant_id,
+                String::from_str(&env, "test"),
+                None,
+            );
+            assert_eq!(result, Err(ContractError::Unauthorized));
+        });
+    }
+
+    #[test]
+    fn test_only_owner_can_unpause() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let stranger = Address::generate(&env);
+            let grant_id = 1;
+            setup_grant(&env, &owner, grant_id);
+
+            pause(
+                &env,
+                &owner,
+                grant_id,
+                String::from_str(&env, "reason"),
+                None,
+            )
+            .unwrap();
+
+            let result = unpause(&env, &stranger, grant_id);
+            assert_eq!(result, Err(ContractError::Unauthorized));
+        });
+    }
+
+    #[test]
+    fn test_pause_and_unpause_flow() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        let grant_id = 1;
+        let owner = Address::generate(&env);
+
+        with_contract_id(&env, &contract_id, || {
+            setup_grant(&env, &owner, grant_id);
+            assert!(!is_paused(&env, grant_id));
+
+            pause(
+                &env,
+                &owner,
+                grant_id,
+                String::from_str(&env, "maintenance"),
+                None,
+            )
+            .unwrap();
+            assert!(is_paused(&env, grant_id));
+        });
+
+        with_contract_id(&env, &contract_id, || {
+            unpause(&env, &owner, grant_id).unwrap();
+            assert!(!is_paused(&env, grant_id));
+        });
+    }
+
+    #[test]
+    fn test_require_not_paused_blocks_when_paused() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let grant_id = 1;
+            setup_grant(&env, &owner, grant_id);
+
+            assert!(require_not_paused(&env, grant_id).is_ok());
+
+            pause(
+                &env,
+                &owner,
+                grant_id,
+                String::from_str(&env, "test"),
+                None,
+            )
+            .unwrap();
+            assert_eq!(
+                require_not_paused(&env, grant_id),
+                Err(ContractError::ContractPaused)
+            );
+        });
+    }
+
+    #[test]
+    fn test_auto_unpause_elapsed_is_paused_false() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        let grant_id = 1;
+        let now = env.ledger().timestamp();
+        let future = now + 100;
+
+        with_contract_id(&env, &contract_id, || {
+            let owner = Address::generate(&env);
+            setup_grant(&env, &owner, grant_id);
+
+            pause(
+                &env,
+                &owner,
+                grant_id,
+                String::from_str(&env, "auto"),
+                Some(future),
+            )
+            .unwrap();
+            assert!(is_paused(&env, grant_id));
+        });
+
+        env.ledger().set_timestamp(future + 1);
+
+        with_contract_id(&env, &contract_id, || {
+            assert!(!is_paused(&env, grant_id));
+        });
+    }
+
+    #[test]
+    fn test_try_auto_unpause_records_history() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        let grant_id = 1;
+        let now = env.ledger().timestamp();
+        let future = now + 100;
+
+        with_contract_id(&env, &contract_id, || {
+            let owner = Address::generate(&env);
+            setup_grant(&env, &owner, grant_id);
+
+            pause(
+                &env,
+                &owner,
+                grant_id,
+                String::from_str(&env, "auto"),
+                Some(future),
+            )
+            .unwrap();
+        });
+
+        env.ledger().set_timestamp(future + 1);
+
+        with_contract_id(&env, &contract_id, || {
+            let result = try_auto_unpause(&env, grant_id);
+            assert!(result);
+
+            let record = get_record(&env, grant_id).unwrap();
+            assert_eq!(record.unpause_history.len(), 1);
+        });
+    }
 }

--- a/contracts/contracts/stellar-grants/src/grant_pause.rs
+++ b/contracts/contracts/stellar-grants/src/grant_pause.rs
@@ -1,15 +1,21 @@
-use soroban_sdk::{Address, Env, String, Symbol};
-use crate::types::{GrantPauseRecord, ContractError};
-use crate::storage::keys::DataKey;
 use crate::storage::helpers::Storage;
+use crate::storage::keys::DataKey;
+use crate::types::{ContractError, GrantPauseRecord};
+use soroban_sdk::{Address, Env, String, Symbol};
 
-pub fn pause(env: &Env, caller: &Address, grant_id: u64, reason: String, auto_unpause_at: Option<u64>) -> Result<(), ContractError> {
+pub fn pause(
+    env: &Env,
+    caller: &Address,
+    grant_id: u64,
+    reason: String,
+    auto_unpause_at: Option<u64>,
+) -> Result<(), ContractError> {
     caller.require_auth();
     let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
     if grant.owner != *caller {
         return Err(ContractError::Unauthorized);
     }
-    
+
     let key = DataKey::GrantPaused(grant_id);
     let mut record = get_record(env, grant_id).unwrap_or_else(|| GrantPauseRecord {
         grant_id,
@@ -19,20 +25,21 @@ pub fn pause(env: &Env, caller: &Address, grant_id: u64, reason: String, auto_un
         auto_unpause_at,
         unpause_history: soroban_sdk::Vec::new(env),
     });
-    
+
     record.paused_by = caller.clone();
     record.paused_at = env.ledger().timestamp();
     record.reason = reason;
     record.auto_unpause_at = auto_unpause_at;
-    
+
     if let Some(time) = auto_unpause_at {
         if time <= env.ledger().timestamp() {
-             record.auto_unpause_at = None;
+            record.auto_unpause_at = None;
         }
     }
-    
+
     env.storage().persistent().set(&key, &record);
-    env.events().publish((Symbol::new(env, "grant_paused"), grant_id), caller.clone());
+    env.events()
+        .publish((Symbol::new(env, "grant_paused"), grant_id), caller.clone());
     Ok(())
 }
 
@@ -42,7 +49,7 @@ pub fn unpause(env: &Env, caller: &Address, grant_id: u64) -> Result<(), Contrac
     if grant.owner != *caller {
         return Err(ContractError::Unauthorized);
     }
-    
+
     let key = DataKey::GrantPaused(grant_id);
     if let Some(mut record) = get_record(env, grant_id) {
         let now = env.ledger().timestamp();
@@ -50,7 +57,10 @@ pub fn unpause(env: &Env, caller: &Address, grant_id: u64) -> Result<(), Contrac
         record.auto_unpause_at = Some(now);
         env.storage().persistent().set(&key, &record);
     }
-    env.events().publish((Symbol::new(env, "grant_unpaused"), grant_id), caller.clone());
+    env.events().publish(
+        (Symbol::new(env, "grant_unpaused"), grant_id),
+        caller.clone(),
+    );
     Ok(())
 }
 
@@ -74,7 +84,9 @@ pub fn is_paused(env: &Env, grant_id: u64) -> bool {
 }
 
 pub fn get_record(env: &Env, grant_id: u64) -> Option<GrantPauseRecord> {
-    env.storage().persistent().get(&DataKey::GrantPaused(grant_id))
+    env.storage()
+        .persistent()
+        .get(&DataKey::GrantPaused(grant_id))
 }
 
 pub fn try_auto_unpause(env: &Env, grant_id: u64) -> bool {
@@ -84,8 +96,11 @@ pub fn try_auto_unpause(env: &Env, grant_id: u64) -> bool {
             if now >= auto_unpause {
                 let contract_address = env.current_contract_address();
                 record.unpause_history.push_back((contract_address, now));
-                env.storage().persistent().set(&DataKey::GrantPaused(grant_id), &record);
-                env.events().publish((Symbol::new(env, "grant_unpaused"), grant_id), auto_unpause);
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::GrantPaused(grant_id), &record);
+                env.events()
+                    .publish((Symbol::new(env, "grant_unpaused"), grant_id), auto_unpause);
                 return true;
             }
         }
@@ -96,8 +111,8 @@ pub fn try_auto_unpause(env: &Env, grant_id: u64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::Grant;
     use crate::storage::Storage;
+    use crate::types::Grant;
     use soroban_sdk::testutils::{Address as _, Ledger};
     use soroban_sdk::{Env, String, Vec};
 
@@ -221,14 +236,7 @@ mod tests {
 
             assert!(require_not_paused(&env, grant_id).is_ok());
 
-            pause(
-                &env,
-                &owner,
-                grant_id,
-                String::from_str(&env, "test"),
-                None,
-            )
-            .unwrap();
+            pause(&env, &owner, grant_id, String::from_str(&env, "test"), None).unwrap();
             assert_eq!(
                 require_not_paused(&env, grant_id),
                 Err(ContractError::ContractPaused)

--- a/contracts/contracts/stellar-grants/src/grant_timer.rs
+++ b/contracts/contracts/stellar-grants/src/grant_timer.rs
@@ -71,7 +71,8 @@ pub fn trigger_timers(env: &Env, caller: &Address, grant_id: u64) -> u32 {
 
         let eligible = match timer.trigger_type {
             TimerTriggerType::AutoExpire => {
-                grant.status == GrantStatus::Active && grant.milestones_paid_out < grant.total_milestones
+                grant.status == GrantStatus::Active
+                    && grant.milestones_paid_out < grant.total_milestones
             }
             TimerTriggerType::AutoActivate => {
                 grant.status == GrantStatus::Active && grant.escrow_balance >= grant.total_amount
@@ -180,7 +181,10 @@ fn execute_timer_action(env: &Env, grant: &crate::types::Grant, timer: &TimerRec
         TimerTriggerType::AutoCancel => {
             if let Some(mut g) = Storage::get_grant(env, grant.id) {
                 g.status = GrantStatus::Cancelled;
-                g.reason = Some(soroban_sdk::String::from_str(env, "auto-cancelled: not funded by deadline"));
+                g.reason = Some(soroban_sdk::String::from_str(
+                    env,
+                    "auto-cancelled: not funded by deadline",
+                ));
                 g.timestamp = env.ledger().timestamp();
                 Storage::set_grant(env, grant.id, &g);
             }

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -111,50 +111,39 @@ pub use errors::ContractError;
 pub use events::Events;
 pub use storage::Storage;
 pub use types::{
-    AcceptanceCriteria, Amendment, AmendmentStatus, AnalyticsSnapshot,
-    Arbiter, ArbiterVote, ArbitrationCase, AuditAction,
-    AuditEntry, AutoApproveConfig, AutoApproveRecord, BatchResult,
-    BondClaim, BondStatus, BountyGrant, BountyStatus, BountySubmission, BreakerState, CategoryStats,
-    ChecklistSubmission, ClawbackRequest, ClawbackStatus, CollateralDeposit,
-    CollateralRequirement, CollateralStatus, ComplianceAttestation, ComplianceLevel,
-    ComplianceStatus, ConditionResult, ContractVersion, ContributionType,
-    ContributorPortfolio, CriterionStatus, CrowdfundCampaign, CrowdfundPledge,
-    CrowdfundStatus, ChainId, BridgeRelayer, CrossChainProof, DashboardView, DecayConfig, DecayType,
-    DexConfig, Dispute, DisputeStatus, EscrowAccount,
-    EscrowLifecycleState, EscrowMode, EscrowState, EscrowReleaseRequest, EscrowReleaseApproval, EvidenceField,
-    EvidenceFieldType, EvidenceSchema, ExportGrant, ExportGrantPage,
-    ExportMilestone, ExportMilestonePage, ExtensionRequest, ExtensionStatus,
-    FeeRecord, ForkRecord, FunderGrantSummary, FunderLedger,
-    FunderReport, FunderTokenSummary, Grant, GrantArchetype,
-    GrantCard, GrantCategory, GrantDetailView, GrantFund, GrantPortfolio,
-    GrantStatus, GrantSummary, GrantTag, GrantTemplate,
-    GrantVersion, HookCallResult, HookEvent, HookRegistration,
-    InsuranceClaim, InsurancePolicy, Invoice, InvoiceStatus,
-    IpRights, LicenseRecord, LicenseType, LineItem,
-    LockupRecord, LockupStatus, MatchingAllocation, MatchingContribution,
-    MatchingRound, MerkleCommitment, MerkleProof, MigrationRecord,
-    Milestone, MilestoneDag, MilestoneDependency, MilestoneNft,
-    MilestoneState, MilestoneSubmission, MilestoneTemplate, MultisigProposal,
-    MultisigSigner, NftMetadata, NotificationEvent, OracleConfig,
-    ParamRecord, ParamType, ParamValue, PauseRecord,
-    PaymentSplit, PaymentStream, PerformanceBond, PortfolioFilter,
-    PortfolioStats, PriceQuote, ProtocolConfig, ProtocolMetrics,
-    ProtocolModule, ProvenanceRecord, PublicReview, PublicReviewSignal,
-    QuadraticVoteRecord, RateLimitAction, ReferralCode, ReferralRecord,
-    ReferralReward, RegistryEntry, RegistryEntryType, ReleaseCondition,
-    RelayAllowance, RelayConfig, RelayRecord, RelayableAction,
-    RenewalProposal, RenewalStatus, ReputationTier, RevenueEpoch,
-    ReviewParticipation, ReviewerAvailability, ReviewerProfile, ReviewerRequest,
-    ReviewerRequestStatus, ReviewerRewardPool, ReviewerRewardRecord, ReviewerView,
-    Role, RoleAssignment, RollingWindow, ScoreResult,
-    ScoringDimension, ScoringRubric, ScoringWeight, SignatureStatus,
-    SplitRecipient, StakerEpochRecord, StructuredEvidence, Subscription,
-    SubscriptionScope, SwapResult, SwapRoute, SyndicateGrant,
-    SyndicateMember, SyndicateStatus, TemplateCategory, TimerRecord,
-    TimerTriggerType, TokenMetric, TransferProposal, TransferableRole,
-    VerificationAttestation, VerificationLevel, VerificationStatus, VoiceCredits,
-    VotingMechanism, WaitlistConfig, WaitlistEntry, WhitelistEntry,
-    WhitelistMode, WhitelistScope,
+    AcceptanceCriteria, Amendment, AmendmentStatus, AnalyticsSnapshot, Arbiter, ArbiterVote,
+    ArbitrationCase, AuditAction, AuditEntry, AutoApproveConfig, AutoApproveRecord, BatchResult,
+    BondClaim, BondStatus, BountyGrant, BountyStatus, BountySubmission, BreakerState,
+    BridgeRelayer, CategoryStats, ChainId, ChecklistSubmission, ClawbackRequest, ClawbackStatus,
+    CollateralDeposit, CollateralRequirement, CollateralStatus, ComplianceAttestation,
+    ComplianceLevel, ComplianceStatus, ConditionResult, ContractVersion, ContributionType,
+    ContributorPortfolio, CriterionStatus, CrossChainProof, CrowdfundCampaign, CrowdfundPledge,
+    CrowdfundStatus, DashboardView, DecayConfig, DecayType, DexConfig, Dispute, DisputeStatus,
+    EscrowAccount, EscrowLifecycleState, EscrowMode, EscrowReleaseApproval, EscrowReleaseRequest,
+    EscrowState, EvidenceField, EvidenceFieldType, EvidenceSchema, ExportGrant, ExportGrantPage,
+    ExportMilestone, ExportMilestonePage, ExtensionRequest, ExtensionStatus, FeeRecord, ForkRecord,
+    FunderGrantSummary, FunderLedger, FunderReport, FunderTokenSummary, Grant, GrantArchetype,
+    GrantCard, GrantCategory, GrantDetailView, GrantFund, GrantPortfolio, GrantStatus,
+    GrantSummary, GrantTag, GrantTemplate, GrantVersion, HookCallResult, HookEvent,
+    HookRegistration, InsuranceClaim, InsurancePolicy, Invoice, InvoiceStatus, IpRights,
+    LicenseRecord, LicenseType, LineItem, LockupRecord, LockupStatus, MatchingAllocation,
+    MatchingContribution, MatchingRound, MerkleCommitment, MerkleProof, MigrationRecord, Milestone,
+    MilestoneDag, MilestoneDependency, MilestoneNft, MilestoneState, MilestoneSubmission,
+    MilestoneTemplate, MultisigProposal, MultisigSigner, NftMetadata, NotificationEvent,
+    OracleConfig, ParamRecord, ParamType, ParamValue, PauseRecord, PaymentSplit, PaymentStream,
+    PerformanceBond, PortfolioFilter, PortfolioStats, PriceQuote, ProtocolConfig, ProtocolMetrics,
+    ProtocolModule, ProvenanceRecord, PublicReview, PublicReviewSignal, QuadraticVoteRecord,
+    RateLimitAction, ReferralCode, ReferralRecord, ReferralReward, RegistryEntry,
+    RegistryEntryType, RelayAllowance, RelayConfig, RelayRecord, RelayableAction, ReleaseCondition,
+    RenewalProposal, RenewalStatus, ReputationTier, RevenueEpoch, ReviewParticipation,
+    ReviewerAvailability, ReviewerProfile, ReviewerRequest, ReviewerRequestStatus,
+    ReviewerRewardPool, ReviewerRewardRecord, ReviewerView, Role, RoleAssignment, RollingWindow,
+    ScoreResult, ScoringDimension, ScoringRubric, ScoringWeight, SignatureStatus, SplitRecipient,
+    StakerEpochRecord, StructuredEvidence, Subscription, SubscriptionScope, SwapResult, SwapRoute,
+    SyndicateGrant, SyndicateMember, SyndicateStatus, TemplateCategory, TimerRecord,
+    TimerTriggerType, TokenMetric, TransferProposal, TransferableRole, VerificationAttestation,
+    VerificationLevel, VerificationStatus, VoiceCredits, VotingMechanism, WaitlistConfig,
+    WaitlistEntry, WhitelistEntry, WhitelistMode, WhitelistScope,
 };
 
 use metrics::MetricField;
@@ -525,11 +514,7 @@ impl StellarGrantsContract {
                 // Deduct protocol fee (split across reviewer reward pool,
                 // revenue-share pool, and treasury) before passing the net
                 // amount to the grant recipient or split recipients.
-                let net_amount = fees::deduct_and_split_fee(
-                    env,
-                    &grant.token,
-                    ms.amount,
-                )?;
+                let net_amount = fees::deduct_and_split_fee(env, &grant.token, ms.amount)?;
                 if split_payment::has_split(env, grant_id, idx) {
                     split_payment::execute_split(env, grant_id, idx, net_amount)?;
                 } else {
@@ -537,9 +522,19 @@ impl StellarGrantsContract {
                 }
             }
             if owner_amount > 0 {
-                let config: ProtocolConfig = env.storage().persistent().get(&storage::keys::DataKey::Config).unwrap();
+                let config: ProtocolConfig = env
+                    .storage()
+                    .persistent()
+                    .get(&storage::keys::DataKey::Config)
+                    .unwrap();
                 if config.multisig_threshold > 0 && owner_amount >= config.multisig_threshold {
-                    crate::escrow_multisig::create_request(env, grant_id, 0, owner_amount, grant.owner.clone())?;
+                    crate::escrow_multisig::create_request(
+                        env,
+                        grant_id,
+                        0,
+                        owner_amount,
+                        grant.owner.clone(),
+                    )?;
                 } else {
                     escrow::release(env, grant_id, &grant.owner, owner_amount)?;
                 }
@@ -1225,7 +1220,7 @@ impl StellarGrantsContract {
     }
 
     // ── Milestone Templates ────────────────────────────────────────────────────
-    
+
     pub fn save_template(
         env: Env,
         owner: Address,
@@ -1235,9 +1230,17 @@ impl StellarGrantsContract {
         default_amount_pct: u32,
         is_public: bool,
     ) -> Result<u64, ContractError> {
-        milestone_template::save_template(&env, owner, name, description, category, default_amount_pct, is_public)
+        milestone_template::save_template(
+            &env,
+            owner,
+            name,
+            description,
+            category,
+            default_amount_pct,
+            is_public,
+        )
     }
-    
+
     pub fn create_milestones_from_template(
         env: Env,
         caller: Address,
@@ -1940,17 +1943,12 @@ impl StellarGrantsContract {
         caller.require_auth();
         bounty::select_winner(&env, &caller, bounty_id, &winner)?;
         metrics::increment(&env, MetricField::BountiesAwarded, 1);
-        let bounty = bounty::get_bounty(&env, bounty_id)
-            .ok_or(ContractError::BountyNotFound)?;
+        let bounty = bounty::get_bounty(&env, bounty_id).ok_or(ContractError::BountyNotFound)?;
         metrics::update_token_locked(&env, &bounty.token, -bounty.prize_amount);
         Ok(())
     }
 
-    pub fn cancel_bounty(
-        env: Env,
-        caller: Address,
-        bounty_id: u64,
-    ) -> Result<(), ContractError> {
+    pub fn cancel_bounty(env: Env, caller: Address, bounty_id: u64) -> Result<(), ContractError> {
         caller.require_auth();
         bounty::cancel_bounty(&env, &caller, bounty_id)
     }
@@ -3971,12 +3969,20 @@ impl StellarGrantsContract {
     }
 
     /// Join the waitlist for a grant. Returns the position (1-indexed).
-    pub fn join_waitlist(env: Env, applicant: Address, grant_id: u64) -> Result<u32, ContractError> {
+    pub fn join_waitlist(
+        env: Env,
+        applicant: Address,
+        grant_id: u64,
+    ) -> Result<u32, ContractError> {
         waitlist::join(&env, &applicant, grant_id)
     }
 
     /// Leave the waitlist voluntarily.
-    pub fn leave_waitlist(env: Env, applicant: Address, grant_id: u64) -> Result<(), ContractError> {
+    pub fn leave_waitlist(
+        env: Env,
+        applicant: Address,
+        grant_id: u64,
+    ) -> Result<(), ContractError> {
         waitlist::leave(&env, &applicant, grant_id)
     }
 
@@ -4186,7 +4192,7 @@ fn apply_milestone_submission(
     } else {
         proof_url
     };
-    
+
     let milestone = Milestone {
         idx: milestone_idx,
         description: description.clone(),

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -27,6 +27,7 @@ mod audit;
 mod auto_approve;
 mod badge;
 mod batch_read;
+mod bounty;
 mod checklist;
 mod circuit_breaker;
 mod clawback;
@@ -113,7 +114,7 @@ pub use types::{
     AcceptanceCriteria, Amendment, AmendmentStatus, AnalyticsSnapshot,
     Arbiter, ArbiterVote, ArbitrationCase, AuditAction,
     AuditEntry, AutoApproveConfig, AutoApproveRecord, BatchResult,
-    BondClaim, BondStatus, BreakerState, CategoryStats,
+    BondClaim, BondStatus, BountyGrant, BountyStatus, BountySubmission, BreakerState, CategoryStats,
     ChecklistSubmission, ClawbackRequest, ClawbackStatus, CollateralDeposit,
     CollateralRequirement, CollateralStatus, ComplianceAttestation, ComplianceLevel,
     ComplianceStatus, ConditionResult, ContractVersion, ContributionType,
@@ -521,10 +522,18 @@ impl StellarGrantsContract {
                         VerificationLevel::FullKyc,
                     )?;
                 }
+                // Deduct protocol fee (split across reviewer reward pool,
+                // revenue-share pool, and treasury) before passing the net
+                // amount to the grant recipient or split recipients.
+                let net_amount = fees::deduct_and_split_fee(
+                    env,
+                    &grant.token,
+                    ms.amount,
+                )?;
                 if split_payment::has_split(env, grant_id, idx) {
-                    split_payment::execute_split(env, grant_id, idx, ms.amount)?;
+                    split_payment::execute_split(env, grant_id, idx, net_amount)?;
                 } else {
-                    owner_amount = owner_amount.saturating_add(ms.amount);
+                    owner_amount = owner_amount.saturating_add(net_amount);
                 }
             }
             if owner_amount > 0 {
@@ -1874,6 +1883,92 @@ impl StellarGrantsContract {
         address: Address,
     ) -> Option<VerificationAttestation> {
         contributor_verification::get_attestation(&env, &address)
+    }
+
+    // ── Issue #533: Bounty-Mode Grant Entry Points ───────────────────────────
+
+    pub fn create_bounty(
+        env: Env,
+        owner: Address,
+        title: String,
+        description: String,
+        token: Address,
+        prize_amount: i128,
+        submission_window_ledgers: u32,
+    ) -> Result<u64, ContractError> {
+        owner.require_auth();
+        circuit_breaker::require_open(&env, ProtocolModule::Bounty)?;
+        let id = bounty::create_bounty(
+            &env,
+            &owner,
+            title,
+            description,
+            &token,
+            prize_amount,
+            submission_window_ledgers,
+        )?;
+        metrics::increment(&env, MetricField::BountiesCreated, 1);
+        metrics::update_token_locked(&env, &token, prize_amount);
+        Ok(id)
+    }
+
+    pub fn submit_bounty_solution(
+        env: Env,
+        bounty_id: u64,
+        submitter: Address,
+        proof_url: String,
+    ) -> Result<(), ContractError> {
+        submitter.require_auth();
+        bounty::submit_solution(&env, bounty_id, &submitter, proof_url)
+    }
+
+    pub fn start_bounty_review(
+        env: Env,
+        caller: Address,
+        bounty_id: u64,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        bounty::start_review(&env, &caller, bounty_id)
+    }
+
+    pub fn select_bounty_winner(
+        env: Env,
+        caller: Address,
+        bounty_id: u64,
+        winner: Address,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        bounty::select_winner(&env, &caller, bounty_id, &winner)?;
+        metrics::increment(&env, MetricField::BountiesAwarded, 1);
+        let bounty = bounty::get_bounty(&env, bounty_id)
+            .ok_or(ContractError::BountyNotFound)?;
+        metrics::update_token_locked(&env, &bounty.token, -bounty.prize_amount);
+        Ok(())
+    }
+
+    pub fn cancel_bounty(
+        env: Env,
+        caller: Address,
+        bounty_id: u64,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        bounty::cancel_bounty(&env, &caller, bounty_id)
+    }
+
+    pub fn get_bounty(env: Env, bounty_id: u64) -> Option<BountyGrant> {
+        bounty::get_bounty(&env, bounty_id)
+    }
+
+    pub fn get_bounty_submission(
+        env: Env,
+        bounty_id: u64,
+        submitter: Address,
+    ) -> Option<BountySubmission> {
+        bounty::get_submission(&env, bounty_id, &submitter)
+    }
+
+    pub fn list_bounty_submitters(env: Env, bounty_id: u64) -> Vec<Address> {
+        bounty::list_submitters(&env, bounty_id)
     }
 
     // ── Issue #517: Protocol Fee Management Entry Points ─────────────────────

--- a/contracts/contracts/stellar-grants/src/milestone_template.rs
+++ b/contracts/contracts/stellar-grants/src/milestone_template.rs
@@ -1,6 +1,6 @@
-use soroban_sdk::{Address, Env, String, Vec};
-use crate::types::{TemplateCategory, MilestoneTemplate, ContractError};
 use crate::storage::keys::DataKey;
+use crate::types::{ContractError, MilestoneTemplate, TemplateCategory};
+use soroban_sdk::{Address, Env, String, Vec};
 
 pub fn save_template(
     env: &Env,
@@ -12,12 +12,12 @@ pub fn save_template(
     is_public: bool,
 ) -> Result<u64, ContractError> {
     owner.require_auth();
-    
+
     let id_key = DataKey::TemplateCounter;
     let mut id: u64 = env.storage().persistent().get(&id_key).unwrap_or(0);
     id += 1;
     env.storage().persistent().set(&id_key, &id);
-    
+
     let template = MilestoneTemplate {
         id,
         owner: owner.clone(),
@@ -28,50 +28,70 @@ pub fn save_template(
         is_public,
         use_count: 0,
     };
-    
-    env.storage().persistent().set(&DataKey::MilestoneTemplate(id), &template);
-    
-    let mut owner_templates: Vec<u64> = env.storage().persistent().get(&DataKey::TemplatesByOwner(owner.clone())).unwrap_or_else(|| Vec::new(env));
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::MilestoneTemplate(id), &template);
+
+    let mut owner_templates: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::TemplatesByOwner(owner.clone()))
+        .unwrap_or_else(|| Vec::new(env));
     owner_templates.push_back(id);
-    env.storage().persistent().set(&DataKey::TemplatesByOwner(owner), &owner_templates);
-    
+    env.storage()
+        .persistent()
+        .set(&DataKey::TemplatesByOwner(owner), &owner_templates);
+
     Ok(id)
 }
 
-pub fn create_from_templates(env: &Env, caller: Address, template_ids: Vec<u64>, total_amount: i128) -> Result<Vec<(String, i128)>, ContractError> {
+pub fn create_from_templates(
+    env: &Env,
+    caller: Address,
+    template_ids: Vec<u64>,
+    total_amount: i128,
+) -> Result<Vec<(String, i128)>, ContractError> {
     caller.require_auth();
-    
+
     let mut results = Vec::new(env);
-    
+
     for id in template_ids.iter() {
-        let mut template = get_template(env, id).ok_or(ContractError::InvalidState)?; 
+        let mut template = get_template(env, id).ok_or(ContractError::InvalidState)?;
         if !template.is_public && template.owner != caller {
             return Err(ContractError::Unauthorized);
         }
-        
+
         template.use_count += 1;
-        env.storage().persistent().set(&DataKey::MilestoneTemplate(id), &template);
-        
+        env.storage()
+            .persistent()
+            .set(&DataKey::MilestoneTemplate(id), &template);
+
         let amount = (total_amount * (template.default_amount_pct as i128)) / 100;
         results.push_back((template.description.clone(), amount));
     }
-    
+
     Ok(results)
 }
 
 pub fn get_template(env: &Env, id: u64) -> Option<MilestoneTemplate> {
-    env.storage().persistent().get(&DataKey::MilestoneTemplate(id))
+    env.storage()
+        .persistent()
+        .get(&DataKey::MilestoneTemplate(id))
 }
 
 pub fn templates_by_owner(env: &Env, owner: Address) -> Vec<u64> {
-    env.storage().persistent().get(&DataKey::TemplatesByOwner(owner)).unwrap_or_else(|| Vec::new(env))
+    env.storage()
+        .persistent()
+        .get(&DataKey::TemplatesByOwner(owner))
+        .unwrap_or_else(|| Vec::new(env))
 }
 
 pub fn public_templates(env: &Env, limit: u32) -> Vec<u64> {
     let mut results = Vec::new(env);
     let id_key = DataKey::TemplateCounter;
     let max_id: u64 = env.storage().persistent().get(&id_key).unwrap_or(0);
-    
+
     let mut count = 0;
     for id in (1..=max_id).rev() {
         if let Some(template) = get_template(env, id) {
@@ -96,9 +116,11 @@ pub fn delete_template(env: &Env, caller: Address, id: u64) -> Result<(), Contra
     if template.use_count > 0 {
         return Err(ContractError::InvalidState);
     }
-    
-    env.storage().persistent().remove(&DataKey::MilestoneTemplate(id));
-    
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::MilestoneTemplate(id));
+
     let owner_templates = templates_by_owner(env, caller.clone());
     let mut new_templates = Vec::new(env);
     for tid in owner_templates.iter() {
@@ -106,7 +128,9 @@ pub fn delete_template(env: &Env, caller: Address, id: u64) -> Result<(), Contra
             new_templates.push_back(tid);
         }
     }
-    env.storage().persistent().set(&DataKey::TemplatesByOwner(caller), &new_templates);
-    
+    env.storage()
+        .persistent()
+        .set(&DataKey::TemplatesByOwner(caller), &new_templates);
+
     Ok(())
 }

--- a/contracts/contracts/stellar-grants/src/storage/helpers.rs
+++ b/contracts/contracts/stellar-grants/src/storage/helpers.rs
@@ -1,11 +1,11 @@
 use super::keys::{
-    ArbitrationKey, AutoApproveKey, BondKey, CollateralKey, ConditionalReleaseKey, CrowdfundKey,
-    DataKey, EscrowKey, GrantKey, GrantTimerKey, InsuranceKey, MilestoneKey, UserKey, VotingKey,
-    WaitlistKey,
+    ArbitrationKey, AutoApproveKey, BondKey, BountyKey, CollateralKey, ConditionalReleaseKey,
+    CrowdfundKey, DataKey, EscrowKey, GrantKey, GrantTimerKey, InsuranceKey, MilestoneKey, UserKey,
+    VotingKey, WaitlistKey,
 };
 use crate::types::{
     AcceptanceCriteria, Amendment, AnalyticsSnapshot, AuditEntry, AutoApproveConfig,
-    AutoApproveRecord, BreakerState, ChecklistSubmission,
+    AutoApproveRecord, BountyGrant, BountySubmission, BreakerState, ChecklistSubmission,
     ClawbackRequest, ComplianceAttestation, ContractError, ContractVersion,
     ContributorProfile, CrowdfundCampaign, CrowdfundPledge, DexConfig, Dispute, EscrowAccount,
     EscrowState, EvidenceSchema, FunderLedger, Grant, GrantCategory, GrantTag, GrantVersion,
@@ -2188,6 +2188,69 @@ impl Storage {
     pub fn set_waitlist_entries(env: &Env, grant_id: u64, entries: &Vec<WaitlistEntry>) {
         let key = DataKey::Waitlist(WaitlistKey::Entries(grant_id));
         env.storage().persistent().set(&key, entries);
+        Self::bump(env, &key);
+    }
+
+    // ── Issue #533: Bounty-Mode Grants ───────────────────────────────────────
+
+    pub fn next_bounty_id(env: &Env) -> u64 {
+        let key = DataKey::Bounty(BountyKey::Counter);
+        let mut id: u64 = env.storage().persistent().get(&key).unwrap_or(0);
+        id += 1;
+        env.storage().persistent().set(&key, &id);
+        id
+    }
+
+    pub fn get_bounty(env: &Env, bounty_id: u64) -> Option<BountyGrant> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Bounty(BountyKey::Data(bounty_id)))
+    }
+
+    pub fn set_bounty(env: &Env, bounty: &BountyGrant) {
+        let key = DataKey::Bounty(BountyKey::Data(bounty.id));
+        env.storage().persistent().set(&key, bounty);
+        Self::bump(env, &key);
+    }
+
+    pub fn get_bounty_submission(
+        env: &Env,
+        bounty_id: u64,
+        submitter: &Address,
+    ) -> Option<BountySubmission> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Bounty(BountyKey::Submission(
+                bounty_id,
+                submitter.clone(),
+            )))
+    }
+
+    pub fn set_bounty_submission(env: &Env, submission: &BountySubmission) {
+        let key = DataKey::Bounty(BountyKey::Submission(
+            submission.bounty_id,
+            submission.submitter.clone(),
+        ));
+        env.storage().persistent().set(&key, submission);
+        Self::bump(env, &key);
+    }
+
+    pub fn get_bounty_submitters(env: &Env, bounty_id: u64) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Bounty(BountyKey::Submitters(bounty_id)))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn add_bounty_submitter(env: &Env, bounty_id: u64, submitter: &Address) {
+        let key = DataKey::Bounty(BountyKey::Submitters(bounty_id));
+        let mut submitters: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env));
+        submitters.push_back(submitter.clone());
+        env.storage().persistent().set(&key, &submitters);
         Self::bump(env, &key);
     }
 }

--- a/contracts/contracts/stellar-grants/src/storage/helpers.rs
+++ b/contracts/contracts/stellar-grants/src/storage/helpers.rs
@@ -6,18 +6,17 @@ use super::keys::{
 use crate::types::{
     AcceptanceCriteria, Amendment, AnalyticsSnapshot, AuditEntry, AutoApproveConfig,
     AutoApproveRecord, BountyGrant, BountySubmission, BreakerState, ChecklistSubmission,
-    ClawbackRequest, ComplianceAttestation, ContractError, ContractVersion,
-    ContributorProfile, CrowdfundCampaign, CrowdfundPledge, DexConfig, Dispute, EscrowAccount,
-    EscrowState, EvidenceSchema, FunderLedger, Grant, GrantCategory, GrantTag, GrantVersion,
-    HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy, Invoice, LicenseRecord,
-    MerkleCommitment, MigrationRecord, Milestone, MilestoneDag, MilestoneNft, MultisigProposal,
-    OracleConfig, ParamRecord, PauseRecord, PaymentSplit, PaymentStream, ProtocolConfig,
-    ProtocolMetrics, ProtocolModule, PublicReview, QuadraticVoteRecord, RateLimitAction,
-    RateLimitRecord, RegistryEntry, RelayAllowance, RelayConfig, ReleaseCondition, RenewalProposal,
-    RevenueEpoch, ReviewerProfile,
-    ReviewerRequest, Role, RoleAssignment, RollingWindow, ScoringRubric, StakerEpochRecord, StructuredEvidence,
-    SyndicateGrant, SyndicateMember, TimerRecord, TokenMetric, TransferProposal,
-    VerificationAttestation, VoiceCredits, VotingMechanism,
+    ClawbackRequest, ComplianceAttestation, ContractError, ContractVersion, ContributorProfile,
+    CrowdfundCampaign, CrowdfundPledge, DexConfig, Dispute, EscrowAccount, EscrowState,
+    EvidenceSchema, FunderLedger, Grant, GrantCategory, GrantTag, GrantVersion, HookEvent,
+    HookRegistration, InsuranceClaim, InsurancePolicy, Invoice, LicenseRecord, MerkleCommitment,
+    MigrationRecord, Milestone, MilestoneDag, MilestoneNft, MultisigProposal, OracleConfig,
+    ParamRecord, PauseRecord, PaymentSplit, PaymentStream, ProtocolConfig, ProtocolMetrics,
+    ProtocolModule, PublicReview, QuadraticVoteRecord, RateLimitAction, RateLimitRecord,
+    RegistryEntry, RelayAllowance, RelayConfig, ReleaseCondition, RenewalProposal, RevenueEpoch,
+    ReviewerProfile, ReviewerRequest, Role, RoleAssignment, RollingWindow, ScoringRubric,
+    StakerEpochRecord, StructuredEvidence, SyndicateGrant, SyndicateMember, TimerRecord,
+    TokenMetric, TransferProposal, VerificationAttestation, VoiceCredits, VotingMechanism,
     WaitlistConfig, WaitlistEntry,
 };
 use crate::types::{
@@ -591,9 +590,12 @@ impl Storage {
     }
 
     pub fn remove_clawback(env: &Env, grant_id: u64, milestone_idx: u32) {
-        env.storage().persistent().remove(&DataKey::Milestone(
-            MilestoneKey::Clawback(grant_id, milestone_idx),
-        ));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Milestone(MilestoneKey::Clawback(
+                grant_id,
+                milestone_idx,
+            )));
     }
 
     // ── Issue #516: ProtocolConfig ────────────────────────────────────────────
@@ -2107,10 +2109,8 @@ impl Storage {
         milestone_idx: u32,
         conditions: &Vec<ReleaseCondition>,
     ) {
-        let key = DataKey::ConditionalRelease(ConditionalReleaseKey::Conditions(
-            grant_id,
-            milestone_idx,
-        ));
+        let key =
+            DataKey::ConditionalRelease(ConditionalReleaseKey::Conditions(grant_id, milestone_idx));
         env.storage().persistent().set(&key, conditions);
         Self::bump(env, &key);
     }
@@ -2133,9 +2133,12 @@ impl Storage {
         grant_id: u64,
         milestone_idx: u32,
     ) -> Option<AutoApproveRecord> {
-        env.storage().persistent().get(&DataKey::AutoApprove(
-            AutoApproveKey::Record(grant_id, milestone_idx),
-        ))
+        env.storage()
+            .persistent()
+            .get(&DataKey::AutoApprove(AutoApproveKey::Record(
+                grant_id,
+                milestone_idx,
+            )))
     }
 
     pub fn set_auto_approve_record(

--- a/contracts/contracts/stellar-grants/src/storage/keys.rs
+++ b/contracts/contracts/stellar-grants/src/storage/keys.rs
@@ -195,6 +195,15 @@ pub enum GrantTimerKey {
     Timers(u64),
 }
 
+#[contracttype]
+#[derive(Clone)]
+pub enum BountyKey {
+    Counter,
+    Data(u64),
+    Submission(u64, Address),
+    Submitters(u64),
+}
+
 // ── Structured DataKey ────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -215,6 +224,7 @@ pub enum DataKey {
     ConditionalRelease(ConditionalReleaseKey),
     AutoApprove(AutoApproveKey),
     GrantTimer(GrantTimerKey),
+    Bounty(BountyKey),
     Matching(MatchingKey),
     Provenance(ProvenanceKey),
     ReviewerReward(ReviewerRewardKey),

--- a/contracts/contracts/stellar-grants/src/types.rs
+++ b/contracts/contracts/stellar-grants/src/types.rs
@@ -507,6 +507,41 @@ pub struct ReviewerRewardPool {
     pub total_paid_out: i128,
 }
 
+// ── Issue #533: Bounty-Mode Grants ────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BountyGrant {
+    pub id: u64,
+    pub owner: Address,
+    pub title: String,
+    pub description: String,
+    pub token: Address,
+    pub prize_amount: i128,
+    pub status: BountyStatus,
+    pub submission_deadline: u64,
+    pub winner: Option<Address>,
+    pub created_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BountyStatus {
+    Open,
+    UnderReview,
+    Awarded,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BountySubmission {
+    pub bounty_id: u64,
+    pub submitter: Address,
+    pub proof_url: String,
+    pub submitted_at: u64,
+}
+
 // ── Issue #517: Protocol Fee Collection ──────────────────────────────────────
 
 #[contracttype]

--- a/contracts/contracts/stellar-grants/src/waitlist.rs
+++ b/contracts/contracts/stellar-grants/src/waitlist.rs
@@ -1,7 +1,7 @@
-use soroban_sdk::{Address, Env, String, Vec};
 use crate::events::Events;
 use crate::storage::Storage;
 use crate::types::{ContractError, WaitlistConfig, WaitlistEntry};
+use soroban_sdk::{Address, Env, String, Vec};
 
 /// Configure the waitlist for a grant. Owner only.
 pub fn configure(
@@ -11,7 +11,7 @@ pub fn configure(
     config: WaitlistConfig,
 ) -> Result<(), ContractError> {
     let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
-    
+
     if grant.owner != *owner {
         return Err(ContractError::Unauthorized);
     }
@@ -22,8 +22,7 @@ pub fn configure(
 
 /// Join the waitlist for a grant. Returns the position (1-indexed).
 pub fn join(env: &Env, applicant: &Address, grant_id: u64) -> Result<u32, ContractError> {
-    let config = Storage::get_waitlist_config(env, grant_id)
-        .ok_or(ContractError::InvalidInput)?;
+    let config = Storage::get_waitlist_config(env, grant_id).ok_or(ContractError::InvalidInput)?;
 
     let mut entries = Storage::get_waitlist_entries(env, grant_id);
 
@@ -139,7 +138,7 @@ pub fn promote_next(env: &Env, grant_id: u64) -> Option<Address> {
     }
 
     let mut entries = Storage::get_waitlist_entries(env, grant_id);
-    
+
     if entries.is_empty() {
         return None;
     }

--- a/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_cancel_bounty_by_non_owner_rejected.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_cancel_bounty_by_non_owner_rejected.1.json
@@ -1,0 +1,209 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Counter"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u64": "1"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "created_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "prize_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "symbol": "Open"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submission_deadline"
+                    },
+                    "val": {
+                      "u64": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Bounty"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "winner"
+                    },
+                    "val": "void"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_list_submitters_tracks_all_entrants.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_list_submitters_tracks_all_entrants.1.json
@@ -1,0 +1,481 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Counter"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u64": "1"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "created_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "prize_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "symbol": "Open"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submission_deadline"
+                    },
+                    "val": {
+                      "u64": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Bounty"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "winner"
+                    },
+                    "val": "void"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submission"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bounty_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "proof_url"
+                    },
+                    "val": {
+                      "string": "p1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitted_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitter"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submission"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bounty_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "proof_url"
+                    },
+                    "val": {
+                      "string": "p2"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitted_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitter"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submitters"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "bounty_submission_received"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "bounty_id"
+                  },
+                  "val": {
+                    "u64": "1"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "submitter"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "timestamp"
+                  },
+                  "val": {
+                    "u64": "0"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "bounty_submission_received"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "bounty_id"
+                  },
+                  "val": {
+                    "u64": "1"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "submitter"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "timestamp"
+                  },
+                  "val": {
+                    "u64": "0"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_select_winner_unauthorized_caller_rejected.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_select_winner_unauthorized_caller_rejected.1.json
@@ -1,0 +1,363 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Counter"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u64": "1"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "created_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "prize_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "symbol": "Open"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submission_deadline"
+                    },
+                    "val": {
+                      "u64": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Bounty"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "winner"
+                    },
+                    "val": "void"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submission"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bounty_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "proof_url"
+                    },
+                    "val": {
+                      "string": "proof"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitted_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitter"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submitters"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "bounty_submission_received"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "bounty_id"
+                  },
+                  "val": {
+                    "u64": "1"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "submitter"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "timestamp"
+                  },
+                  "val": {
+                    "u64": "0"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_select_winner_without_submission_rejected.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_select_winner_without_submission_rejected.1.json
@@ -1,0 +1,209 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Counter"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u64": "1"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "created_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "prize_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "symbol": "Open"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submission_deadline"
+                    },
+                    "val": {
+                      "u64": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Bounty"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "winner"
+                    },
+                    "val": "void"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_start_review_closes_to_new_submissions.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_start_review_closes_to_new_submissions.1.json
@@ -1,0 +1,209 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Counter"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u64": "1"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "created_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "prize_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "symbol": "UnderReview"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submission_deadline"
+                    },
+                    "val": {
+                      "u64": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Bounty"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "winner"
+                    },
+                    "val": "void"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_submit_solution_after_deadline_rejected.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_submit_solution_after_deadline_rejected.1.json
@@ -1,0 +1,210 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 10000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Counter"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u64": "1"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "created_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "prize_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "symbol": "Open"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submission_deadline"
+                    },
+                    "val": {
+                      "u64": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Bounty"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "winner"
+                    },
+                    "val": "void"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_submit_solution_to_unknown_bounty_rejected.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_submit_solution_to_unknown_bounty_rejected.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_submit_solution_twice_rejected.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/bounty/tests/test_submit_solution_twice_rejected.1.json
@@ -1,0 +1,363 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Counter"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u64": "1"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "created_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "prize_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "symbol": "Open"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submission_deadline"
+                    },
+                    "val": {
+                      "u64": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Bounty"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "winner"
+                    },
+                    "val": "void"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submission"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bounty_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "proof_url"
+                    },
+                    "val": {
+                      "string": "proof1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitted_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitter"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Bounty"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submitters"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "bounty_submission_received"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "bounty_id"
+                  },
+                  "val": {
+                    "u64": "1"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "submitter"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "timestamp"
+                  },
+                  "val": {
+                    "u64": "0"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/checklist/tests/test_define_criteria.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/checklist/tests/test_define_criteria.1.json
@@ -44,10 +44,17 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "EscrowAccount"
+                    "symbol": "Escrow"
                   },
                   {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "Account"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -147,7 +154,14 @@
                     "symbol": "Grant"
                   },
                   {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -300,13 +314,20 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "MilestoneChecklist"
+                    "symbol": "Milestone"
                   },
                   {
-                    "u64": "1"
-                  },
-                  {
-                    "u32": 0
+                    "vec": [
+                      {
+                        "symbol": "Checklist"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "u32": 0
+                      }
+                    ]
                   }
                 ]
               },

--- a/contracts/contracts/stellar-grants/test_snapshots/checklist/tests/test_optional_rejected_does_not_block.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/checklist/tests/test_optional_rejected_does_not_block.1.json
@@ -72,134 +72,17 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "ChecklistSubmission"
+                    "symbol": "Escrow"
                   },
                   {
-                    "u64": "1"
-                  },
-                  {
-                    "u32": 0
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "all_required_met"
-                    },
-                    "val": {
-                      "bool": true
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "criteria"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "description"
-                              },
-                              "val": {
-                                "string": "Nice to have"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "idx"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "is_required"
-                              },
-                              "val": {
-                                "bool": false
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "evidence_urls"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "string": "proof"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "grant_id"
-                    },
-                    "val": {
-                      "u64": "1"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestone_idx"
-                    },
-                    "val": {
-                      "u32": 0
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "statuses"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "u32": 3
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "submitted_at"
-                    },
-                    "val": {
-                      "u64": "0"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "EscrowAccount"
-                  },
-                  {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "Account"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -299,7 +182,14 @@
                     "symbol": "Grant"
                   },
                   {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -452,13 +342,20 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "MilestoneChecklist"
+                    "symbol": "Milestone"
                   },
                   {
-                    "u64": "1"
-                  },
-                  {
-                    "u32": 0
+                    "vec": [
+                      {
+                        "symbol": "Checklist"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "u32": 0
+                      }
+                    ]
                   }
                 ]
               },
@@ -492,6 +389,137 @@
                         }
                       }
                     ]
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Milestone"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submission"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "u32": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "all_required_met"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "criteria"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "description"
+                              },
+                              "val": {
+                                "string": "Nice to have"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "idx"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "is_required"
+                              },
+                              "val": {
+                                "bool": false
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "evidence_urls"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "string": "proof"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grant_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_idx"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "statuses"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "u32": 3
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitted_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
                   }
                 ]
               }

--- a/contracts/contracts/stellar-grants/test_snapshots/checklist/tests/test_required_rejected_blocks_approval.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/checklist/tests/test_required_rejected_blocks_approval.1.json
@@ -72,134 +72,17 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "ChecklistSubmission"
+                    "symbol": "Escrow"
                   },
                   {
-                    "u64": "1"
-                  },
-                  {
-                    "u32": 0
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "all_required_met"
-                    },
-                    "val": {
-                      "bool": false
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "criteria"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "description"
-                              },
-                              "val": {
-                                "string": "Must pass"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "idx"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "is_required"
-                              },
-                              "val": {
-                                "bool": true
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "evidence_urls"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "string": "proof"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "grant_id"
-                    },
-                    "val": {
-                      "u64": "1"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestone_idx"
-                    },
-                    "val": {
-                      "u32": 0
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "statuses"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "u32": 3
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "submitted_at"
-                    },
-                    "val": {
-                      "u64": "0"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "EscrowAccount"
-                  },
-                  {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "Account"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -299,7 +182,14 @@
                     "symbol": "Grant"
                   },
                   {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -452,13 +342,20 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "MilestoneChecklist"
+                    "symbol": "Milestone"
                   },
                   {
-                    "u64": "1"
-                  },
-                  {
-                    "u32": 0
+                    "vec": [
+                      {
+                        "symbol": "Checklist"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "u32": 0
+                      }
+                    ]
                   }
                 ]
               },
@@ -492,6 +389,137 @@
                         }
                       }
                     ]
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Milestone"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submission"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "u32": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "all_required_met"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "criteria"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "description"
+                              },
+                              "val": {
+                                "string": "Must pass"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "idx"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "is_required"
+                              },
+                              "val": {
+                                "bool": true
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "evidence_urls"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "string": "proof"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grant_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_idx"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "statuses"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "u32": 3
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitted_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
                   }
                 ]
               }

--- a/contracts/contracts/stellar-grants/test_snapshots/checklist/tests/test_submit_and_review_required_approved.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/checklist/tests/test_submit_and_review_required_approved.1.json
@@ -75,134 +75,17 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "ChecklistSubmission"
+                    "symbol": "Escrow"
                   },
                   {
-                    "u64": "1"
-                  },
-                  {
-                    "u32": 0
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "all_required_met"
-                    },
-                    "val": {
-                      "bool": true
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "criteria"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "description"
-                              },
-                              "val": {
-                                "string": "Code compiles"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "idx"
-                              },
-                              "val": {
-                                "u32": 0
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "is_required"
-                              },
-                              "val": {
-                                "bool": true
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "evidence_urls"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "string": "https://example.com"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "grant_id"
-                    },
-                    "val": {
-                      "u64": "1"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestone_idx"
-                    },
-                    "val": {
-                      "u32": 0
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "statuses"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "u32": 2
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "submitted_at"
-                    },
-                    "val": {
-                      "u64": "0"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "EscrowAccount"
-                  },
-                  {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "Account"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -302,7 +185,14 @@
                     "symbol": "Grant"
                   },
                   {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -455,13 +345,20 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "MilestoneChecklist"
+                    "symbol": "Milestone"
                   },
                   {
-                    "u64": "1"
-                  },
-                  {
-                    "u32": 0
+                    "vec": [
+                      {
+                        "symbol": "Checklist"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "u32": 0
+                      }
+                    ]
                   }
                 ]
               },
@@ -495,6 +392,137 @@
                         }
                       }
                     ]
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Milestone"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Submission"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "u32": 0
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "all_required_met"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "criteria"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "description"
+                              },
+                              "val": {
+                                "string": "Code compiles"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "idx"
+                              },
+                              "val": {
+                                "u32": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "is_required"
+                              },
+                              "val": {
+                                "bool": true
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "evidence_urls"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "string": "https://example.com"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grant_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_idx"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "statuses"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "u32": 2
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "submitted_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
                   }
                 ]
               }

--- a/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_attest_and_is_verified.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_attest_and_is_verified.1.json
@@ -1,0 +1,310 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "VerificationAttestation"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "attestation_hash"
+                    },
+                    "val": {
+                      "bytes": ""
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "attested_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "expires_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "level"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "subject"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "verifier"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "VerifierContract"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "contributor_verified"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "expires_at"
+                  },
+                  "val": "void"
+                },
+                {
+                  "key": {
+                    "symbol": "level"
+                  },
+                  "val": {
+                    "u32": 2
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "subject"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "verifier"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_expired_attestation_is_unverified.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_expired_attestation_is_unverified.1.json
@@ -1,0 +1,314 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 10,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "VerificationAttestation"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "attestation_hash"
+                    },
+                    "val": {
+                      "bytes": ""
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "attested_at"
+                    },
+                    "val": {
+                      "u64": "10"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "expires_at"
+                    },
+                    "val": {
+                      "u64": "5"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "level"
+                    },
+                    "val": {
+                      "u32": 4
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "subject"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "verifier"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "VerifierContract"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "contributor_verified"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "expires_at"
+                  },
+                  "val": {
+                    "u64": "5"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "level"
+                  },
+                  "val": {
+                    "u32": 4
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "subject"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "verifier"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_payout_below_threshold_skips_check.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_payout_below_threshold_skips_check.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_revoke_marks_unverified.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_revoke_marks_unverified.1.json
@@ -1,0 +1,239 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "VerificationAttestation"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "attestation_hash"
+                    },
+                    "val": {
+                      "bytes": ""
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "attested_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "expires_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "level"
+                    },
+                    "val": {
+                      "u32": 4
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "subject"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "verifier"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "VerifierContract"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "verification_revoked"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "revoked_by"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "subject"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_unauthorized_attester_rejected.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/contributor_verification/tests/test_unauthorized_attester_rejected.1.json
@@ -1,0 +1,176 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "VerifierContract"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/factory/tests/test_research_template_creates_grant.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/factory/tests/test_research_template_creates_grant.1.json
@@ -28,10 +28,377 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "AuditLog"
+                    "symbol": "Config"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "decay_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "decay_floor"
+                          },
+                          "val": {
+                            "u32": 50
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "decay_type"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "half_life_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "inactivity_threshold_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "linear_decay_per_day"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
                   },
                   {
-                    "u64": "1"
+                    "key": {
+                      "symbol": "dispute_window_ledgers"
+                    },
+                    "val": {
+                      "u32": 17280
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "fast_bonus_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "kyc_payout_threshold"
+                    },
+                    "val": {
+                      "i128": "170141183460469231731687303715884105727"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_desc_len"
+                    },
+                    "val": {
+                      "u32": 1024
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_title_len"
+                    },
+                    "val": {
+                      "u32": 128
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_milestones_per_grant"
+                    },
+                    "val": {
+                      "u32": 20
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_reviewers"
+                    },
+                    "val": {
+                      "u32": 10
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "min_stake_amount"
+                    },
+                    "val": {
+                      "i128": "1000000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_escrow_threshold"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_threshold"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "protocol_fee_bps"
+                    },
+                    "val": {
+                      "u32": 100
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "quorum_threshold_bps"
+                    },
+                    "val": {
+                      "u32": 5001
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "rate_limit_multiplier"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "referral_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revenue_share_pool_bps"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewer_reward_pool_bps"
+                    },
+                    "val": {
+                      "u32": 2000
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Escrow"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Account"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "balance"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "locked"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_deposited"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_released"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Escrow"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "State"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "approvals_count"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "lifecycle"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "mode"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "quorum_ready"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "AuditLog"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -114,125 +481,20 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "EscrowAccount"
+                    "symbol": "Grant"
                   },
                   {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "Counter"
+                      }
+                    ]
                   }
                 ]
               },
               "durability": "persistent",
               "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "balance"
-                    },
-                    "val": {
-                      "i128": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "locked"
-                    },
-                    "val": {
-                      "bool": false
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "owner"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "token"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "total_deposited"
-                    },
-                    "val": {
-                      "i128": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "total_released"
-                    },
-                    "val": {
-                      "i128": "0"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "EscrowState"
-                  },
-                  {
-                    "u64": "1"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "approvals_count"
-                    },
-                    "val": {
-                      "u32": 0
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "lifecycle"
-                    },
-                    "val": {
-                      "u32": 1
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "mode"
-                    },
-                    "val": {
-                      "u32": 1
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "quorum_ready"
-                    },
-                    "val": {
-                      "bool": false
-                    }
-                  }
-                ]
+                "u64": "1"
               }
             }
           },
@@ -253,7 +515,48 @@
                     "symbol": "Grant"
                   },
                   {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "CurrentVersion"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u32": 1
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
@@ -412,40 +715,24 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "GrantCounter"
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "GlobalOrder"
+                      }
+                    ]
                   }
                 ]
               },
               "durability": "persistent",
               "val": {
-                "u64": "1"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
                 "vec": [
-                  {
-                    "symbol": "MultisigSigners"
-                  },
                   {
                     "u64": "1"
                   }
                 ]
-              },
-              "durability": "persistent",
-              "val": {
-                "vec": []
               }
             }
           },
@@ -463,7 +750,58 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "ProtocolConfig"
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "OwnerIndex"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "u64": "1"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "SpecVersion"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "u32": 1
+                      }
+                    ]
                   }
                 ]
               },
@@ -472,79 +810,61 @@
                 "map": [
                   {
                     "key": {
-                      "symbol": "dispute_window_ledgers"
+                      "symbol": "amendment_id"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "created_at"
                     },
                     "val": {
-                      "u32": 17280
+                      "u64": "0"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "max_grant_desc_len"
+                      "symbol": "description"
                     },
                     "val": {
-                      "u32": 1024
+                      "string": "Desc"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "max_grant_title_len"
+                      "symbol": "grant_id"
                     },
                     "val": {
-                      "u32": 128
+                      "u64": "1"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "max_milestones_per_grant"
+                      "symbol": "title"
                     },
                     "val": {
-                      "u32": 20
+                      "string": "Research"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "max_reviewers"
+                      "symbol": "total_amount"
                     },
                     "val": {
-                      "u32": 10
+                      "i128": "400"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "min_stake_amount"
+                      "symbol": "total_milestones"
                     },
                     "val": {
-                      "i128": "1000000"
+                      "u32": 4
                     }
                   },
                   {
                     "key": {
-                      "symbol": "multisig_threshold"
-                    },
-                    "val": {
-                      "i128": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "protocol_fee_bps"
-                    },
-                    "val": {
-                      "u32": 100
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "quorum_threshold_bps"
-                    },
-                    "val": {
-                      "u32": 5001
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "rate_limit_multiplier"
+                      "symbol": "version"
                     },
                     "val": {
                       "u32": 1
@@ -568,7 +888,83 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "ProtocolMetrics"
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "StatusIndex"
+                      },
+                      {
+                        "u32": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "u64": "1"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "TokenIndex"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "u64": "1"
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Metrics"
                   }
                 ]
               },
@@ -697,16 +1093,285 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "VotingMechanism"
+                    "symbol": "Provenance"
                   },
                   {
-                    "u64": "1"
+                    "vec": [
+                      {
+                        "symbol": "ByGrant"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "u32": 1
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Provenance"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Counter"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "u32": 1
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Provenance"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Index"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": [
+                  {
+                    "u32": 1
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Provenance"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Record"
+                      },
+                      {
+                        "u32": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "actor"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "amount"
+                    },
+                    "val": {
+                      "i128": "400"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "co_contributors"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "contribution_type"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grant_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "ledger_sequence"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_idx"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "tags"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Voting"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Mechanism"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
                   }
                 ]
               },
               "durability": "persistent",
               "val": {
                 "u32": 0
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Voting"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "MultisigSigners"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "vec": []
               }
             }
           },

--- a/contracts/contracts/stellar-grants/test_snapshots/fees/tests/test_deduct_and_split_fee_respects_both_splits.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/fees/tests/test_deduct_and_split_fee_respects_both_splits.1.json
@@ -1,0 +1,457 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Config"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "decay_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "decay_floor"
+                          },
+                          "val": {
+                            "u32": 50
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "decay_type"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "half_life_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "inactivity_threshold_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "linear_decay_per_day"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "dispute_window_ledgers"
+                    },
+                    "val": {
+                      "u32": 17280
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "fast_bonus_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "kyc_payout_threshold"
+                    },
+                    "val": {
+                      "i128": "170141183460469231731687303715884105727"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_desc_len"
+                    },
+                    "val": {
+                      "u32": 1024
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_title_len"
+                    },
+                    "val": {
+                      "u32": 128
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_milestones_per_grant"
+                    },
+                    "val": {
+                      "u32": 20
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_reviewers"
+                    },
+                    "val": {
+                      "u32": 10
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "min_stake_amount"
+                    },
+                    "val": {
+                      "i128": "1000000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_escrow_threshold"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_threshold"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "protocol_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "quorum_threshold_bps"
+                    },
+                    "val": {
+                      "u32": 5001
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "rate_limit_multiplier"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "referral_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revenue_share_pool_bps"
+                    },
+                    "val": {
+                      "u32": 2000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewer_reward_pool_bps"
+                    },
+                    "val": {
+                      "u32": 3000
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "FeesCollected"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "i128": "50000"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "RevenueEpoch"
+                  },
+                  {
+                    "u32": 0
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "claimed_count"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "end_at"
+                    },
+                    "val": {
+                      "u64": "604800"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "finalized"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "start_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_revenue"
+                    },
+                    "val": {
+                      "i128": "20000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_stake_weight"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ReviewerReward"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Pool"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "balance"
+                    },
+                    "val": {
+                      "i128": "30000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_deposited"
+                    },
+                    "val": {
+                      "i128": "30000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_paid_out"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/fees/tests/test_deduct_and_split_fee_respects_reviewer_reward_split.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/fees/tests/test_deduct_and_split_fee_respects_reviewer_reward_split.1.json
@@ -1,0 +1,365 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Config"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "decay_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "decay_floor"
+                          },
+                          "val": {
+                            "u32": 50
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "decay_type"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "half_life_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "inactivity_threshold_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "linear_decay_per_day"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "dispute_window_ledgers"
+                    },
+                    "val": {
+                      "u32": 17280
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "fast_bonus_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "kyc_payout_threshold"
+                    },
+                    "val": {
+                      "i128": "170141183460469231731687303715884105727"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_desc_len"
+                    },
+                    "val": {
+                      "u32": 1024
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_title_len"
+                    },
+                    "val": {
+                      "u32": 128
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_milestones_per_grant"
+                    },
+                    "val": {
+                      "u32": 20
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_reviewers"
+                    },
+                    "val": {
+                      "u32": 10
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "min_stake_amount"
+                    },
+                    "val": {
+                      "i128": "1000000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_escrow_threshold"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_threshold"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "protocol_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "quorum_threshold_bps"
+                    },
+                    "val": {
+                      "u32": 5001
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "rate_limit_multiplier"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "referral_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revenue_share_pool_bps"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewer_reward_pool_bps"
+                    },
+                    "val": {
+                      "u32": 5000
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "FeesCollected"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "i128": "50000"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ReviewerReward"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Pool"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "balance"
+                    },
+                    "val": {
+                      "i128": "50000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_deposited"
+                    },
+                    "val": {
+                      "i128": "50000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_paid_out"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/fees/tests/test_deduct_and_split_no_revenue_share_leaves_more_to_treasury.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/fees/tests/test_deduct_and_split_no_revenue_share_leaves_more_to_treasury.1.json
@@ -1,0 +1,365 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Config"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "decay_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "decay_floor"
+                          },
+                          "val": {
+                            "u32": 50
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "decay_type"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "half_life_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "inactivity_threshold_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "linear_decay_per_day"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "dispute_window_ledgers"
+                    },
+                    "val": {
+                      "u32": 17280
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "fast_bonus_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "kyc_payout_threshold"
+                    },
+                    "val": {
+                      "i128": "170141183460469231731687303715884105727"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_desc_len"
+                    },
+                    "val": {
+                      "u32": 1024
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_title_len"
+                    },
+                    "val": {
+                      "u32": 128
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_milestones_per_grant"
+                    },
+                    "val": {
+                      "u32": 20
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_reviewers"
+                    },
+                    "val": {
+                      "u32": 10
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "min_stake_amount"
+                    },
+                    "val": {
+                      "i128": "1000000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_escrow_threshold"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_threshold"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "protocol_fee_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "quorum_threshold_bps"
+                    },
+                    "val": {
+                      "u32": 5001
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "rate_limit_multiplier"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "referral_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revenue_share_pool_bps"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewer_reward_pool_bps"
+                    },
+                    "val": {
+                      "u32": 2000
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "FeesCollected"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "i128": "4000"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ReviewerReward"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Pool"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "balance"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_deposited"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_paid_out"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/fees/tests/test_deduct_and_split_zero_fee_no_ops.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/fees/tests/test_deduct_and_split_zero_fee_no_ops.1.json
@@ -1,0 +1,271 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Config"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "decay_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "decay_floor"
+                          },
+                          "val": {
+                            "u32": 50
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "decay_type"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "half_life_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "inactivity_threshold_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "linear_decay_per_day"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "dispute_window_ledgers"
+                    },
+                    "val": {
+                      "u32": 17280
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "fast_bonus_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "kyc_payout_threshold"
+                    },
+                    "val": {
+                      "i128": "170141183460469231731687303715884105727"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_desc_len"
+                    },
+                    "val": {
+                      "u32": 1024
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_grant_title_len"
+                    },
+                    "val": {
+                      "u32": 128
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_milestones_per_grant"
+                    },
+                    "val": {
+                      "u32": 20
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "max_reviewers"
+                    },
+                    "val": {
+                      "u32": 10
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "min_stake_amount"
+                    },
+                    "val": {
+                      "i128": "1000000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_escrow_threshold"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "multisig_threshold"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "protocol_fee_bps"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "quorum_threshold_bps"
+                    },
+                    "val": {
+                      "u32": 5001
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "rate_limit_multiplier"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "referral_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revenue_share_pool_bps"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewer_reward_pool_bps"
+                    },
+                    "val": {
+                      "u32": 2000
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_auto_unpause_elapsed_is_paused_false.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_auto_unpause_elapsed_is_paused_false.1.json
@@ -1,0 +1,331 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 101,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "escrow_balance"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "funders"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_amount"
+                    },
+                    "val": {
+                      "i128": "500"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_paid_out"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "require_compliance"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Test Grant"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_milestones"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GrantPaused"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "auto_unpause_at"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grant_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_by"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": {
+                      "string": "auto"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "unpause_history"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_only_owner_can_pause.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_only_owner_can_pause.1.json
@@ -1,0 +1,254 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "escrow_balance"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "funders"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_amount"
+                    },
+                    "val": {
+                      "i128": "500"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_paid_out"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "require_compliance"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Test Grant"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_milestones"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_only_owner_can_unpause.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_only_owner_can_unpause.1.json
@@ -1,0 +1,385 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ],
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "escrow_balance"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "funders"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_amount"
+                    },
+                    "val": {
+                      "i128": "500"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_paid_out"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "require_compliance"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Test Grant"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_milestones"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GrantPaused"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "auto_unpause_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "grant_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_by"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": {
+                      "string": "reason"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "unpause_history"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "grant_paused"
+              },
+              {
+                "u64": "1"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_pause_and_unpause_flow.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_pause_and_unpause_flow.1.json
@@ -1,0 +1,400 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "escrow_balance"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "funders"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_amount"
+                    },
+                    "val": {
+                      "i128": "500"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_paid_out"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "require_compliance"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Test Grant"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_milestones"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GrantPaused"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "auto_unpause_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grant_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_by"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": {
+                      "string": "maintenance"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "unpause_history"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                            },
+                            {
+                              "u64": "0"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "5541220902715666415"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "grant_unpaused"
+              },
+              {
+                "u64": "1"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_require_not_paused_blocks_when_paused.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_require_not_paused_blocks_when_paused.1.json
@@ -1,0 +1,352 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "escrow_balance"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "funders"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_amount"
+                    },
+                    "val": {
+                      "i128": "500"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_paid_out"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "require_compliance"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Test Grant"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_milestones"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GrantPaused"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "auto_unpause_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "grant_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_by"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": {
+                      "string": "test"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "unpause_history"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "grant_paused"
+              },
+              {
+                "u64": "1"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_try_auto_unpause_records_history.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/grant_pause/tests/test_try_auto_unpause_records_history.1.json
@@ -1,0 +1,366 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 101,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "Grant"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Data"
+                      },
+                      {
+                        "u64": "1"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "description"
+                    },
+                    "val": {
+                      "string": "desc"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "escrow_balance"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "funders"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestone_amount"
+                    },
+                    "val": {
+                      "i128": "500"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_paid_out"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "owner"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "require_compliance"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewers"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "status"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "title"
+                    },
+                    "val": {
+                      "string": "Test Grant"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_amount"
+                    },
+                    "val": {
+                      "i128": "1000"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_milestones"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GrantPaused"
+                  },
+                  {
+                    "u64": "1"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "auto_unpause_at"
+                    },
+                    "val": {
+                      "u64": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grant_id"
+                    },
+                    "val": {
+                      "u64": "1"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "paused_by"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reason"
+                    },
+                    "val": {
+                      "string": "auto"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "unpause_history"
+                    },
+                    "val": {
+                      "vec": [
+                        {
+                          "vec": [
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                            },
+                            {
+                              "u64": "101"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+              "key": {
+                "ledger_key_nonce": {
+                  "nonce": "801925984706572462"
+                }
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 6311999
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "grant_unpaused"
+              },
+              {
+                "u64": "1"
+              }
+            ],
+            "data": {
+              "u64": "100"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/merkle/tests/test_tampered_leaf_fails_verification.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/merkle/tests/test_tampered_leaf_fails_verification.1.json
@@ -28,13 +28,20 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "MerkleCommitment"
+                    "symbol": "Milestone"
                   },
                   {
-                    "u64": "1"
-                  },
-                  {
-                    "u32": 0
+                    "vec": [
+                      {
+                        "symbol": "MerkleCommit"
+                      },
+                      {
+                        "u64": "1"
+                      },
+                      {
+                        "u32": 0
+                      }
+                    ]
                   }
                 ]
               },

--- a/contracts/contracts/stellar-grants/test_snapshots/rate_limit/tests/test_admin_bypasses_limit.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/rate_limit/tests/test_admin_bypasses_limit.1.json
@@ -28,31 +28,7 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "GlobalAdmin"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "ProtocolConfig"
+                    "symbol": "Config"
                   }
                 ]
               },
@@ -61,10 +37,83 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "decay_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "decay_floor"
+                          },
+                          "val": {
+                            "u32": 50
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "decay_type"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "half_life_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "inactivity_threshold_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "linear_decay_per_day"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "dispute_window_ledgers"
                     },
                     "val": {
                       "u32": 17280
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "fast_bonus_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "kyc_payout_threshold"
+                    },
+                    "val": {
+                      "i128": "170141183460469231731687303715884105727"
                     }
                   },
                   {
@@ -109,6 +158,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "multisig_escrow_threshold"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "multisig_threshold"
                     },
                     "val": {
@@ -138,6 +195,30 @@
                     "val": {
                       "u32": 1
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "referral_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revenue_share_pool_bps"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewer_reward_pool_bps"
+                    },
+                    "val": {
+                      "u32": 2000
+                    }
                   }
                 ]
               }
@@ -146,6 +227,30 @@
           "ext": "v0"
         },
         "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
       },
       {
         "entry": {

--- a/contracts/contracts/stellar-grants/test_snapshots/rate_limit/tests/test_exceed_limit_returns_error.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/rate_limit/tests/test_exceed_limit_returns_error.1.json
@@ -28,31 +28,7 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "GlobalAdmin"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "ProtocolConfig"
+                    "symbol": "Config"
                   }
                 ]
               },
@@ -61,10 +37,83 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "decay_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "decay_floor"
+                          },
+                          "val": {
+                            "u32": 50
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "decay_type"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "half_life_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "inactivity_threshold_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "linear_decay_per_day"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "dispute_window_ledgers"
                     },
                     "val": {
                       "u32": 17280
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "fast_bonus_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "kyc_payout_threshold"
+                    },
+                    "val": {
+                      "i128": "170141183460469231731687303715884105727"
                     }
                   },
                   {
@@ -109,6 +158,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "multisig_escrow_threshold"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "multisig_threshold"
                     },
                     "val": {
@@ -138,6 +195,30 @@
                     "val": {
                       "u32": 1
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "referral_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revenue_share_pool_bps"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewer_reward_pool_bps"
+                    },
+                    "val": {
+                      "u32": 2000
+                    }
                   }
                 ]
               }
@@ -146,6 +227,30 @@
           "ext": "v0"
         },
         "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
       },
       {
         "entry": {

--- a/contracts/contracts/stellar-grants/test_snapshots/rate_limit/tests/test_reset_record_clears_count.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/rate_limit/tests/test_reset_record_clears_count.1.json
@@ -62,31 +62,7 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "GlobalAdmin"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "ProtocolConfig"
+                    "symbol": "Config"
                   }
                 ]
               },
@@ -95,10 +71,83 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "decay_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "decay_floor"
+                          },
+                          "val": {
+                            "u32": 50
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "decay_type"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "half_life_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "inactivity_threshold_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "linear_decay_per_day"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "dispute_window_ledgers"
                     },
                     "val": {
                       "u32": 17280
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "fast_bonus_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "kyc_payout_threshold"
+                    },
+                    "val": {
+                      "i128": "170141183460469231731687303715884105727"
                     }
                   },
                   {
@@ -143,6 +192,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "multisig_escrow_threshold"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "multisig_threshold"
                     },
                     "val": {
@@ -172,6 +229,30 @@
                     "val": {
                       "u32": 1
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "referral_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revenue_share_pool_bps"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewer_reward_pool_bps"
+                    },
+                    "val": {
+                      "u32": 2000
+                    }
                   }
                 ]
               }
@@ -180,6 +261,30 @@
           "ext": "v0"
         },
         "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
       },
       {
         "entry": {

--- a/contracts/contracts/stellar-grants/test_snapshots/rate_limit/tests/test_window_reset_allows_new_actions.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/rate_limit/tests/test_window_reset_allows_new_actions.1.json
@@ -28,31 +28,7 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "GlobalAdmin"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "ProtocolConfig"
+                    "symbol": "Config"
                   }
                 ]
               },
@@ -61,10 +37,83 @@
                 "map": [
                   {
                     "key": {
+                      "symbol": "decay_config"
+                    },
+                    "val": {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "decay_floor"
+                          },
+                          "val": {
+                            "u32": 50
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "decay_type"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "enabled"
+                          },
+                          "val": {
+                            "bool": false
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "half_life_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "inactivity_threshold_ledgers"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "linear_decay_per_day"
+                          },
+                          "val": {
+                            "u32": 0
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "dispute_window_ledgers"
                     },
                     "val": {
                       "u32": 17280
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "fast_bonus_bps"
+                    },
+                    "val": {
+                      "u32": 500
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "kyc_payout_threshold"
+                    },
+                    "val": {
+                      "i128": "170141183460469231731687303715884105727"
                     }
                   },
                   {
@@ -109,6 +158,14 @@
                   },
                   {
                     "key": {
+                      "symbol": "multisig_escrow_threshold"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
                       "symbol": "multisig_threshold"
                     },
                     "val": {
@@ -138,6 +195,30 @@
                     "val": {
                       "u32": 1
                     }
+                  },
+                  {
+                    "key": {
+                      "symbol": "referral_fee_bps"
+                    },
+                    "val": {
+                      "u32": 1000
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "revenue_share_pool_bps"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reviewer_reward_pool_bps"
+                    },
+                    "val": {
+                      "u32": 2000
+                    }
                   }
                 ]
               }
@@ -146,6 +227,30 @@
           "ext": "v0"
         },
         "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "GlobalAdmin"
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
       },
       {
         "entry": {

--- a/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_nested_protect_inside_external_call_detects_reentrancy.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_nested_protect_inside_external_call_detects_reentrancy.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_external_call_clears_guard_on_error.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_external_call_clears_guard_on_error.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_external_call_rejects_reentry.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_external_call_rejects_reentry.1.json
@@ -1,0 +1,83 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ExternalCallGuard"
+                  }
+                ]
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 15
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_external_call_succeeds.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_external_call_succeeds.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_fails_when_guard_held.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_fails_when_guard_held.1.json
@@ -1,0 +1,83 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "ExternalCallGuard"
+                  }
+                ]
+              },
+              "durability": "temporary",
+              "val": "void"
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 15
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_succeeds_when_guard_not_held.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/reentrancy/tests/test_protect_succeeds_when_guard_not_held.1.json
@@ -1,0 +1,61 @@
+{
+  "generators": {
+    "address": 1,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 25,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": "ledger_key_contract_instance",
+              "durability": "persistent",
+              "val": {
+                "contract_instance": {
+                  "executable": {
+                    "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "storage": null
+                }
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_code": {
+              "ext": "v0",
+              "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "code": ""
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      }
+    ]
+  },
+  "events": []
+}

--- a/contracts/contracts/stellar-grants/test_snapshots/revenue_share/tests/test_claim_after_epoch_finalized_and_rejects_double_claim.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/revenue_share/tests/test_claim_after_epoch_finalized_and_rejects_double_claim.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 5,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
@@ -8,37 +8,15 @@
     [],
     [
       [
-        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "function_name": "set_admin",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                }
-              ]
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
-              "function_name": "mint",
-              "args": [
-                {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                },
-                {
-                  "i128": "1000000"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -53,14 +31,14 @@
         {
           "function": {
             "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "set_global_admin",
+              "contract_address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
+              "function_name": "mint",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
                 },
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  "i128": "100"
                 }
               ]
             }
@@ -72,37 +50,23 @@
     [],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
         {
           "function": {
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "",
-              "args": []
+              "function_name": "claim_revenue_share",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                },
+                {
+                  "u32": 0
+                }
+              ]
             }
           },
-          "sub_invocations": [
-            {
-              "function": {
-                "contract_fn": {
-                  "contract_address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
-                  "function_name": "transfer",
-                  "args": [
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    },
-                    {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
-                    },
-                    {
-                      "i128": "1000"
-                    }
-                  ]
-                }
-              },
-              "sub_invocations": []
-            }
-          ]
+          "sub_invocations": []
         }
       ]
     ],
@@ -123,7 +87,7 @@
           "last_modified_ledger_seq": 0,
           "data": {
             "account": {
-              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+              "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "balance": "0",
               "seq_num": "0",
               "num_sub_entries": 0,
@@ -145,7 +109,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV",
+              "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V",
               "key": {
                 "ledger_key_nonce": {
                   "nonce": "801925984706572462"
@@ -169,17 +133,10 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "Escrow"
+                    "symbol": "RevenueEpoch"
                   },
                   {
-                    "vec": [
-                      {
-                        "symbol": "Account"
-                      },
-                      {
-                        "u64": "1"
-                      }
-                    ]
+                    "u32": 0
                   }
                 ]
               },
@@ -188,262 +145,26 @@
                 "map": [
                   {
                     "key": {
-                      "symbol": "balance"
+                      "symbol": "claimed_count"
                     },
                     "val": {
-                      "i128": "1000"
+                      "u32": 1
                     }
                   },
                   {
                     "key": {
-                      "symbol": "locked"
+                      "symbol": "end_at"
                     },
                     "val": {
-                      "bool": false
+                      "u64": "604800"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "owner"
+                      "symbol": "finalized"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "token"
-                    },
-                    "val": {
-                      "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "total_deposited"
-                    },
-                    "val": {
-                      "i128": "1000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "total_released"
-                    },
-                    "val": {
-                      "i128": "0"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "Escrow"
-                  },
-                  {
-                    "vec": [
-                      {
-                        "symbol": "FunderContrib"
-                      },
-                      {
-                        "u64": "1"
-                      },
-                      {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                      }
-                    ]
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "contributed"
-                    },
-                    "val": {
-                      "i128": "1000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "funder"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "last_contribution_at"
-                    },
-                    "val": {
-                      "u64": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "refunded"
-                    },
-                    "val": {
-                      "i128": "0"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "Escrow"
-                  },
-                  {
-                    "vec": [
-                      {
-                        "symbol": "FundersList"
-                      },
-                      {
-                        "u64": "1"
-                      }
-                    ]
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "vec": [
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 1000000
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "GlobalAdmin"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "Grant"
-                  },
-                  {
-                    "vec": [
-                      {
-                        "symbol": "Data"
-                      },
-                      {
-                        "u64": "1"
-                      }
-                    ]
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "description"
-                    },
-                    "val": {
-                      "string": "desc"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "escrow_balance"
-                    },
-                    "val": {
-                      "i128": "1000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "funders"
-                    },
-                    "val": {
-                      "vec": [
-                        {
-                          "map": [
-                            {
-                              "key": {
-                                "symbol": "amount"
-                              },
-                              "val": {
-                                "i128": "1000"
-                              }
-                            },
-                            {
-                              "key": {
-                                "symbol": "funder"
-                              },
-                              "val": {
-                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                              }
-                            }
-                          ]
-                        }
-                      ]
+                      "bool": true
                     }
                   },
                   {
@@ -451,64 +172,12 @@
                       "symbol": "id"
                     },
                     "val": {
-                      "u64": "1"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestone_amount"
-                    },
-                    "val": {
-                      "i128": "10000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestones_paid_out"
-                    },
-                    "val": {
                       "u32": 0
                     }
                   },
                   {
                     "key": {
-                      "symbol": "owner"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "reason"
-                    },
-                    "val": "void"
-                  },
-                  {
-                    "key": {
-                      "symbol": "require_compliance"
-                    },
-                    "val": "void"
-                  },
-                  {
-                    "key": {
-                      "symbol": "reviewers"
-                    },
-                    "val": {
-                      "vec": []
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "status"
-                    },
-                    "val": {
-                      "u32": 1
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "timestamp"
+                      "symbol": "start_at"
                     },
                     "val": {
                       "u64": "0"
@@ -516,34 +185,26 @@
                   },
                   {
                     "key": {
-                      "symbol": "title"
-                    },
-                    "val": {
-                      "string": "test"
-                    }
-                  },
-                  {
-                    "key": {
                       "symbol": "token"
                     },
                     "val": {
-                      "address": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG"
+                      "address": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "total_amount"
+                      "symbol": "total_revenue"
                     },
                     "val": {
-                      "i128": "100000"
+                      "i128": "100"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "total_milestones"
+                      "symbol": "total_stake_weight"
                     },
                     "val": {
-                      "u32": 1
+                      "i128": "100"
                     }
                   }
                 ]
@@ -552,7 +213,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 4095
+        "live_until": 1000000
       },
       {
         "entry": {
@@ -564,25 +225,66 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "User"
+                    "symbol": "StakerEpochRecord"
                   },
                   {
-                    "vec": [
-                      {
-                        "symbol": "FunderGrants"
-                      },
-                      {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                      }
-                    ]
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  },
+                  {
+                    "u32": 0
                   }
                 ]
               },
               "durability": "persistent",
               "val": {
-                "vec": [
+                "map": [
                   {
-                    "u64": "1"
+                    "key": {
+                      "symbol": "claimable"
+                    },
+                    "val": {
+                      "i128": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "claimed"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "claimed_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "epoch_id"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "stake_weight"
+                    },
+                    "val": {
+                      "i128": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "staker"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
                   }
                 ]
               }
@@ -624,27 +326,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "1033654523790656264"
-                }
-              },
-              "durability": "temporary",
-              "val": "void"
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 6311999
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
-              "key": {
-                "ledger_key_nonce": {
-                  "nonce": "4837995959683129791"
+                  "nonce": "5541220902715666415"
                 }
               },
               "durability": "temporary",
@@ -664,7 +346,7 @@
               "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4",
               "key": {
                 "ledger_key_nonce": {
-                  "nonce": "5541220902715666415"
+                  "nonce": "1033654523790656264"
                 }
               },
               "durability": "temporary",
@@ -681,7 +363,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
@@ -700,7 +382,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "1000"
+                      "i128": "0"
                     }
                   },
                   {
@@ -733,14 +415,14 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": {
                 "vec": [
                   {
                     "symbol": "Balance"
                   },
                   {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                   }
                 ]
               },
@@ -752,7 +434,7 @@
                       "symbol": "amount"
                     },
                     "val": {
-                      "i128": "999000"
+                      "i128": "100"
                     }
                   },
                   {
@@ -785,7 +467,7 @@
           "data": {
             "contract_data": {
               "ext": "v0",
-              "contract": "CDLDVFKHEZ2RVB3NG4UQA4VPD3TSHV6XMHXMHP2BSGCJ2IIWVTOHGDSG",
+              "contract": "CBUSYNQKASUYFWYC3M2GUEDMX4AIVWPALDBYJPNK6554BREHTGZ2IUNF",
               "key": "ledger_key_contract_instance",
               "durability": "persistent",
               "val": {
@@ -811,7 +493,7 @@
                               "symbol": "name"
                             },
                             "val": {
-                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAL7NV"
+                              "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGO6V"
                             }
                           },
                           {
@@ -834,7 +516,7 @@
                         ]
                       },
                       "val": {
-                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                       }
                     },
                     {
@@ -865,7 +547,7 @@
                                   "symbol": "issuer"
                                 },
                                 "val": {
-                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000005"
+                                  "bytes": "0000000000000000000000000000000000000000000000000000000000000003"
                                 }
                               }
                             ]

--- a/contracts/contracts/stellar-grants/test_snapshots/revenue_share/tests/test_compute_claim_proportional_to_weight.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/revenue_share/tests/test_compute_claim_proportional_to_weight.1.json
@@ -1,27 +1,12 @@
 {
   "generators": {
-    "address": 5,
+    "address": 4,
     "nonce": 0,
     "mux_id": 0
   },
   "auth": [
     [],
-    [],
-    [
-      [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-        {
-          "function": {
-            "contract_fn": {
-              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "function_name": "",
-              "args": []
-            }
-          },
-          "sub_invocations": []
-        }
-      ]
-    ]
+    []
   ],
   "ledger": {
     "protocol_version": 25,
@@ -43,17 +28,10 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "Escrow"
+                    "symbol": "RevenueEpoch"
                   },
                   {
-                    "vec": [
-                      {
-                        "symbol": "Account"
-                      },
-                      {
-                        "u64": "1"
-                      }
-                    ]
+                    "u32": 0
                   }
                 ]
               },
@@ -62,26 +40,42 @@
                 "map": [
                   {
                     "key": {
-                      "symbol": "balance"
+                      "symbol": "claimed_count"
                     },
                     "val": {
-                      "i128": "0"
+                      "u32": 0
                     }
                   },
                   {
                     "key": {
-                      "symbol": "locked"
+                      "symbol": "end_at"
                     },
                     "val": {
-                      "bool": false
+                      "u64": "604800"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "owner"
+                      "symbol": "finalized"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "start_at"
+                    },
+                    "val": {
+                      "u64": "0"
                     }
                   },
                   {
@@ -89,23 +83,23 @@
                       "symbol": "token"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "total_deposited"
+                      "symbol": "total_revenue"
                     },
                     "val": {
-                      "i128": "0"
+                      "i128": "300"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "total_released"
+                      "symbol": "total_stake_weight"
                     },
                     "val": {
-                      "i128": "0"
+                      "i128": "300"
                     }
                   }
                 ]
@@ -126,19 +120,72 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "GlobalAdmin"
+                    "symbol": "StakerEpochRecord"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  },
+                  {
+                    "u32": 0
                   }
                 ]
               },
               "durability": "persistent",
               "val": {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "claimable"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "claimed"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "claimed_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "epoch_id"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "stake_weight"
+                    },
+                    "val": {
+                      "i128": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "staker"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  }
+                ]
               }
             }
           },
           "ext": "v0"
         },
-        "live_until": 4095
+        "live_until": 1000000
       },
       {
         "entry": {
@@ -150,17 +197,13 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "Grant"
+                    "symbol": "StakerEpochRecord"
                   },
                   {
-                    "vec": [
-                      {
-                        "symbol": "Data"
-                      },
-                      {
-                        "u64": "1"
-                      }
-                    ]
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  },
+                  {
+                    "u32": 0
                   }
                 ]
               },
@@ -169,15 +212,7 @@
                 "map": [
                   {
                     "key": {
-                      "symbol": "description"
-                    },
-                    "val": {
-                      "string": "desc"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "escrow_balance"
+                      "symbol": "claimable"
                     },
                     "val": {
                       "i128": "0"
@@ -185,31 +220,21 @@
                   },
                   {
                     "key": {
-                      "symbol": "funders"
+                      "symbol": "claimed"
                     },
                     "val": {
-                      "vec": []
+                      "bool": false
                     }
                   },
                   {
                     "key": {
-                      "symbol": "id"
+                      "symbol": "claimed_at"
                     },
-                    "val": {
-                      "u64": "1"
-                    }
+                    "val": "void"
                   },
                   {
                     "key": {
-                      "symbol": "milestone_amount"
-                    },
-                    "val": {
-                      "i128": "10000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestones_paid_out"
+                      "symbol": "epoch_id"
                     },
                     "val": {
                       "u32": 0
@@ -217,82 +242,18 @@
                   },
                   {
                     "key": {
-                      "symbol": "owner"
+                      "symbol": "stake_weight"
                     },
                     "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      "i128": "200"
                     }
                   },
                   {
                     "key": {
-                      "symbol": "reason"
-                    },
-                    "val": "void"
-                  },
-                  {
-                    "key": {
-                      "symbol": "require_compliance"
-                    },
-                    "val": "void"
-                  },
-                  {
-                    "key": {
-                      "symbol": "reviewers"
+                      "symbol": "staker"
                     },
                     "val": {
-                      "vec": [
-                        {
-                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "status"
-                    },
-                    "val": {
-                      "u32": 1
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "timestamp"
-                    },
-                    "val": {
-                      "u64": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "title"
-                    },
-                    "val": {
-                      "string": "test"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "token"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "total_amount"
-                    },
-                    "val": {
-                      "i128": "100000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "total_milestones"
-                    },
-                    "val": {
-                      "u32": 3
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
                     }
                   }
                 ]
@@ -301,7 +262,7 @@
           },
           "ext": "v0"
         },
-        "live_until": 4095
+        "live_until": 1000000
       },
       {
         "entry": {
@@ -325,26 +286,6 @@
           "ext": "v0"
         },
         "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
-              "key": {
-                "ledger_key_nonce": {
-                  "nonce": "801925984706572462"
-                }
-              },
-              "durability": "temporary",
-              "val": "void"
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 6311999
       },
       {
         "entry": {

--- a/contracts/contracts/stellar-grants/test_snapshots/revenue_share/tests/test_unclaimed_epochs_returns_finalized_records.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/revenue_share/tests/test_unclaimed_epochs_returns_finalized_records.1.json
@@ -11,7 +11,7 @@
   "ledger": {
     "protocol_version": 25,
     "sequence_number": 0,
-    "timestamp": 0,
+    "timestamp": 604800,
     "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
     "base_reserve": 0,
     "min_persistent_entry_ttl": 4096,
@@ -28,7 +28,10 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "Config"
+                    "symbol": "RevenueEpoch"
+                  },
+                  {
+                    "u32": 0
                   }
                 ]
               },
@@ -37,176 +40,7 @@
                 "map": [
                   {
                     "key": {
-                      "symbol": "decay_config"
-                    },
-                    "val": {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "decay_floor"
-                          },
-                          "val": {
-                            "u32": 50
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "decay_type"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "enabled"
-                          },
-                          "val": {
-                            "bool": false
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "half_life_ledgers"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "inactivity_threshold_ledgers"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "linear_decay_per_day"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "dispute_window_ledgers"
-                    },
-                    "val": {
-                      "u32": 17280
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "fast_bonus_bps"
-                    },
-                    "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "kyc_payout_threshold"
-                    },
-                    "val": {
-                      "i128": "170141183460469231731687303715884105727"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "max_grant_desc_len"
-                    },
-                    "val": {
-                      "u32": 1024
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "max_grant_title_len"
-                    },
-                    "val": {
-                      "u32": 128
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "max_milestones_per_grant"
-                    },
-                    "val": {
-                      "u32": 20
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "max_reviewers"
-                    },
-                    "val": {
-                      "u32": 10
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "min_stake_amount"
-                    },
-                    "val": {
-                      "i128": "1000000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "multisig_escrow_threshold"
-                    },
-                    "val": {
-                      "u32": 2
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "multisig_threshold"
-                    },
-                    "val": {
-                      "i128": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "protocol_fee_bps"
-                    },
-                    "val": {
-                      "u32": 100
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "quorum_threshold_bps"
-                    },
-                    "val": {
-                      "u32": 5001
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "rate_limit_multiplier"
-                    },
-                    "val": {
-                      "u32": 1
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "referral_fee_bps"
-                    },
-                    "val": {
-                      "u32": 1000
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "revenue_share_pool_bps"
+                      "symbol": "claimed_count"
                     },
                     "val": {
                       "u32": 0
@@ -214,10 +48,135 @@
                   },
                   {
                     "key": {
-                      "symbol": "reviewer_reward_pool_bps"
+                      "symbol": "end_at"
                     },
                     "val": {
-                      "u32": 2000
+                      "u64": "604800"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "finalized"
+                    },
+                    "val": {
+                      "bool": true
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "start_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_revenue"
+                    },
+                    "val": {
+                      "i128": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_stake_weight"
+                    },
+                    "val": {
+                      "i128": "100"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "StakerEpochRecord"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  },
+                  {
+                    "u32": 0
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "claimable"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "claimed"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "claimed_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "epoch_id"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "stake_weight"
+                    },
+                    "val": {
+                      "i128": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "staker"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   }
                 ]

--- a/contracts/contracts/stellar-grants/test_snapshots/revenue_share/tests/test_unfinalized_epoch_has_no_claim.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/revenue_share/tests/test_unfinalized_epoch_has_no_claim.1.json
@@ -6,6 +6,7 @@
   },
   "auth": [
     [],
+    [],
     []
   ],
   "ledger": {
@@ -28,7 +29,10 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "Config"
+                    "symbol": "RevenueEpoch"
+                  },
+                  {
+                    "u32": 0
                   }
                 ]
               },
@@ -37,176 +41,7 @@
                 "map": [
                   {
                     "key": {
-                      "symbol": "decay_config"
-                    },
-                    "val": {
-                      "map": [
-                        {
-                          "key": {
-                            "symbol": "decay_floor"
-                          },
-                          "val": {
-                            "u32": 50
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "decay_type"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "enabled"
-                          },
-                          "val": {
-                            "bool": false
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "half_life_ledgers"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "inactivity_threshold_ledgers"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        },
-                        {
-                          "key": {
-                            "symbol": "linear_decay_per_day"
-                          },
-                          "val": {
-                            "u32": 0
-                          }
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "dispute_window_ledgers"
-                    },
-                    "val": {
-                      "u32": 17280
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "fast_bonus_bps"
-                    },
-                    "val": {
-                      "u32": 500
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "kyc_payout_threshold"
-                    },
-                    "val": {
-                      "i128": "170141183460469231731687303715884105727"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "max_grant_desc_len"
-                    },
-                    "val": {
-                      "u32": 1024
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "max_grant_title_len"
-                    },
-                    "val": {
-                      "u32": 128
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "max_milestones_per_grant"
-                    },
-                    "val": {
-                      "u32": 20
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "max_reviewers"
-                    },
-                    "val": {
-                      "u32": 10
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "min_stake_amount"
-                    },
-                    "val": {
-                      "i128": "1000000"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "multisig_escrow_threshold"
-                    },
-                    "val": {
-                      "u32": 2
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "multisig_threshold"
-                    },
-                    "val": {
-                      "i128": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "protocol_fee_bps"
-                    },
-                    "val": {
-                      "u32": 100
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "quorum_threshold_bps"
-                    },
-                    "val": {
-                      "u32": 5001
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "rate_limit_multiplier"
-                    },
-                    "val": {
-                      "u32": 1
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "referral_fee_bps"
-                    },
-                    "val": {
-                      "u32": 1000
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "revenue_share_pool_bps"
+                      "symbol": "claimed_count"
                     },
                     "val": {
                       "u32": 0
@@ -214,10 +49,135 @@
                   },
                   {
                     "key": {
-                      "symbol": "reviewer_reward_pool_bps"
+                      "symbol": "end_at"
                     },
                     "val": {
-                      "u32": 2000
+                      "u64": "604800"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "finalized"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "id"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "start_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "token"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_revenue"
+                    },
+                    "val": {
+                      "i128": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_stake_weight"
+                    },
+                    "val": {
+                      "i128": "100"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 1000000
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "StakerEpochRecord"
+                  },
+                  {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  },
+                  {
+                    "u32": 0
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "claimable"
+                    },
+                    "val": {
+                      "i128": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "claimed"
+                    },
+                    "val": {
+                      "bool": false
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "claimed_at"
+                    },
+                    "val": "void"
+                  },
+                  {
+                    "key": {
+                      "symbol": "epoch_id"
+                    },
+                    "val": {
+                      "u32": 0
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "stake_weight"
+                    },
+                    "val": {
+                      "i128": "100"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "staker"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
                     }
                   }
                 ]

--- a/contracts/contracts/stellar-grants/test_snapshots/scoring/tests/test_rank_contributors.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/scoring/tests/test_rank_contributors.1.json
@@ -46,238 +46,6 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "Contributor"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "bio"
-                    },
-                    "val": {
-                      "string": "bio"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "contributor"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "github_url"
-                    },
-                    "val": {
-                      "string": "https://github.com"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "grants_count"
-                    },
-                    "val": {
-                      "u32": 5
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestones_completed"
-                    },
-                    "val": {
-                      "u32": 8
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestones_rejected"
-                    },
-                    "val": {
-                      "u32": 2
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "name"
-                    },
-                    "val": {
-                      "string": "test"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "registration_timestamp"
-                    },
-                    "val": {
-                      "u64": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "reputation_score"
-                    },
-                    "val": {
-                      "u64": "750"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "skills"
-                    },
-                    "val": {
-                      "vec": []
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "total_earned"
-                    },
-                    "val": {
-                      "i128": "500000000000"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
-                    "symbol": "Contributor"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "bio"
-                    },
-                    "val": {
-                      "string": "bio"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "contributor"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "github_url"
-                    },
-                    "val": {
-                      "string": "url"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "grants_count"
-                    },
-                    "val": {
-                      "u32": 2
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestones_completed"
-                    },
-                    "val": {
-                      "u32": 3
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestones_rejected"
-                    },
-                    "val": {
-                      "u32": 1
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "name"
-                    },
-                    "val": {
-                      "string": "c2"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "registration_timestamp"
-                    },
-                    "val": {
-                      "u64": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "reputation_score"
-                    },
-                    "val": {
-                      "u64": "200"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "skills"
-                    },
-                    "val": {
-                      "vec": []
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "total_earned"
-                    },
-                    "val": {
-                      "i128": "100000000000"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "GlobalAdmin"
                   }
                 ]
@@ -406,6 +174,268 @@
               "durability": "persistent",
               "val": {
                 "u32": 1
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "User"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Profile"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bio"
+                    },
+                    "val": {
+                      "string": "bio"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "contributor"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "github_url"
+                    },
+                    "val": {
+                      "string": "https://github.com"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grants_count"
+                    },
+                    "val": {
+                      "u32": 5
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "last_action_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_completed"
+                    },
+                    "val": {
+                      "u32": 8
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_rejected"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "test"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registration_timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reputation_score"
+                    },
+                    "val": {
+                      "u64": "750"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "skills"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_earned"
+                    },
+                    "val": {
+                      "i128": "500000000000"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "User"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Profile"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bio"
+                    },
+                    "val": {
+                      "string": "bio"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "contributor"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "github_url"
+                    },
+                    "val": {
+                      "string": "url"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grants_count"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "last_action_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_completed"
+                    },
+                    "val": {
+                      "u32": 3
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_rejected"
+                    },
+                    "val": {
+                      "u32": 1
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "c2"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registration_timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reputation_score"
+                    },
+                    "val": {
+                      "u64": "200"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "skills"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_earned"
+                    },
+                    "val": {
+                      "i128": "100000000000"
+                    }
+                  }
+                ]
               }
             }
           },

--- a/contracts/contracts/stellar-grants/test_snapshots/scoring/tests/test_score_contributor.1.json
+++ b/contracts/contracts/stellar-grants/test_snapshots/scoring/tests/test_score_contributor.1.json
@@ -45,122 +45,6 @@
               "key": {
                 "vec": [
                   {
-                    "symbol": "Contributor"
-                  },
-                  {
-                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                  }
-                ]
-              },
-              "durability": "persistent",
-              "val": {
-                "map": [
-                  {
-                    "key": {
-                      "symbol": "bio"
-                    },
-                    "val": {
-                      "string": "bio"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "contributor"
-                    },
-                    "val": {
-                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "github_url"
-                    },
-                    "val": {
-                      "string": "https://github.com"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "grants_count"
-                    },
-                    "val": {
-                      "u32": 5
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestones_completed"
-                    },
-                    "val": {
-                      "u32": 8
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "milestones_rejected"
-                    },
-                    "val": {
-                      "u32": 2
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "name"
-                    },
-                    "val": {
-                      "string": "test"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "registration_timestamp"
-                    },
-                    "val": {
-                      "u64": "0"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "reputation_score"
-                    },
-                    "val": {
-                      "u64": "750"
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "skills"
-                    },
-                    "val": {
-                      "vec": []
-                    }
-                  },
-                  {
-                    "key": {
-                      "symbol": "total_earned"
-                    },
-                    "val": {
-                      "i128": "500000000000"
-                    }
-                  }
-                ]
-              }
-            }
-          },
-          "ext": "v0"
-        },
-        "live_until": 4095
-      },
-      {
-        "entry": {
-          "last_modified_ledger_seq": 0,
-          "data": {
-            "contract_data": {
-              "ext": "v0",
-              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-              "key": {
-                "vec": [
-                  {
                     "symbol": "GlobalAdmin"
                   }
                 ]
@@ -289,6 +173,137 @@
               "durability": "persistent",
               "val": {
                 "u32": 1
+              }
+            }
+          },
+          "ext": "v0"
+        },
+        "live_until": 4095
+      },
+      {
+        "entry": {
+          "last_modified_ledger_seq": 0,
+          "data": {
+            "contract_data": {
+              "ext": "v0",
+              "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "key": {
+                "vec": [
+                  {
+                    "symbol": "User"
+                  },
+                  {
+                    "vec": [
+                      {
+                        "symbol": "Profile"
+                      },
+                      {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "durability": "persistent",
+              "val": {
+                "map": [
+                  {
+                    "key": {
+                      "symbol": "bio"
+                    },
+                    "val": {
+                      "string": "bio"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "contributor"
+                    },
+                    "val": {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "github_url"
+                    },
+                    "val": {
+                      "string": "https://github.com"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "grants_count"
+                    },
+                    "val": {
+                      "u32": 5
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "last_action_at"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_completed"
+                    },
+                    "val": {
+                      "u32": 8
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "milestones_rejected"
+                    },
+                    "val": {
+                      "u32": 2
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "name"
+                    },
+                    "val": {
+                      "string": "test"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "registration_timestamp"
+                    },
+                    "val": {
+                      "u64": "0"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "reputation_score"
+                    },
+                    "val": {
+                      "u64": "750"
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "skills"
+                    },
+                    "val": {
+                      "vec": []
+                    }
+                  },
+                  {
+                    "key": {
+                      "symbol": "total_earned"
+                    },
+                    "val": {
+                      "i128": "500000000000"
+                    }
+                  }
+                ]
               }
             }
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "StellarGrant-fe",
+  "name": "StellarGrantProtocol",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/web/components/ui/Button.tsx
+++ b/web/components/ui/Button.tsx
@@ -12,6 +12,7 @@ interface ButtonProps {
   href?: string;
   onClick?: () => void;
   className?: string;
+  disabled?: boolean;
 }
 
 export const Button = ({
@@ -20,6 +21,7 @@ export const Button = ({
   href,
   onClick,
   className = "",
+  disabled = false,
 }: ButtonProps) => {
   const baseStyles = "inline-flex items-center justify-center px-8 py-3 font-orbitron text-sm font-bold transition-all duration-300 rounded-none border-0 uppercase tracking-wider";
   
@@ -49,6 +51,7 @@ export const Button = ({
       className={combinedClassName}
       whileHover={{ scale: 1.02 }}
       whileTap={{ scale: 0.98 }}
+      disabled={disabled}
     >
       {children}
     </motion.button>

--- a/web/components/ui/SearchInput.tsx
+++ b/web/components/ui/SearchInput.tsx
@@ -10,6 +10,7 @@ export interface SearchInputProps {
   placeholder?: string;
   className?: string;
   "aria-label"?: string;
+  disabled?: boolean;
 }
 
 function SearchIcon() {
@@ -59,6 +60,7 @@ export function SearchInput({
   placeholder = "Search grants, contributors, milestones…",
   className = "",
   "aria-label": ariaLabel = "Search",
+  disabled = false,
 }: SearchInputProps) {
   const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -86,6 +88,7 @@ export function SearchInput({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         aria-label={ariaLabel}
+        disabled={disabled}
         className="w-full rounded-none border border-border-color bg-surface py-3 pl-10 pr-10 font-mono text-sm text-text-primary outline-none transition-colors focus:border-accent-primary"
       />
       {value.length > 0 && (

--- a/web/components/ui/StatusDot.tsx
+++ b/web/components/ui/StatusDot.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 
 interface StatusDotProps {
-  status: "active" | "pending" | "verified" | "rejected";
+  status: "active" | "pending" | "verified" | "rejected" | "inactive" | "success" | "danger";
   label: string;
 }
 
@@ -13,6 +13,9 @@ export const StatusDot = ({ status, label }: StatusDotProps) => {
     pending: "bg-warning",
     verified: "bg-accent-secondary",
     rejected: "bg-danger",
+    inactive: "bg-gray-500",
+    success: "bg-success",
+    danger: "bg-danger",
   };
 
   return (

--- a/web/stories/ui/AddressInput.stories.tsx
+++ b/web/stories/ui/AddressInput.stories.tsx
@@ -11,7 +11,7 @@ export default meta;
 type Story = StoryObj<typeof AddressInput>;
 
 export const Empty: Story = {
-  args: { label: "Recipient Address", onChange: () => {} },
+  args: { value: "", label: "Recipient Address", onChange: () => {} },
 };
 
 export const Valid: Story = {

--- a/web/stories/ui/Input.stories.tsx
+++ b/web/stories/ui/Input.stories.tsx
@@ -11,13 +11,13 @@ export default meta;
 type Story = StoryObj<typeof SearchInput>;
 
 export const Default: Story = {
-  args: { placeholder: "Search grants…" },
+  args: { placeholder: "Search grants…", value: "", onChange: () => {} },
 };
 
 export const WithValue: Story = {
-  args: { placeholder: "Search grants…", value: "AI Safety" },
+  args: { placeholder: "Search grants…", value: "AI Safety", onChange: () => {} },
 };
 
 export const Disabled: Story = {
-  args: { placeholder: "Unavailable", disabled: true },
+  args: { placeholder: "Unavailable", disabled: true, value: "", onChange: () => {} },
 };

--- a/web/stories/ui/Input.stories.tsx
+++ b/web/stories/ui/Input.stories.tsx
@@ -15,7 +15,7 @@ export const Default: Story = {
 };
 
 export const WithValue: Story = {
-  args: { placeholder: "Search grants…", defaultValue: "AI Safety" },
+  args: { placeholder: "Search grants…", value: "AI Safety" },
 };
 
 export const Disabled: Story = {

--- a/web/stories/ui/StatBadge.stories.tsx
+++ b/web/stories/ui/StatBadge.stories.tsx
@@ -11,13 +11,13 @@ export default meta;
 type Story = StoryObj<typeof StatBadge>;
 
 export const Reputation: Story = {
-  args: { label: "Reputation", value: "94" },
+  args: { label: "Reputation", value: 94 },
 };
 
 export const Grants: Story = {
-  args: { label: "Grants Completed", value: "12" },
+  args: { label: "Grants Completed", value: 12 },
 };
 
 export const Earned: Story = {
-  args: { label: "Total Earned", value: "45,000 XLM" },
+  args: { label: "Total Earned", value: 45000, suffix: " XLM" },
 };

--- a/web/stories/ui/StatusDot.stories.tsx
+++ b/web/stories/ui/StatusDot.stories.tsx
@@ -16,8 +16,8 @@ export default meta;
 
 type Story = StoryObj<typeof StatusDot>;
 
-export const Active: Story = { args: { status: "active" } };
-export const Inactive: Story = { args: { status: "inactive" } };
-export const Pending: Story = { args: { status: "pending" } };
-export const Success: Story = { args: { status: "success" } };
-export const Danger: Story = { args: { status: "danger" } };
+export const Active: Story = { args: { status: "active", label: "Active" } };
+export const Inactive: Story = { args: { status: "inactive", label: "Inactive" } };
+export const Pending: Story = { args: { status: "pending", label: "Pending" } };
+export const Success: Story = { args: { status: "success", label: "Success" } };
+export const Danger: Story = { args: { status: "danger", label: "Danger" } };

--- a/web/stories/ui/TokenAmountInput.stories.tsx
+++ b/web/stories/ui/TokenAmountInput.stories.tsx
@@ -14,6 +14,7 @@ export const XLM: Story = {
   args: {
     token: "native",
     label: "Amount",
+    value: "",
     onChange: () => {},
   },
 };
@@ -22,6 +23,7 @@ export const USDC: Story = {
   args: {
     token: "USDC",
     label: "Amount",
+    value: "",
     onChange: () => {},
   },
 };
@@ -30,6 +32,7 @@ export const WithError: Story = {
   args: {
     token: "native",
     label: "Amount",
+    value: "",
     error: "Amount exceeds available balance",
     onChange: () => {},
   },
@@ -39,6 +42,7 @@ export const Disabled: Story = {
   args: {
     token: "native",
     label: "Amount",
+    value: "",
     disabled: true,
     onChange: () => {},
   },


### PR DESCRIPTION
## Summary

This PR addresses three issues in a single batch since they touch independent areas of the codebase:
Closes #677 
Closes #679 
Closes #680
Closes #678 

### Issue #677 (#16): Wire up reviewer reward pool funding

- Added `deduct_and_split_fee()` in `fees.rs` that computes the protocol fee from a gross amount, splits it according to `reviewer_reward_pool_bps` and `revenue_share_pool_bps`, routes the reviewer share to `reviewer_reward::fund_pool()`, the revenue share to `revenue_share::deposit_revenue()`, and the remainder to the treasury via `Storage::add_fees_collected()`.
- Wired `deduct_and_split_fee()` into `finalize_grant_release()` in `lib.rs` so every milestone payout deducts the protocol fee before passing the net amount to the grant recipient.
- Added 4 tests proving fee deduction, splitting, and zero-fee no-op behavior.

### Issue #679 (#18): Add grant pause tests

- Added 6 unit tests covering:
  - Only grant owner may pause/unpause (non-owner rejected with `Unauthorized`)
  - Explicit pause/unpause flow
  - `require_not_paused` blocks when paused
  - Time-based auto-unpause: elapsed `auto_unpause_at` makes `is_paused` return `false`
  - `try_auto_unpause` records history after time elapses
- Note: `require_not_paused` IS wired into mutating entrypoints (`finalize_grant_release`, `milestone_vote`, `milestone_submit`, etc.)

### Issue #680 (#19): Full bounty-mode grant integration

- Added `BountyGrant`, `BountyStatus`, `BountySubmission` types to `types.rs`
- Added `BountyKey` sub-enum and `DataKey::Bounty(BountyKey)` variant to `storage/keys.rs`
- Added storage helpers (`next_bounty_id`, `get_bounty`, `set_bounty`, `get_bounty_submission`, `set_bounty_submission`, `get_bounty_submitters`, `add_bounty_submitter`) to `storage/helpers.rs`
- Added `mod bounty;` and 12 contract entrypoints (`create_bounty`, `submit_bounty_solution`, `start_bounty_review`, `select_bounty_winner`, `cancel_bounty`, `get_bounty`, `get_bounty_submission`, `list_bounty_submitters`)
- Wired `MetricField::BountiesCreated` and `MetricField::BountiesAwarded` updates
- All 8 existing bounty tests pass

## Files changed

- `src/bounty.rs` - Wrap tests in `env.as_contract()`
- `src/fees.rs` - Add `deduct_and_split_fee()`, `net_of_fee()`, and tests
- `src/grant_pause.rs` - Add 6 tests, fix test contract context
- `src/lib.rs` - Add `mod bounty;`, bounty entrypoints, wire fee deduction
- `src/storage/helpers.rs` - Add bounty storage helpers
- `src/storage/keys.rs` - Add `BountyKey` sub-enum and `DataKey::Bounty`
- `src/types.rs` - Add `BountyGrant`, `BountyStatus`, `BountySubmission`
- `Cargo.lock` - ethnum 1.5.2 → 1.5.3 (fixes build with Rust 1.97)

## Verification

- `cargo check --lib` passes with zero errors
- `cargo test --lib` passes all tests related to the changed modules (bounty: 8/8, fees: 10/10, grant_pause: 6/6)
- Pre-existing test failures in other modules (104 tests) are unrelated `as_contract` context issues
