### PR TITLE
feat(contracts): wire up reviewer SLA, referral rewards, and reviewer…

### DIFF
--- a/contracts/contracts/stellar-grants/src/batch_read.rs
+++ b/contracts/contracts/stellar-grants/src/batch_read.rs
@@ -144,6 +144,7 @@ pub fn reviewer_dashboard(env: &Env, reviewer: &Address) -> ReviewerView {
     let reputation = Storage::get_reviewer_reputation(env, reviewer.clone());
 
     let mut pending_votes = soroban_sdk::Vec::new(env);
+    let mut sla_breach_count: u32 = 0;
 
     let active_grants = grant_index::by_status(env, crate::types::GrantStatus::Active, 0, 100);
     for grant_id in active_grants.iter() {
@@ -152,6 +153,13 @@ pub fn reviewer_dashboard(env: &Env, reviewer: &Address) -> ReviewerView {
                 continue;
             }
             for idx in 0..grant.total_milestones {
+                // Issue #611: surface SLA breaches this reviewer has accrued.
+                let sla_id = crate::reviewer_sla::milestone_sla_id(grant_id, idx);
+                if let Some(sla) = crate::reviewer_sla::get_sla(env, reviewer, sla_id) {
+                    if sla.breached {
+                        sla_breach_count = sla_breach_count.saturating_add(1);
+                    }
+                }
                 if let Some(ms) = Storage::get_milestone(env, grant_id, idx) {
                     if ms.state == MilestoneState::Submitted
                         && !ms.votes.contains_key(reviewer.clone())
@@ -168,7 +176,7 @@ pub fn reviewer_dashboard(env: &Env, reviewer: &Address) -> ReviewerView {
         profile,
         reputation,
         pending_votes,
-        sla_breach_count: 0,
+        sla_breach_count,
         pending_rewards: 0,
     }
 }

--- a/contracts/contracts/stellar-grants/src/governance.rs
+++ b/contracts/contracts/stellar-grants/src/governance.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{Address, Env, String};
 use crate::constants::MAX_BIO_LEN;
 use crate::events::Events;
 use crate::quadratic;
+use crate::reviewer_sla;
 use crate::storage::Storage;
 use crate::types::{ContractError, Grant, Milestone, MilestoneState, VotingMechanism};
 
@@ -10,6 +11,18 @@ pub struct VoteResult {
     pub approved: bool,
     pub quorum_reached: bool,
     pub approval_pct: u32,
+}
+
+/// Resolve the reviewer's SLA for this milestone (issue #611).
+///
+/// The breach check runs first so that a vote cast after the deadline is
+/// recorded as a breach — `fulfill_sla` is then a no-op on the breached
+/// record, and the reviewer forfeits reward accrual for the milestone.
+/// A no-op when the reviewer has no SLA record for this milestone.
+fn settle_sla(env: &Env, reviewer: &Address, grant_id: u64, milestone_idx: u32) {
+    let sla_id = reviewer_sla::milestone_sla_id(grant_id, milestone_idx);
+    reviewer_sla::check_and_mark_breach(env, reviewer, sla_id);
+    reviewer_sla::fulfill_sla(env, reviewer, sla_id);
 }
 
 /// Cast a vote (approve = true, reject = false) on a milestone.
@@ -32,8 +45,8 @@ pub fn cast_vote(
         let total_participation = for_v.saturating_add(against_v);
 
         // Require both participation quorum (>50% of reviewers) and approval (>50% of votes)
-        let participation_quorum = total_participation > 0
-            && total_participation * 2 > milestone.reviewer_count_snapshot;
+        let participation_quorum =
+            total_participation > 0 && total_participation * 2 > milestone.reviewer_count_snapshot;
         let approval = total_participation > 0 && for_v * 2 > total_participation;
         let vote_finalized = participation_quorum && approval;
 
@@ -53,6 +66,7 @@ pub fn cast_vote(
                 },
             );
         }
+        settle_sla(env, reviewer, grant.id, milestone.idx);
         Events::milestone_voted(
             env,
             grant.id,
@@ -127,6 +141,8 @@ pub fn cast_vote(
         };
         Events::milestone_status_changed(env, grant_id, milestone_idx, new_state);
     }
+
+    settle_sla(env, reviewer, grant.id, milestone.idx);
 
     Events::milestone_voted(
         env,

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -112,38 +112,39 @@ pub use events::Events;
 pub use storage::Storage;
 pub use types::{
     AcceptanceCriteria, Amendment, AmendmentStatus, AnalyticsSnapshot, Arbiter, ArbiterVote,
-    ArbitrationCase, AuditAction, AuditEntry, AutoApproveConfig, AutoApproveRecord, BatchItemResult,
-    BatchMilestoneVote, BatchResult, BondClaim, BondStatus, BountyGrant, BountyStatus,
-    BountySubmission, BreakerState, BridgeRelayer, CategoryStats, ChainId, ChecklistSubmission,
-    ClawbackRequest, ClawbackStatus, CollateralDeposit, CollateralRequirement, CollateralStatus,
-    ComplianceAttestation, ComplianceLevel, ComplianceStatus, ConditionResult, ContractVersion,
-    ContributionType, ContributorPortfolio, CriterionStatus, CrossChainProof, CrowdfundCampaign,
-    CrowdfundPledge, CrowdfundStatus, DashboardView, DecayConfig, DecayType, DexConfig, Dispute,
-    DisputeStatus, EscrowAccount, EscrowLifecycleState, EscrowMode, EscrowReleaseApproval,
-    EscrowReleaseRequest, EscrowState, EvidenceField, EvidenceFieldType, EvidenceSchema,
-    ExportGrant, ExportGrantPage, ExportMilestone, ExportMilestonePage, ExtensionRequest,
-    ExtensionStatus, FeeRecord, ForkRecord, FunderGrantSummary, FunderLedger, FunderReport,
-    FunderTokenSummary, Grant, GrantArchetype, GrantCard, GrantCategory, GrantDetailView,
-    GrantFund, GrantPortfolio, GrantStatus, GrantSummary, GrantTag, GrantTemplate, GrantVersion,
-    HookCallResult, HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy, Invoice,
-    InvoiceStatus, IpRights, LicenseRecord, LicenseType, LineItem, LockupRecord, LockupStatus,
-    MatchingAllocation, MatchingContribution, MatchingRound, MerkleCommitment, MerkleProof,
-    MigrationRecord, Milestone, MilestoneDag, MilestoneDependency, MilestoneNft, MilestoneState,
-    MilestoneSubmission, MilestoneTemplate, MultisigProposal, MultisigSigner, MultiGrantBatchResult,
-    NftMetadata, NotificationEvent, OracleConfig, ParamRecord, ParamType, ParamValue, PauseRecord,
-    PaymentSplit, PaymentStream, PerformanceBond, PortfolioFilter, PortfolioStats, PriceQuote,
-    ProtocolConfig, ProtocolMetrics, ProtocolModule, ProvenanceRecord, PublicReview,
-    PublicReviewSignal, QuadraticVoteRecord, RateLimitAction, ReferralCode, ReferralRecord,
-    ReferralReward, RegistryEntry, RegistryEntryType, RelayAllowance, RelayConfig, RelayRecord,
-    RelayableAction, ReleaseCondition, RenewalProposal, RenewalStatus, ReputationTier, RevenueEpoch,
-    ReviewParticipation, ReviewerAvailability, ReviewerProfile, ReviewerRequest,
-    ReviewerRequestStatus, ReviewerRewardPool, ReviewerRewardRecord, ReviewerView, Role,
-    RoleAssignment, RollingWindow, ScoreResult, ScoringDimension, ScoringRubric, ScoringWeight,
-    SignatureStatus, SplitRecipient, StakerEpochRecord, StructuredEvidence, Subscription,
-    SubscriptionScope, SwapResult, SwapRoute, SyndicateGrant, SyndicateMember, SyndicateStatus,
-    TemplateCategory, TimerRecord, TimerTriggerType, TokenMetric, TransferProposal,
-    TransferableRole, VerificationAttestation, VerificationLevel, VerificationStatus, VoiceCredits,
-    VotingMechanism, WaitlistConfig, WaitlistEntry, WhitelistEntry, WhitelistMode, WhitelistScope,
+    ArbitrationCase, AuditAction, AuditEntry, AutoApproveConfig, AutoApproveRecord,
+    BatchItemResult, BatchMilestoneVote, BatchResult, BondClaim, BondStatus, BountyGrant,
+    BountyStatus, BountySubmission, BreakerState, BridgeRelayer, CategoryStats, ChainId,
+    ChecklistSubmission, ClawbackRequest, ClawbackStatus, CollateralDeposit, CollateralRequirement,
+    CollateralStatus, ComplianceAttestation, ComplianceLevel, ComplianceStatus, ConditionResult,
+    ContractVersion, ContributionType, ContributorPortfolio, CriterionStatus, CrossChainProof,
+    CrowdfundCampaign, CrowdfundPledge, CrowdfundStatus, DashboardView, DecayConfig, DecayType,
+    DexConfig, Dispute, DisputeStatus, EscrowAccount, EscrowLifecycleState, EscrowMode,
+    EscrowReleaseApproval, EscrowReleaseRequest, EscrowState, EvidenceField, EvidenceFieldType,
+    EvidenceSchema, ExportGrant, ExportGrantPage, ExportMilestone, ExportMilestonePage,
+    ExtensionRequest, ExtensionStatus, FeeRecord, ForkRecord, FunderGrantSummary, FunderLedger,
+    FunderReport, FunderTokenSummary, Grant, GrantArchetype, GrantCard, GrantCategory,
+    GrantDetailView, GrantFund, GrantPortfolio, GrantStatus, GrantSummary, GrantTag, GrantTemplate,
+    GrantVersion, HookCallResult, HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy,
+    Invoice, InvoiceStatus, IpRights, LicenseRecord, LicenseType, LineItem, LockupRecord,
+    LockupStatus, MatchingAllocation, MatchingContribution, MatchingRound, MerkleCommitment,
+    MerkleProof, MigrationRecord, Milestone, MilestoneDag, MilestoneDependency, MilestoneNft,
+    MilestoneState, MilestoneSubmission, MilestoneTemplate, MultiGrantBatchResult,
+    MultisigProposal, MultisigSigner, NftMetadata, NotificationEvent, OracleConfig, ParamRecord,
+    ParamType, ParamValue, PauseRecord, PaymentSplit, PaymentStream, PerformanceBond,
+    PortfolioFilter, PortfolioStats, PriceQuote, ProtocolConfig, ProtocolMetrics, ProtocolModule,
+    ProvenanceRecord, PublicReview, PublicReviewSignal, QuadraticVoteRecord, RateLimitAction,
+    ReferralCode, ReferralRecord, ReferralReward, RegistryEntry, RegistryEntryType, RelayAllowance,
+    RelayConfig, RelayRecord, RelayableAction, ReleaseCondition, RenewalProposal, RenewalStatus,
+    ReputationTier, RevenueEpoch, ReviewParticipation, ReviewerAvailability, ReviewerProfile,
+    ReviewerRequest, ReviewerRequestStatus, ReviewerRewardPool, ReviewerRewardRecord, ReviewerView,
+    Role, RoleAssignment, RollingWindow, ScoreResult, ScoringDimension, ScoringRubric,
+    ScoringWeight, SignatureStatus, SplitRecipient, StakerEpochRecord, StructuredEvidence,
+    Subscription, SubscriptionScope, SwapResult, SwapRoute, SyndicateGrant, SyndicateMember,
+    SyndicateStatus, TemplateCategory, TimerRecord, TimerTriggerType, TokenMetric,
+    TransferProposal, TransferableRole, VerificationAttestation, VerificationLevel,
+    VerificationStatus, VoiceCredits, VotingMechanism, WaitlistConfig, WaitlistEntry,
+    WhitelistEntry, WhitelistMode, WhitelistScope,
 };
 
 use metrics::MetricField;
@@ -515,6 +516,11 @@ impl StellarGrantsContract {
                 // revenue-share pool, and treasury) before passing the net
                 // amount to the grant recipient or split recipients.
                 let net_amount = fees::deduct_and_split_fee(env, &grant.token, ms.amount)?;
+                // Issue #569: a payout is the qualifying first action for a
+                // referred contributor — credit their referrer out of the fee
+                // this payout generated. No-op after the first paid reward.
+                let fee_amount = math::safe_sub(ms.amount, net_amount)?;
+                referral::trigger_reward(env, &grant.owner, &grant.token, fee_amount)?;
                 if split_payment::has_split(env, grant_id, idx) {
                     split_payment::execute_split(env, grant_id, idx, net_amount)?;
                 } else {
@@ -614,7 +620,7 @@ impl StellarGrantsContract {
             soroban_sdk::Vec::new(&env),
         );
 
-        reviewer_reward::record_participation(&env, &reviewer, grant_id, false);
+        reviewer_reward::record_participation(&env, &reviewer, grant_id, milestone_idx, false);
 
         if result.quorum_reached {
             if result.approved {
@@ -1121,7 +1127,7 @@ impl StellarGrantsContract {
         owner: Address,
         grant_ids: Vec<u64>,
         reviewer: Address,
-    ) -> Result<BatchResult, ContractError> {
+    ) -> Result<MultiGrantBatchResult, ContractError> {
         owner.require_auth();
         multi_grant::batch_add_reviewer(&env, &owner, grant_ids, &reviewer)
     }
@@ -1132,7 +1138,7 @@ impl StellarGrantsContract {
         owner: Address,
         grant_ids: Vec<u64>,
         reviewer: Address,
-    ) -> Result<BatchResult, ContractError> {
+    ) -> Result<MultiGrantBatchResult, ContractError> {
         owner.require_auth();
         multi_grant::batch_remove_reviewer(&env, &owner, grant_ids, &reviewer)
     }
@@ -2329,6 +2335,42 @@ impl StellarGrantsContract {
         reviewer: Address,
     ) -> Option<ReviewerRequest> {
         reviewer_pool::get_request(&env, grant_id, &reviewer)
+    }
+
+    /// Find up to `limit` reviewers registered under an expertise tag.
+    pub fn reviewer_find_by_tag(env: Env, tag: String, limit: u32) -> Vec<ReviewerProfile> {
+        reviewer_pool::find_by_tag(&env, &tag, limit)
+    }
+
+    // ── Issue #611: Reviewer SLA enforcement ────────────────────────────────
+
+    /// Return a reviewer's SLA record for a milestone, if one was registered.
+    pub fn reviewer_get_sla(
+        env: Env,
+        reviewer: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Option<reviewer_sla::ReviewerSlaRecord> {
+        reviewer_sla::get_sla(
+            &env,
+            &reviewer,
+            reviewer_sla::milestone_sla_id(grant_id, milestone_idx),
+        )
+    }
+
+    /// Check whether a reviewer has breached their SLA for a milestone,
+    /// persisting the breach on first detection. Returns true if breached.
+    pub fn check_reviewer_sla(
+        env: Env,
+        reviewer: Address,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> bool {
+        reviewer_sla::check_and_mark_breach(
+            &env,
+            &reviewer,
+            reviewer_sla::milestone_sla_id(grant_id, milestone_idx),
+        )
     }
 
     // ── Issue #571: Taxonomy, Category, and Tag System for Grants ──────────

--- a/contracts/contracts/stellar-grants/src/multi_grant.rs
+++ b/contracts/contracts/stellar-grants/src/multi_grant.rs
@@ -1,7 +1,9 @@
 use crate::errors::ContractError;
 use crate::storage::keys::{DataKey, GrantKey};
 use crate::storage::Storage;
-use crate::types::{MultiGrantBatchResult, GrantPortfolio, GrantStatus, PortfolioFilter, PortfolioStats};
+use crate::types::{
+    GrantPortfolio, GrantStatus, MultiGrantBatchResult, PortfolioFilter, PortfolioStats,
+};
 use soroban_sdk::{Address, Env, Vec};
 
 /// Return portfolio stats for an owner address.

--- a/contracts/contracts/stellar-grants/src/referral.rs
+++ b/contracts/contracts/stellar-grants/src/referral.rs
@@ -285,3 +285,182 @@ pub fn deactivate_code(
 
     Ok(())
 }
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use crate::types::AcceptanceCriteria;
+    use crate::{StellarGrantsContract, StellarGrantsContractClient};
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::{vec, String, Vec};
+
+    struct Fixture<'a> {
+        env: Env,
+        client: StellarGrantsContractClient<'a>,
+        token: Address,
+        owner: Address,
+        referrer: Address,
+        reviewer: Address,
+        funder: Address,
+    }
+
+    fn setup<'a>() -> Fixture<'a> {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(StellarGrantsContract, ());
+        let client = StellarGrantsContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let token = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+
+        // The payout path reads the persisted protocol config, so publish the
+        // defaults (1% protocol fee, 10% of that to the referrer).
+        client.set_global_admin(&admin, &admin);
+        client.update_config(&admin, &config::default_config());
+
+        let funder = Address::generate(&env);
+        token::StellarAssetClient::new(&env, &token).mint(&funder, &100_000_000);
+
+        Fixture {
+            client,
+            token,
+            owner: Address::generate(&env),
+            referrer: Address::generate(&env),
+            reviewer: Address::generate(&env),
+            funder,
+            env,
+        }
+    }
+
+    /// Register the referrer (a code requires a registered participant) and
+    /// have `owner` join under their code.
+    fn apply_referral(f: &Fixture) {
+        f.client.reviewer_register(
+            &f.referrer,
+            &String::from_str(&f.env, "Referrer"),
+            &Vec::new(&f.env),
+            &None,
+        );
+        let code = f.client.referral_create_code(&f.referrer, &None, &None);
+        f.client.referral_apply_code(&f.owner, &code);
+    }
+
+    /// Run one grant of `amount` for `owner` all the way to payout: the fee it
+    /// generates is the qualifying action that triggers the referral reward.
+    fn run_grant_to_payout(f: &Fixture, amount: i128) -> u64 {
+        let env = &f.env;
+        let grant_id = f.client.grant_create(
+            &f.owner,
+            &String::from_str(env, "Referred grant"),
+            &String::from_str(env, "Description"),
+            &f.token,
+            &amount,
+            &amount,
+            &1,
+            &vec![env, f.reviewer.clone()],
+        );
+        f.client.grant_fund(&grant_id, &f.funder, &amount);
+        f.client.milestone_submit(
+            &grant_id,
+            &0,
+            &f.owner,
+            &String::from_str(env, "Done"),
+            &String::from_str(env, "https://proof.url"),
+        );
+
+        // An approving vote requires every required criterion to be signed off.
+        f.client.checklist_define_criteria(
+            &f.owner,
+            &grant_id,
+            &0,
+            &vec![
+                env,
+                AcceptanceCriteria {
+                    idx: 0,
+                    description: String::from_str(env, "Ships"),
+                    is_required: true,
+                },
+            ],
+        );
+        f.client
+            .checklist_submit(&f.owner, &grant_id, &0, &vec![env, None]);
+        f.client
+            .checklist_review_criterion(&f.reviewer, &grant_id, &0, &0, &true);
+
+        f.client
+            .milestone_vote(&grant_id, &0, &f.reviewer, &true, &None);
+        f.client.grant_complete(&grant_id);
+        grant_id
+    }
+
+    #[test]
+    fn test_referral_reward_accrues_on_first_qualifying_payout() {
+        let f = setup();
+        apply_referral(&f);
+
+        assert_eq!(f.client.referral_pending_rewards(&f.referrer, &f.token), 0);
+
+        run_grant_to_payout(&f, 1_000_000);
+
+        // 1% protocol fee on 1_000_000 = 10_000; 10% referral share = 1_000.
+        assert_eq!(
+            f.client.referral_pending_rewards(&f.referrer, &f.token),
+            1_000
+        );
+
+        let record = f.client.referral_get_record(&f.owner).unwrap();
+        assert!(record.reward_paid);
+        assert!(record.first_action_at.is_some());
+    }
+
+    #[test]
+    fn test_referrer_can_claim_reward_after_referred_payout() {
+        let f = setup();
+        apply_referral(&f);
+
+        // Before the qualifying action there is nothing to claim.
+        assert_eq!(
+            f.client
+                .try_referral_claim_rewards(&f.referrer, &f.token)
+                .unwrap_err(),
+            Ok(ContractError::NoRewardsToClaim)
+        );
+
+        run_grant_to_payout(&f, 1_000_000);
+
+        let claimed = f.client.referral_claim_rewards(&f.referrer, &f.token);
+        assert_eq!(claimed, 1_000);
+        assert_eq!(
+            token::Client::new(&f.env, &f.token).balance(&f.referrer),
+            1_000
+        );
+        assert_eq!(f.client.referral_pending_rewards(&f.referrer, &f.token), 0);
+    }
+
+    #[test]
+    fn test_referral_reward_pays_only_once_per_referred_user() {
+        let f = setup();
+        apply_referral(&f);
+
+        run_grant_to_payout(&f, 1_000_000);
+        run_grant_to_payout(&f, 1_000_000);
+
+        assert_eq!(
+            f.client.referral_pending_rewards(&f.referrer, &f.token),
+            1_000
+        );
+    }
+
+    #[test]
+    fn test_payout_without_referral_record_accrues_nothing() {
+        let f = setup();
+
+        run_grant_to_payout(&f, 1_000_000);
+
+        assert_eq!(f.client.referral_pending_rewards(&f.referrer, &f.token), 0);
+        assert!(f.client.referral_get_record(&f.owner).is_none());
+    }
+}

--- a/contracts/contracts/stellar-grants/src/reviewer_pool.rs
+++ b/contracts/contracts/stellar-grants/src/reviewer_pool.rs
@@ -1,8 +1,39 @@
+use crate::constants::DEFAULT_REVIEWER_SLA_SECONDS;
+use crate::reviewer_sla;
 use crate::storage::Storage;
 use crate::types::{
     ContractError, ReviewerAvailability, ReviewerProfile, ReviewerRequest, ReviewerRequestStatus,
 };
 use soroban_sdk::{Address, Env, String, Vec};
+
+/// Upper bound on results returned by [`find_by_tag`], to keep the scan bounded.
+const MAX_TAG_QUERY_RESULTS: u32 = 50;
+
+/// Drop `reviewer` from the index of every tag in `tags`.
+fn unindex_tags(env: &Env, reviewer: &Address, tags: &Vec<String>) {
+    for tag in tags.iter() {
+        let index = Storage::get_reviewer_tag_index(env, &tag);
+        let mut filtered = Vec::new(env);
+        for indexed in index.iter() {
+            if indexed != *reviewer {
+                filtered.push_back(indexed);
+            }
+        }
+        Storage::set_reviewer_tag_index(env, &tag, &filtered);
+    }
+}
+
+/// Add `reviewer` to the index of every tag in `tags`, skipping duplicates.
+fn index_tags(env: &Env, reviewer: &Address, tags: &Vec<String>) {
+    for tag in tags.iter() {
+        let mut index = Storage::get_reviewer_tag_index(env, &tag);
+        if index.iter().any(|indexed| indexed == *reviewer) {
+            continue;
+        }
+        index.push_back(reviewer.clone());
+        Storage::set_reviewer_tag_index(env, &tag, &index);
+    }
+}
 
 pub fn register_reviewer(
     env: &Env,
@@ -16,7 +47,7 @@ pub fn register_reviewer(
     let profile = ReviewerProfile {
         reviewer: reviewer.clone(),
         display_name,
-        expertise_tags,
+        expertise_tags: expertise_tags.clone(),
         hourly_rate,
         reviews_completed: 0,
         average_turnaround_ledgers: 0,
@@ -25,7 +56,13 @@ pub fn register_reviewer(
         reputation_score: Storage::get_reviewer_reputation(env, reviewer.clone()),
     };
 
+    // Re-registering replaces the tag set, so retire the previous entries first.
+    if let Some(existing) = Storage::get_reviewer_profile(env, reviewer) {
+        unindex_tags(env, reviewer, &existing.expertise_tags);
+    }
+
     Storage::set_reviewer_profile(env, &profile);
+    index_tags(env, reviewer, &expertise_tags);
     Ok(())
 }
 
@@ -97,6 +134,22 @@ pub fn accept_request(env: &Env, reviewer: &Address, grant_id: u64) -> Result<()
     grant.reviewers.push_back(reviewer.clone());
     Storage::set_grant(env, grant_id, &grant);
 
+    // Issue #611: accepting an assignment starts the review clock. Every
+    // milestone the reviewer is now on the hook for gets its own SLA record;
+    // missing the deadline forfeits reward accrual for that milestone.
+    let deadline = env
+        .ledger()
+        .timestamp()
+        .saturating_add(DEFAULT_REVIEWER_SLA_SECONDS);
+    for milestone_idx in 0..grant.total_milestones {
+        reviewer_sla::register_sla(
+            env,
+            reviewer,
+            reviewer_sla::milestone_sla_id(grant_id, milestone_idx),
+            deadline,
+        );
+    }
+
     let mut updated_request = request;
     updated_request.status = ReviewerRequestStatus::Accepted;
     Storage::set_reviewer_request(env, &updated_request);
@@ -119,8 +172,30 @@ pub fn decline_request(env: &Env, reviewer: &Address, grant_id: u64) -> Result<(
     Ok(())
 }
 
-pub fn find_by_tag(_env: &Env, _tag: &String, _limit: u32) -> Vec<ReviewerProfile> {
-    Vec::new(_env)
+/// Return up to `limit` reviewer profiles whose `expertise_tags` contain `tag`.
+///
+/// Backed by the per-tag index maintained by [`register_reviewer`]; matching is
+/// an exact, case-sensitive comparison on the tag string.
+pub fn find_by_tag(env: &Env, tag: &String, limit: u32) -> Vec<ReviewerProfile> {
+    let limit = limit.min(MAX_TAG_QUERY_RESULTS);
+    let mut result = Vec::new(env);
+    if limit == 0 {
+        return result;
+    }
+
+    for reviewer in Storage::get_reviewer_tag_index(env, tag).iter() {
+        if let Some(profile) = Storage::get_reviewer_profile(env, &reviewer) {
+            // The index is authoritative, but guard against a stale entry.
+            if profile.expertise_tags.iter().any(|t| t == *tag) {
+                result.push_back(profile);
+                if result.len() >= limit {
+                    break;
+                }
+            }
+        }
+    }
+
+    result
 }
 
 pub fn get_profile(env: &Env, reviewer: &Address) -> Option<ReviewerProfile> {
@@ -129,4 +204,164 @@ pub fn get_profile(env: &Env, reviewer: &Address) -> Option<ReviewerProfile> {
 
 pub fn get_request(env: &Env, grant_id: u64, reviewer: &Address) -> Option<ReviewerRequest> {
     Storage::get_reviewer_request(env, grant_id, reviewer)
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use crate::{StellarGrantsContract, StellarGrantsContractClient};
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::vec;
+
+    fn tag(env: &Env, s: &str) -> String {
+        String::from_str(env, s)
+    }
+
+    fn setup<'a>() -> (Env, StellarGrantsContractClient<'a>) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarGrantsContract, ());
+        let client = StellarGrantsContractClient::new(&env, &contract_id);
+        (env, client)
+    }
+
+    fn register(
+        env: &Env,
+        client: &StellarGrantsContractClient<'_>,
+        name: &str,
+        tags: Vec<String>,
+    ) -> Address {
+        let reviewer = Address::generate(env);
+        client.reviewer_register(&reviewer, &String::from_str(env, name), &tags, &None);
+        reviewer
+    }
+
+    fn addresses(profiles: &Vec<ReviewerProfile>) -> soroban_sdk::Vec<Address> {
+        let mut out = soroban_sdk::Vec::new(profiles.env());
+        for p in profiles.iter() {
+            out.push_back(p.reviewer);
+        }
+        out
+    }
+
+    #[test]
+    fn test_find_by_tag_returns_only_reviewers_with_that_tag() {
+        let (env, client) = setup();
+
+        let rustacean = register(
+            &env,
+            &client,
+            "Rustacean",
+            vec![&env, tag(&env, "rust"), tag(&env, "security")],
+        );
+        let designer = register(&env, &client, "Designer", vec![&env, tag(&env, "design")]);
+        let auditor = register(
+            &env,
+            &client,
+            "Auditor",
+            vec![&env, tag(&env, "security"), tag(&env, "solidity")],
+        );
+
+        let rust_hits = client.reviewer_find_by_tag(&tag(&env, "rust"), &10);
+        assert_eq!(addresses(&rust_hits), vec![&env, rustacean.clone()]);
+
+        let security_hits = client.reviewer_find_by_tag(&tag(&env, "security"), &10);
+        assert_eq!(
+            addresses(&security_hits),
+            vec![&env, rustacean, auditor.clone()]
+        );
+
+        let design_hits = client.reviewer_find_by_tag(&tag(&env, "design"), &10);
+        assert_eq!(addresses(&design_hits), vec![&env, designer]);
+
+        let solidity_hits = client.reviewer_find_by_tag(&tag(&env, "solidity"), &10);
+        assert_eq!(addresses(&solidity_hits), vec![&env, auditor]);
+    }
+
+    #[test]
+    fn test_find_by_tag_returns_full_profiles() {
+        let (env, client) = setup();
+
+        let reviewer = register(&env, &client, "Rustacean", vec![&env, tag(&env, "rust")]);
+
+        let hits = client.reviewer_find_by_tag(&tag(&env, "rust"), &10);
+        assert_eq!(hits.len(), 1);
+        let profile = hits.get(0).unwrap();
+        assert_eq!(profile.reviewer, reviewer);
+        assert_eq!(profile.display_name, String::from_str(&env, "Rustacean"));
+        assert_eq!(profile.expertise_tags, vec![&env, tag(&env, "rust")]);
+    }
+
+    #[test]
+    fn test_find_by_tag_unknown_tag_is_empty() {
+        let (env, client) = setup();
+        register(&env, &client, "Rustacean", vec![&env, tag(&env, "rust")]);
+
+        assert_eq!(
+            client.reviewer_find_by_tag(&tag(&env, "cobol"), &10).len(),
+            0
+        );
+        // Matching is exact and case-sensitive.
+        assert_eq!(
+            client.reviewer_find_by_tag(&tag(&env, "Rust"), &10).len(),
+            0
+        );
+        assert_eq!(client.reviewer_find_by_tag(&tag(&env, "rus"), &10).len(), 0);
+    }
+
+    #[test]
+    fn test_find_by_tag_respects_limit() {
+        let (env, client) = setup();
+        for i in 0..3 {
+            let _ = i;
+            register(&env, &client, "R", vec![&env, tag(&env, "rust")]);
+        }
+
+        assert_eq!(client.reviewer_find_by_tag(&tag(&env, "rust"), &0).len(), 0);
+        assert_eq!(client.reviewer_find_by_tag(&tag(&env, "rust"), &2).len(), 2);
+        assert_eq!(
+            client.reviewer_find_by_tag(&tag(&env, "rust"), &100).len(),
+            3
+        );
+    }
+
+    #[test]
+    fn test_reregistering_replaces_the_indexed_tags() {
+        let (env, client) = setup();
+        let reviewer = register(&env, &client, "Rustacean", vec![&env, tag(&env, "rust")]);
+
+        client.reviewer_register(
+            &reviewer,
+            &String::from_str(&env, "Rustacean"),
+            &vec![&env, tag(&env, "design")],
+            &None,
+        );
+
+        assert_eq!(
+            client.reviewer_find_by_tag(&tag(&env, "rust"), &10).len(),
+            0
+        );
+        assert_eq!(
+            addresses(&client.reviewer_find_by_tag(&tag(&env, "design"), &10)),
+            vec![&env, reviewer]
+        );
+    }
+
+    #[test]
+    fn test_reregistering_same_tag_does_not_duplicate() {
+        let (env, client) = setup();
+        let reviewer = register(&env, &client, "Rustacean", vec![&env, tag(&env, "rust")]);
+
+        client.reviewer_register(
+            &reviewer,
+            &String::from_str(&env, "Rustacean v2"),
+            &vec![&env, tag(&env, "rust")],
+            &None,
+        );
+
+        assert_eq!(
+            client.reviewer_find_by_tag(&tag(&env, "rust"), &10).len(),
+            1
+        );
+    }
 }

--- a/contracts/contracts/stellar-grants/src/reviewer_reward.rs
+++ b/contracts/contracts/stellar-grants/src/reviewer_reward.rs
@@ -1,4 +1,5 @@
 use crate::errors::ContractError;
+use crate::reviewer_sla;
 use crate::storage::keys::{DataKey, ReviewerRewardKey};
 use crate::types::{ReviewParticipation, ReviewerRewardPool, ReviewerRewardRecord};
 use soroban_sdk::{token, Address, Env, Vec};
@@ -36,7 +37,22 @@ pub fn fund_pool(env: &Env, token: &Address, amount: i128) {
 }
 
 /// Record a reviewer's participation in a milestone vote.
-pub fn record_participation(env: &Env, reviewer: &Address, grant_id: u64, was_fast: bool) {
+///
+/// A reviewer who breached their SLA for this milestone (issue #611) accrues
+/// nothing for it: the vote still counts toward the milestone outcome, but it
+/// earns no participation credit and therefore no share of the reward pool.
+pub fn record_participation(
+    env: &Env,
+    reviewer: &Address,
+    grant_id: u64,
+    milestone_idx: u32,
+    was_fast: bool,
+) {
+    let sla_id = reviewer_sla::milestone_sla_id(grant_id, milestone_idx);
+    if reviewer_sla::check_and_mark_breach(env, reviewer, sla_id) {
+        return;
+    }
+
     let part_key =
         DataKey::ReviewerReward(ReviewerRewardKey::Participation(reviewer.clone(), grant_id));
 
@@ -254,12 +270,12 @@ mod tests {
         let env = soroban_sdk::Env::default();
         let reviewer = Address::generate(&env);
 
-        record_participation(&env, &reviewer, 1, false);
+        record_participation(&env, &reviewer, 1, 0, false);
         let part = get_participation(&env, &reviewer, 1).expect("Participation should exist");
         assert_eq!(part.votes_cast, 1);
         assert_eq!(part.fast_votes, 0);
 
-        record_participation(&env, &reviewer, 1, true);
+        record_participation(&env, &reviewer, 1, 0, true);
         let part = get_participation(&env, &reviewer, 1).expect("Participation should exist");
         assert_eq!(part.votes_cast, 2);
         assert_eq!(part.fast_votes, 1);
@@ -272,10 +288,10 @@ mod tests {
         let reviewer2 = Address::generate(&env);
 
         // Reviewer 1 votes slowly
-        record_participation(&env, &reviewer1, 1, false);
+        record_participation(&env, &reviewer1, 1, 0, false);
 
         // Reviewer 2 votes quickly
-        record_participation(&env, &reviewer2, 1, true);
+        record_participation(&env, &reviewer2, 1, 0, true);
 
         let part1 = get_participation(&env, &reviewer1, 1).expect("Should exist");
         let part2 = get_participation(&env, &reviewer2, 1).expect("Should exist");
@@ -358,8 +374,8 @@ mod tests {
         assert_eq!(pool_balance(&env, &token), 800);
 
         // Each reviewer tracks separately
-        record_participation(&env, &reviewer1, 1, true);
-        record_participation(&env, &reviewer2, 1, false);
+        record_participation(&env, &reviewer1, 1, 0, true);
+        record_participation(&env, &reviewer2, 1, 0, false);
 
         let part1 = get_participation(&env, &reviewer1, 1).expect("Should exist");
         let part2 = get_participation(&env, &reviewer2, 1).expect("Should exist");

--- a/contracts/contracts/stellar-grants/src/reviewer_sla.rs
+++ b/contracts/contracts/stellar-grants/src/reviewer_sla.rs
@@ -40,6 +40,14 @@ fn extend_ttl(env: &Env, key: &SlaKey) {
     }
 }
 
+/// Compose the SLA subject id for a (grant, milestone) pair.
+///
+/// SLAs are keyed by a flat `u64`, so the grant id occupies the high 32 bits
+/// and the milestone index the low 32 bits.
+pub fn milestone_sla_id(grant_id: u64, milestone_idx: u32) -> u64 {
+    ((grant_id & 0xFFFF_FFFF) << 32) | milestone_idx as u64
+}
+
 /// Register a reviewer SLA for `milestone_id` with the given `deadline`.
 pub fn register_sla(env: &Env, reviewer: &Address, milestone_id: u64, deadline: u64) {
     let key = SlaKey::ReviewerSla(reviewer.clone(), milestone_id);
@@ -107,4 +115,232 @@ pub fn get_sla(env: &Env, reviewer: &Address, milestone_id: u64) -> Option<Revie
     let key = SlaKey::ReviewerSla(reviewer.clone(), milestone_id);
     extend_ttl(env, &key);
     env.storage().persistent().get(&key)
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use crate::config;
+    use crate::constants::DEFAULT_REVIEWER_SLA_SECONDS;
+    use crate::reviewer_reward;
+    use crate::types::AcceptanceCriteria;
+    use crate::{StellarGrantsContract, StellarGrantsContractClient};
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{token, vec, String, Vec};
+
+    struct Fixture<'a> {
+        env: Env,
+        contract_id: Address,
+        client: StellarGrantsContractClient<'a>,
+        owner: Address,
+        reviewer: Address,
+        grant_id: u64,
+    }
+
+    /// Register a reviewer, assign them to a funded single-milestone grant via
+    /// the request/accept flow, and submit the milestone for review.
+    fn setup_assigned_reviewer<'a>() -> Fixture<'a> {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(StellarGrantsContract, ());
+        let client = StellarGrantsContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let token = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        client.set_global_admin(&admin, &admin);
+        client.update_config(&admin, &config::default_config());
+
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+        let funder = Address::generate(&env);
+        token::StellarAssetClient::new(&env, &token).mint(&funder, &10_000_000);
+
+        client.reviewer_register(
+            &reviewer,
+            &String::from_str(&env, "Reviewer"),
+            &vec![&env, String::from_str(&env, "rust")],
+            &None,
+        );
+
+        let grant_id = client.grant_create(
+            &owner,
+            &String::from_str(&env, "Grant"),
+            &String::from_str(&env, "Description"),
+            &token,
+            &1_000_000,
+            &1_000_000,
+            &1,
+            &Vec::new(&env),
+        );
+        client.grant_fund(&grant_id, &funder, &1_000_000);
+
+        client.reviewer_request(
+            &owner,
+            &grant_id,
+            &reviewer,
+            &String::from_str(&env, "Please review"),
+            &100,
+        );
+        client.reviewer_accept_request(&reviewer, &grant_id);
+
+        client.milestone_submit(
+            &grant_id,
+            &0,
+            &owner,
+            &String::from_str(&env, "Done"),
+            &String::from_str(&env, "https://proof.url"),
+        );
+        client.checklist_define_criteria(
+            &owner,
+            &grant_id,
+            &0,
+            &vec![
+                &env,
+                AcceptanceCriteria {
+                    idx: 0,
+                    description: String::from_str(&env, "Ships"),
+                    is_required: true,
+                },
+            ],
+        );
+        client.checklist_submit(&owner, &grant_id, &0, &vec![&env, None]);
+        client.checklist_review_criterion(&reviewer, &grant_id, &0, &0, &true);
+
+        Fixture {
+            client,
+            contract_id,
+            owner,
+            reviewer,
+            grant_id,
+            env,
+        }
+    }
+
+    fn advance(env: &Env, seconds: u64) {
+        let now = env.ledger().timestamp();
+        env.ledger().with_mut(|l| l.timestamp = now + seconds);
+    }
+
+    #[test]
+    fn test_milestone_sla_id_is_unique_per_grant_and_milestone() {
+        assert_eq!(milestone_sla_id(0, 0), 0);
+        assert_eq!(milestone_sla_id(0, 7), 7);
+        assert_eq!(milestone_sla_id(1, 0), 1 << 32);
+        assert_ne!(milestone_sla_id(1, 0), milestone_sla_id(0, 1));
+        assert_ne!(milestone_sla_id(2, 3), milestone_sla_id(3, 2));
+    }
+
+    #[test]
+    fn test_accepting_an_assignment_registers_an_sla_per_milestone() {
+        let f = setup_assigned_reviewer();
+
+        let sla = f
+            .client
+            .reviewer_get_sla(&f.reviewer, &f.grant_id, &0)
+            .expect("accepting an assignment should register an SLA");
+        assert_eq!(sla.reviewer, f.reviewer);
+        assert_eq!(sla.deadline, DEFAULT_REVIEWER_SLA_SECONDS);
+        assert!(!sla.fulfilled);
+        assert!(!sla.breached);
+    }
+
+    #[test]
+    fn test_voting_within_the_deadline_fulfills_the_sla_and_accrues_reward() {
+        let f = setup_assigned_reviewer();
+
+        advance(&f.env, DEFAULT_REVIEWER_SLA_SECONDS - 1);
+        f.client
+            .milestone_vote(&f.grant_id, &0, &f.reviewer, &true, &None);
+
+        let sla = f
+            .client
+            .reviewer_get_sla(&f.reviewer, &f.grant_id, &0)
+            .unwrap();
+        assert!(sla.fulfilled);
+        assert!(!sla.breached);
+        assert!(!f.client.check_reviewer_sla(&f.reviewer, &f.grant_id, &0));
+
+        f.env.as_contract(&f.contract_id, || {
+            let participation = reviewer_reward::get_participation(&f.env, &f.reviewer, f.grant_id)
+                .expect("an on-time vote should accrue participation");
+            assert_eq!(participation.votes_cast, 1);
+        });
+    }
+
+    #[test]
+    fn test_missing_the_deadline_records_a_breach_and_forfeits_reward() {
+        let f = setup_assigned_reviewer();
+
+        // The reviewer sits on the assignment past their deadline.
+        advance(&f.env, DEFAULT_REVIEWER_SLA_SECONDS + 1);
+
+        assert!(f.client.check_reviewer_sla(&f.reviewer, &f.grant_id, &0));
+
+        f.client
+            .milestone_vote(&f.grant_id, &0, &f.reviewer, &true, &None);
+
+        let sla = f
+            .client
+            .reviewer_get_sla(&f.reviewer, &f.grant_id, &0)
+            .unwrap();
+        assert!(sla.breached, "deadline passed without a vote");
+        assert!(!sla.fulfilled, "a late vote must not fulfill the SLA");
+
+        f.env.as_contract(&f.contract_id, || {
+            assert!(
+                reviewer_reward::get_participation(&f.env, &f.reviewer, f.grant_id).is_none(),
+                "a breached reviewer accrues no reward for the milestone"
+            );
+        });
+
+        // The vote itself still counts toward the milestone outcome.
+        assert_eq!(
+            f.client.get_milestone(&f.grant_id, &0).state,
+            crate::types::MilestoneState::Approved
+        );
+    }
+
+    #[test]
+    fn test_late_vote_alone_marks_the_breach_without_a_prior_check() {
+        let f = setup_assigned_reviewer();
+
+        advance(&f.env, DEFAULT_REVIEWER_SLA_SECONDS + 1);
+
+        // No explicit check_reviewer_sla call: casting the vote must detect it.
+        f.client
+            .milestone_vote(&f.grant_id, &0, &f.reviewer, &true, &None);
+
+        let sla = f
+            .client
+            .reviewer_get_sla(&f.reviewer, &f.grant_id, &0)
+            .unwrap();
+        assert!(sla.breached);
+        assert!(!sla.fulfilled);
+
+        f.env.as_contract(&f.contract_id, || {
+            assert!(reviewer_reward::get_participation(&f.env, &f.reviewer, f.grant_id).is_none());
+        });
+    }
+
+    #[test]
+    fn test_reviewer_without_an_sla_record_is_never_breached() {
+        let f = setup_assigned_reviewer();
+        let stranger = Address::generate(&f.env);
+
+        assert!(f
+            .client
+            .reviewer_get_sla(&stranger, &f.grant_id, &0)
+            .is_none());
+        assert!(!f.client.check_reviewer_sla(&stranger, &f.grant_id, &0));
+
+        // Unassigned reviewers keep accruing as before.
+        f.env.as_contract(&f.contract_id, || {
+            reviewer_reward::record_participation(&f.env, &stranger, f.grant_id, 0, false);
+            assert!(reviewer_reward::get_participation(&f.env, &stranger, f.grant_id).is_some());
+        });
+        let _ = &f.owner;
+    }
 }

--- a/contracts/contracts/stellar-grants/src/storage/helpers.rs
+++ b/contracts/contracts/stellar-grants/src/storage/helpers.rs
@@ -24,7 +24,7 @@ use crate::types::{
     ExtensionRequest, PerformanceBond, ReferralCode, ReferralRecord, WhitelistEntry, WhitelistMode,
     WhitelistScope,
 };
-use soroban_sdk::{Address, Bytes, Env, Symbol, Vec};
+use soroban_sdk::{Address, Bytes, Env, String, Symbol, Vec};
 
 pub(crate) const PERSISTENT_TTL_THRESHOLD: u32 = 100_000;
 pub(crate) const PERSISTENT_TTL_EXTEND_TO: u32 = 1_000_000;
@@ -860,6 +860,21 @@ impl Storage {
         env.storage().persistent().set(
             &DataKey::User(UserKey::ReviewerProfile(profile.reviewer.clone())),
             profile,
+        );
+    }
+
+    /// Reviewers indexed under an exact expertise tag.
+    pub fn get_reviewer_tag_index(env: &Env, tag: &String) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::User(UserKey::ReviewerTagIndex(tag.clone())))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    pub fn set_reviewer_tag_index(env: &Env, tag: &String, reviewers: &Vec<Address>) {
+        env.storage().persistent().set(
+            &DataKey::User(UserKey::ReviewerTagIndex(tag.clone())),
+            reviewers,
         );
     }
 

--- a/contracts/contracts/stellar-grants/src/storage/keys.rs
+++ b/contracts/contracts/stellar-grants/src/storage/keys.rs
@@ -1,5 +1,5 @@
 use crate::types::{ProtocolModule, RateLimitAction, Role, WhitelistScope};
-use soroban_sdk::{contracttype, Address, Bytes, Symbol};
+use soroban_sdk::{contracttype, Address, Bytes, String, Symbol};
 
 // ── Domain sub-enums ─────────────────────────────────────────────────────────
 
@@ -76,6 +76,8 @@ pub enum UserKey {
     GrantIds(Address),
     ReviewerProfile(Address),
     ReviewerRequest(u64, Address),
+    /// Reviewers registered under a given expertise tag (exact match).
+    ReviewerTagIndex(String),
     ReviewerRep(Address),
     ReviewerStake(u64, Address),
     ReviewerAllowlist,

--- a/contracts/contracts/stellar-grants/src/versioning.rs
+++ b/contracts/contracts/stellar-grants/src/versioning.rs
@@ -8,6 +8,34 @@ fn field(env: &Env, name: &str) -> String {
     String::from_str(env, name)
 }
 
+/// Render an integer as a decimal `String`.
+///
+/// `soroban_sdk` is `no_std` and ships no numeric-to-string conversion, so the
+/// digits are emitted by hand into a fixed buffer (itoa-style). Digits are
+/// accumulated in the negative domain so that `i128::MIN` stays representable.
+fn int_to_string(env: &Env, value: i128) -> String {
+    // 39 digits for i128::MIN plus the sign.
+    let mut buf = [0u8; 40];
+    let mut idx = buf.len();
+    let negative = value < 0;
+    let mut remaining = if negative { value } else { -value };
+
+    loop {
+        idx -= 1;
+        buf[idx] = b'0' + (-(remaining % 10)) as u8;
+        remaining /= 10;
+        if remaining == 0 {
+            break;
+        }
+    }
+    if negative {
+        idx -= 1;
+        buf[idx] = b'-';
+    }
+
+    String::from_bytes(env, &buf[idx..])
+}
+
 fn grant_to_version(
     env: &Env,
     grant: &Grant,
@@ -88,9 +116,9 @@ pub fn propose_amendment(
         } else if changed == description {
             previous_values.push_back(current.description.clone());
         } else if changed == total_amount {
-            previous_values.push_back(field(env, "current_total_amount"));
+            previous_values.push_back(int_to_string(env, current.total_amount));
         } else if changed == total_milestones {
-            previous_values.push_back(field(env, "current_total_milestones"));
+            previous_values.push_back(int_to_string(env, current.total_milestones as i128));
         } else {
             return Err(ContractError::InvalidInput);
         }
@@ -280,4 +308,158 @@ pub fn amendment_history(env: &Env, grant_id: u64) -> Vec<Amendment> {
         }
     }
     amendments
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use crate::types::GrantStatus;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::vec;
+
+    fn seed_grant(env: &Env, owner: &Address, total_amount: i128, total_milestones: u32) -> u64 {
+        let grant = Grant {
+            id: 1,
+            owner: owner.clone(),
+            title: String::from_str(env, "Original title"),
+            description: String::from_str(env, "Original description"),
+            token: Address::generate(env),
+            status: GrantStatus::Active,
+            total_amount,
+            milestone_amount: total_amount / (total_milestones.max(1) as i128),
+            reviewers: Vec::new(env),
+            total_milestones,
+            milestones_paid_out: 0,
+            escrow_balance: total_amount,
+            funders: Vec::new(env),
+            reason: None,
+            timestamp: 0,
+            require_compliance: None,
+        };
+        Storage::set_grant(env, grant.id, &grant);
+        create_initial_version(env, &grant);
+        grant.id
+    }
+
+    #[test]
+    fn test_int_to_string_covers_sign_and_bounds() {
+        let env = Env::default();
+        assert_eq!(int_to_string(&env, 0), String::from_str(&env, "0"));
+        assert_eq!(int_to_string(&env, 7), String::from_str(&env, "7"));
+        assert_eq!(
+            int_to_string(&env, 5_000_000),
+            String::from_str(&env, "5000000")
+        );
+        assert_eq!(int_to_string(&env, -42), String::from_str(&env, "-42"));
+        assert_eq!(
+            int_to_string(&env, i128::MIN),
+            String::from_str(&env, "-170141183460469231731687303715884105728")
+        );
+        assert_eq!(
+            int_to_string(&env, i128::MAX),
+            String::from_str(&env, "170141183460469231731687303715884105727")
+        );
+    }
+
+    #[test]
+    fn test_propose_amendment_records_real_previous_total_amount() {
+        let env = Env::default();
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        let owner = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let grant_id = seed_grant(&env, &owner, 5_000_000, 4);
+
+            let version = propose_amendment(
+                &env,
+                &owner,
+                grant_id,
+                vec![&env, String::from_str(&env, "total_amount")],
+                vec![&env, String::from_str(&env, "7000000")],
+                String::from_str(&env, "scope grew"),
+            )
+            .expect("amendment should be proposed");
+
+            let amendment =
+                Storage::get_amendment(&env, grant_id, version).expect("amendment should exist");
+            assert_eq!(
+                amendment.previous_values.get(0).unwrap(),
+                String::from_str(&env, "5000000")
+            );
+        });
+    }
+
+    #[test]
+    fn test_propose_amendment_records_real_previous_total_milestones() {
+        let env = Env::default();
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        let owner = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let grant_id = seed_grant(&env, &owner, 5_000_000, 4);
+
+            let version = propose_amendment(
+                &env,
+                &owner,
+                grant_id,
+                vec![&env, String::from_str(&env, "total_milestones")],
+                vec![&env, String::from_str(&env, "6")],
+                String::from_str(&env, "more checkpoints"),
+            )
+            .expect("amendment should be proposed");
+
+            let amendment =
+                Storage::get_amendment(&env, grant_id, version).expect("amendment should exist");
+            assert_eq!(
+                amendment.previous_values.get(0).unwrap(),
+                String::from_str(&env, "4")
+            );
+        });
+    }
+
+    #[test]
+    fn test_propose_amendment_records_previous_values_for_all_fields() {
+        let env = Env::default();
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        let owner = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            let grant_id = seed_grant(&env, &owner, 1_234, 2);
+
+            let version = propose_amendment(
+                &env,
+                &owner,
+                grant_id,
+                vec![
+                    &env,
+                    String::from_str(&env, "title"),
+                    String::from_str(&env, "description"),
+                    String::from_str(&env, "total_amount"),
+                    String::from_str(&env, "total_milestones"),
+                ],
+                vec![
+                    &env,
+                    String::from_str(&env, "New title"),
+                    String::from_str(&env, "New description"),
+                    String::from_str(&env, "9999"),
+                    String::from_str(&env, "3"),
+                ],
+                String::from_str(&env, "full rewrite"),
+            )
+            .expect("amendment should be proposed");
+
+            let amendment =
+                Storage::get_amendment(&env, grant_id, version).expect("amendment should exist");
+            assert_eq!(
+                amendment.previous_values,
+                vec![
+                    &env,
+                    String::from_str(&env, "Original title"),
+                    String::from_str(&env, "Original description"),
+                    String::from_str(&env, "1234"),
+                    String::from_str(&env, "2"),
+                ]
+            );
+        });
+    }
 }


### PR DESCRIPTION
… tag discovery

Four dead or misleading code paths in the stellar-grants contract, plus the build fix required to compile any of it.

#611 Wire up reviewer SLA enforcement
- Add reviewer_sla::milestone_sla_id to pack (grant_id, milestone_idx) into the module's flat u64 key space.
- reviewer_pool::accept_request now registers one SLA per milestone at now + DEFAULT_REVIEWER_SLA_SECONDS (a constant that was previously unused).
- governance::cast_vote settles the SLA on every vote. check_and_mark_breach runs before fulfill_sla: fulfill_sla does not check the deadline itself, so a late vote would otherwise mark itself fulfilled and defeat the mechanism.
- reviewer_reward::record_participation takes a milestone_idx and returns early when the reviewer breached, forfeiting reward accrual for that milestone. The vote still counts toward the milestone outcome.
- batch_read::reviewer_dashboard reports a real sla_breach_count instead of 0.

#719 Trigger referral rewards on qualifying contributor action
- finalize_grant_release calls referral::trigger_reward after the fee split, passing gross - net as the fee that generated the reward. The reward_paid guard keeps it a no-op after the first payout.

#718 Implement reviewer discovery by expertise tag
- Add UserKey::ReviewerTagIndex(String), populated at register_reviewer time; re-registering retires the previous tag set. Keyed on the tag string rather than grant_tags.rs's hash_tag (len * 31), which collides on every same-length tag.
- find_by_tag reads the index, loads profiles and caps results at 50.
- Expose it as the reviewer_find_by_tag entry point.

#717 Record real previous values in amendment history
- propose_amendment recorded the literal strings "current_total_amount" and "current_total_milestones" instead of the grant's actual values. Add an itoa-style int_to_string helper (no such helper existed in the crate) and push the real values.

Build fix: batch_add_reviewer / batch_remove_reviewer in lib.rs declared BatchResult while multi_grant returns MultiGrantBatchResult, so main did not compile.

Adds 20 tests. cargo test --lib goes from 149 to 169 passing with an unchanged set of 117 pre-existing failures (Env::default() tests touching storage outside a contract context under soroban-sdk 25).

Closes #717 
Closes #718 
Closes #719 
Closes #720 