### PR TITLE
fix: resolve issues #691, #690, #689, #707 - interfaces, badge, and lockup fixes

### DIFF
--- a/contracts/contracts/stellar-grants/src/badge.rs
+++ b/contracts/contracts/stellar-grants/src/badge.rs
@@ -221,7 +221,7 @@ pub fn manual_award(
     badge_type: BadgeType,
 ) -> Result<(), ContractError> {
     admin.require_auth();
-    if Storage::get_treasury(env) != Some(admin.clone()) {
+    if Storage::get_global_admin(env) != Some(admin.clone()) {
         return Err(ContractError::Unauthorized);
     }
     write_award(env, contributor, badge_type, None, None);

--- a/contracts/contracts/stellar-grants/src/cross_contract.rs
+++ b/contracts/contracts/stellar-grants/src/cross_contract.rs
@@ -1,40 +1,23 @@
-use soroban_sdk::{Address, Bytes, Env, Error, IntoVal, InvokeError, Symbol, TryFromVal, Val, Vec};
+use soroban_sdk::{Address, Env};
 
 use crate::errors::ContractError;
+use crate::interfaces::{HookReceiverClient, OracleClient};
 
-/// Generic safe cross-contract call with try-semantics (no panic on failure).
-pub fn safe_call(
-    env: &Env,
-    contract: &Address,
-    function_name: &Symbol,
-    args: Vec<Val>,
-) -> Result<Val, ContractError> {
-    type CallResult = Result<Result<Val, soroban_sdk::ConversionError>, Result<Error, InvokeError>>;
-    let result: CallResult = env.try_invoke_contract(contract, function_name, args);
-    match result {
-        Ok(Ok(val)) => Ok(val),
-        _ => Err(ContractError::InvalidInput),
-    }
-}
-
-/// Call a hook receiver contract's `on_hook` function.
+/// Call a hook receiver contract's `on_hook` function using the typed interface.
 /// Returns false if the call fails (non-fatal).
-pub fn call_hook_receiver(env: &Env, contract: &Address, event_type: u32, payload: Bytes) -> bool {
-    let args: Vec<Val> = Vec::from_array(env, [event_type.into_val(env), payload.into_val(env)]);
-    let symbol = Symbol::new(env, "on_hook");
-    safe_call(env, contract, &symbol, args).is_ok()
+pub fn call_hook_receiver(env: &Env, contract: &Address, event_type: u32, payload: soroban_sdk::Bytes) -> bool {
+    let client = HookReceiverClient::new(env, contract);
+    client.on_hook(contract, &event_type, &payload).is_ok()
 }
 
-/// Read a price from an oracle contract following the standard interface.
+/// Read a price from an oracle contract using the typed interface.
 pub fn read_oracle_price(
     env: &Env,
     oracle_contract: &Address,
     token: &Address,
 ) -> Result<(i128, u64), ContractError> {
-    let args: Vec<Val> = Vec::from_array(env, [token.clone().into_val(env)]);
-    let symbol = Symbol::new(env, "price");
-    let val = safe_call(env, oracle_contract, &symbol, args)?;
-    <(i128, u64)>::try_from_val(env, &val).map_err(|_| ContractError::InvalidInput)
+    let client = OracleClient::new(env, oracle_contract);
+    client.try_price(token).map_err(|_| ContractError::InvalidInput)
 }
 
 #[cfg(test)]
@@ -44,19 +27,10 @@ mod tests {
     use soroban_sdk::{Address, Env};
 
     #[test]
-    fn test_safe_call_failure_returns_invalid_input() {
-        let env = Env::default();
-        let contract = Address::generate(&env);
-        let symbol = Symbol::new(&env, "missing_fn");
-        let args = Vec::new(&env);
-        assert!(safe_call(&env, &contract, &symbol, args).is_err());
-    }
-
-    #[test]
     fn test_call_hook_receiver_failure_returns_false() {
         let env = Env::default();
         let contract = Address::generate(&env);
-        let payload = Bytes::new(&env);
+        let payload = soroban_sdk::Bytes::new(&env);
         assert!(!call_hook_receiver(&env, &contract, 1, payload));
     }
 }

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -648,6 +648,10 @@ impl StellarGrantsContract {
                 let _ = milestone_nft::mint(&env, grant_id, milestone_idx, &grant.owner, meta);
                 // Track this grant in the contributor's portfolio index (#565)
                 Storage::push_contributor_grant_id(&env, &grant.owner, grant_id);
+                // Award badges for milestone completion (#689)
+                badge::try_award(&env, &grant.owner, BadgeType::FirstMilestone, Some(grant_id), Some(milestone_idx));
+                badge::try_award(&env, &grant.owner, BadgeType::TenMilestones, Some(grant_id), Some(milestone_idx));
+                badge::try_award(&env, &grant.owner, BadgeType::FiftyMilestones, Some(grant_id), Some(milestone_idx));
             } else {
                 audit::log(
                     &env,

--- a/contracts/contracts/stellar-grants/src/lockup.rs
+++ b/contracts/contracts/stellar-grants/src/lockup.rs
@@ -69,6 +69,11 @@ pub fn lock_payout(
     token: &Address,
     amount: i128,
 ) -> Result<(), ContractError> {
+    let admin = Storage::get_global_admin(env).ok_or(ContractError::Unauthorized)?;
+    if admin != *holder {
+        return Err(ContractError::Unauthorized);
+    }
+
     let key = get_lockup_key(grant_id, milestone_idx);
     let mut record: LockupRecord = env
         .storage()

--- a/contracts/contracts/stellar-grants/src/lockup.rs
+++ b/contracts/contracts/stellar-grants/src/lockup.rs
@@ -182,6 +182,7 @@ mod tests {
         let admin = Address::generate(&env);
         let owner = Address::generate(&env);
         let contributor = Address::generate(&env);
+        Storage::set_global_admin(&env, &admin);
         (env, admin, owner, contributor)
     }
 
@@ -233,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_release_before_expiry() {
-        let (env, _admin, owner, contributor) = setup();
+        let (env, admin, owner, _contributor) = setup();
         env.ledger().set(soroban_sdk::testutils::LedgerInfo {
             timestamp: 1000,
             protocol_version: 21,
@@ -248,15 +249,15 @@ mod tests {
         attach_lockup(&env, &owner, 1, 0, 604800).unwrap();
 
         let fake_token = Address::generate(&env);
-        lock_payout(&env, 1, 0, &contributor, &fake_token, 500).unwrap();
+        lock_payout(&env, 1, 0, &admin, &fake_token, 500).unwrap();
 
-        let result = release(&env, &contributor, 1, 0);
+        let result = release(&env, &admin, 1, 0);
         assert_eq!(result, Err(ContractError::NotYetUnlocked));
     }
 
     #[test]
     fn test_release_after_expiry() {
-        let (env, _admin, owner, contributor) = setup();
+        let (env, admin, owner, _contributor) = setup();
         env.ledger().set(soroban_sdk::testutils::LedgerInfo {
             timestamp: 1000,
             protocol_version: 21,
@@ -271,7 +272,7 @@ mod tests {
         attach_lockup(&env, &owner, 1, 0, 100).unwrap();
 
         let fake_token = Address::generate(&env);
-        lock_payout(&env, 1, 0, &contributor, &fake_token, 500).unwrap();
+        lock_payout(&env, 1, 0, &admin, &fake_token, 500).unwrap();
 
         env.ledger().set(soroban_sdk::testutils::LedgerInfo {
             timestamp: 1200,
@@ -284,7 +285,7 @@ mod tests {
             max_entry_ttl: 1_000_000,
         });
 
-        let amount = release(&env, &contributor, 1, 0).unwrap();
+        let amount = release(&env, &admin, 1, 0).unwrap();
         assert_eq!(amount, 500);
 
         let record = get_lockup(&env, 1, 0).unwrap();
@@ -344,5 +345,26 @@ mod tests {
         });
 
         assert!(is_unlocked(&env, 1, 0));
+    }
+
+    #[test]
+    fn test_lock_payout_unauthorized() {
+        let (env, admin, owner, contributor) = setup();
+        env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+            timestamp: 1000,
+            protocol_version: 21,
+            sequence_number: 100,
+            base_reserve: 10,
+            network_id: Default::default(),
+            min_temp_entry_ttl: 100_000,
+            min_persistent_entry_ttl: 100_000,
+            max_entry_ttl: 1_000_000,
+        });
+
+        attach_lockup(&env, &owner, 1, 0, 604800).unwrap();
+
+        let fake_token = Address::generate(&env);
+        let result = lock_payout(&env, 1, 0, &contributor, &fake_token, 500);
+        assert_eq!(result, Err(ContractError::Unauthorized));
     }
 }

--- a/contracts/contracts/stellar-grants/src/oracle.rs
+++ b/contracts/contracts/stellar-grants/src/oracle.rs
@@ -1,6 +1,7 @@
-use soroban_sdk::{Address, Env, IntoVal, Symbol, Val, Vec};
+use soroban_sdk::{Address, Env};
 
 use crate::errors::ContractError;
+use crate::interfaces::OracleClient;
 use crate::storage::Storage;
 use crate::types::{OracleConfig, PriceQuote};
 
@@ -39,12 +40,8 @@ fn fetch_oracle_price(
     oracle: &Address,
     token: &Address,
 ) -> Result<(i128, u64), ContractError> {
-    let mut args: Vec<Val> = Vec::new(env);
-    args.push_back(token.clone().into_val(env));
-
-    let result: Option<(i128, u64)> = env.invoke_contract(oracle, &Symbol::new(env, "price"), args);
-
-    result.ok_or(ContractError::InvalidInput)
+    let client = OracleClient::new(env, oracle);
+    client.try_price(token).map_err(|_| ContractError::InvalidInput)
 }
 
 /// Return the stored oracle config. Returns Err if not configured.


### PR DESCRIPTION
## Summary
This PR resolves four open source issues in the StellarGrantProtocol repository:
1. **Issue #691**: Resolve Unused, Duplicate interfaces Module
2. **Issue #690**: Fix badge::manual_award Checking the Wrong Admin Address
3. **Issue #689**: Wire Up Badge Awarding — Contributors Can Never Actually Earn Badges
4. **Issue #707**: Fix lockup::lock_payout — No Authorization Check, Hijackable Lockup Records
## Changes Made
### Issue #691: Interfaces Module Cleanup
- Refactored `cross_contract::call_hook_receiver` to use typed `HookReceiverClient` interface
- Refactored `cross_contract::read_oracle_price` to use typed `OracleClient` interface
- Refactored `oracle::fetch_oracle_price` to use typed `OracleClient` interface
- Removed hand-rolled cross-contract calls in favor of typed interfaces
- The interfaces module is now the single source of truth for wire formats
### Issue #690: Badge Manual Award Admin Check
- Changed `badge::manual_award` to check `Storage::get_global_admin` instead of `Storage::get_treasury`
- Ensures consistency with all other admin-only functions in the crate
- Only the protocol admin can now manually award badges
### Issue #689: Wire Up Badge Awarding
- Added `badge::try_award` calls for `FirstMilestone`, `TenMilestones`, and `FiftyMilestones` in the milestone approval flow
- Contributors now receive badges when they meet the criteria after milestone approval
- Badge awarding is non-fatal and does not affect the milestone approval process
### Issue #707: Lockup Lock Payout Auth
- Added global admin check to `lock_payout` function
- Prevents arbitrary callers from hijacking lockup records
- Validates holder is the global admin before allowing payout lock
- Added test to verify unauthorized callers cannot overwrite holder/amount
## Related Issues
- Closes #691 
- Closes #690 
- Closes #689 
- Closes #707 
## Testing
- [x] Updated lockup tests to work with new auth requirement
- [x] Added test_lock_payout_unauthorized to verify auth check
- [x] All existing tests should pass with the changes
## Notes for Reviewer
- The lockup::lock_payout function now requires the caller to be the global admin
- The badge awarding is triggered automatically when milestones are approved
- The typed interfaces ensure consistency between the interface definitions and the actual cross-contract calls
---