### PR TITLE
test(multisig): cover proposal lifecycle

### DIFF
--- a/contracts/contracts/stellar-grants/src/multisig.rs
+++ b/contracts/contracts/stellar-grants/src/multisig.rs
@@ -203,3 +203,71 @@ pub fn decode_grant_withdraw(payload: &Bytes) -> Option<u64> {
     }
     Some(u64::from_be_bytes(bytes))
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, testutils::Ledger as _};
+
+    #[test]
+    fn threshold_and_duplicate_signatures() {
+        let env = Env::default();
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        env.as_contract(&contract_id, || {
+            let creator = Address::generate(&env);
+            let signer1 = Address::generate(&env);
+            let signer2 = Address::generate(&env);
+            let mut signers = Vec::new(&env);
+            signers.push_back(signer1.clone());
+            signers.push_back(signer2.clone());
+
+            let payload = encode_grant_withdraw(&env, 7);
+            let id = create_proposal(&env, &creator, 7, payload.clone(), signers, 2, 100).unwrap();
+
+            assert_eq!(sign(&env, &signer1, id, true), Ok(1));
+            assert!(!is_threshold_met(&get_proposal(&env, id).unwrap()));
+            assert_eq!(
+                execute(&env, &creator, id),
+                Err(ContractError::ThresholdNotMet)
+            );
+
+            assert_eq!(sign(&env, &signer1, id, true), Ok(1));
+            assert_eq!(sign(&env, &signer2, id, true), Ok(2));
+            assert!(is_threshold_met(&get_proposal(&env, id).unwrap()));
+            assert_eq!(execute(&env, &creator, id), Ok(payload));
+        });
+    }
+
+    #[test]
+    fn expired_proposal_cannot_be_signed_or_executed() {
+        let env = Env::default();
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        env.as_contract(&contract_id, || {
+            let creator = Address::generate(&env);
+            let signer = Address::generate(&env);
+            let mut signers = Vec::new(&env);
+            signers.push_back(signer.clone());
+
+            let id = create_proposal(&env, &creator, 1, Bytes::new(&env), signers, 1, 10).unwrap();
+            env.ledger().set_timestamp(env.ledger().timestamp() + 11);
+
+            assert_eq!(
+                sign(&env, &signer, id, true),
+                Err(ContractError::ProposalExpired)
+            );
+            assert_eq!(
+                execute(&env, &creator, id),
+                Err(ContractError::ProposalExpired)
+            );
+        });
+    }
+
+    #[test]
+    fn grant_withdraw_payload_round_trip() {
+        let env = Env::default();
+        let grant_id = 123_456_789;
+        let payload = encode_grant_withdraw(&env, grant_id);
+
+        assert_eq!(decode_grant_withdraw(&payload), Some(grant_id));
+    }
+}


### PR DESCRIPTION
## Summary

- Cover proposal execution below and exactly at the signature threshold.
- Verify a duplicate signature is idempotent.
- Verify expired proposals reject both signing and execution.
- Cover grant-withdraw payload encoding and decoding.

## Impact

This is a test-only change limited to `multisig.rs`. It adds three focused regression tests without changing contract behavior.

## Validation

- `cargo test -p stellar-grants --lib multisig::test` — 3 passed
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --target wasm32v1-none -- -D warnings`
- `cargo check --workspace --target wasm32v1-none`

The focused test run temporarily excluded three already-broken upstream test modules; no exclusions are committed.

## Known upstream baseline failures

The complete `cargo test` build on current `main` is already blocked by stale tests in `params.rs`, `reviewer_pool.rs`, and `reviewer_sla.rs`, plus a fuzz integration target that accesses the private `fees` module. This PR does not mix those unrelated repairs into the multisig coverage change.

Closes #721
