### PR TITLE
test(referral): cover code safeguards

### DIFF
--- a/contracts/contracts/stellar-grants/src/referral.rs
+++ b/contracts/contracts/stellar-grants/src/referral.rs
@@ -291,7 +291,7 @@ mod tests {
     use super::*;
     use crate::types::AcceptanceCriteria;
     use crate::{StellarGrantsContract, StellarGrantsContractClient};
-    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::{Address as _, Ledger as _};
     use soroban_sdk::{vec, String, Vec};
 
     struct Fixture<'a> {
@@ -335,15 +335,19 @@ mod tests {
         }
     }
 
-    /// Register the referrer (a code requires a registered participant) and
-    /// have `owner` join under their code.
-    fn apply_referral(f: &Fixture) {
+    fn register_referrer(f: &Fixture) {
         f.client.reviewer_register(
             &f.referrer,
             &String::from_str(&f.env, "Referrer"),
             &Vec::new(&f.env),
             &None,
         );
+    }
+
+    /// Register the referrer (a code requires a registered participant) and
+    /// have `owner` join under their code.
+    fn apply_referral(f: &Fixture) {
+        register_referrer(f);
         let code = f.client.referral_create_code(&f.referrer, &None, &None);
         f.client.referral_apply_code(&f.owner, &code);
     }
@@ -394,6 +398,61 @@ mod tests {
             .milestone_vote(&grant_id, &0, &f.reviewer, &true, &None);
         f.client.grant_complete(&grant_id);
         grant_id
+    }
+
+    #[test]
+    fn test_code_creation_expiry_and_max_uses() {
+        let f = setup();
+        register_referrer(&f);
+
+        let expires_at = f.env.ledger().timestamp() + 10;
+        let expiring = f
+            .client
+            .referral_create_code(&f.referrer, &Some(expires_at), &None);
+        let stored = f.env.as_contract(&f.client.address, || {
+            Storage::get_referral_code(&f.env, &expiring).unwrap()
+        });
+        assert_eq!(stored.expires_at, Some(expires_at));
+        assert!(stored.is_active);
+
+        f.env.ledger().set_timestamp(expires_at + 1);
+        assert_eq!(
+            f.client
+                .try_referral_apply_code(&f.owner, &expiring)
+                .unwrap_err(),
+            Ok(ContractError::ReferralCodeExpired)
+        );
+
+        let limited = f.client.referral_create_code(&f.referrer, &None, &Some(1));
+        f.client.referral_apply_code(&f.owner, &limited);
+        let another = Address::generate(&f.env);
+        assert_eq!(
+            f.client
+                .try_referral_apply_code(&another, &limited)
+                .unwrap_err(),
+            Ok(ContractError::ReferralCodeExhausted)
+        );
+    }
+
+    #[test]
+    fn test_self_referral_and_double_apply_are_rejected() {
+        let f = setup();
+        register_referrer(&f);
+        let code = f.client.referral_create_code(&f.referrer, &None, &None);
+
+        assert_eq!(
+            f.client
+                .try_referral_apply_code(&f.referrer, &code)
+                .unwrap_err(),
+            Ok(ContractError::InvalidInput)
+        );
+        f.client.referral_apply_code(&f.owner, &code);
+        assert_eq!(
+            f.client
+                .try_referral_apply_code(&f.owner, &code)
+                .unwrap_err(),
+            Ok(ContractError::AlreadyReferred)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Verify referral-code creation persists active expiry metadata.
- Cover expired and max-use-exhausted codes.
- Cover self-referral and double-apply rejection.
- Reuse the existing reward-math, idempotency, and zero-balance claim coverage.

## Impact

This change is limited to `referral.rs` and fills only the acceptance-criteria gaps left after the referral reward tests merged.

## Validation

- Both newly added referral tests pass.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --target wasm32v1-none -- -D warnings`
- `cargo check --workspace --target wasm32v1-none`

## Known upstream baseline failures

The complete `cargo test` build on current `main` is already blocked by stale tests in `params.rs`, `reviewer_pool.rs`, and `reviewer_sla.rs`, plus a fuzz integration target that accesses the private `fees` module.

Current `main` also no longer calls `referral::trigger_reward` from the grant payout path, although issue #719 originally added that wiring. Consequently, three pre-existing referral integration tests fail independently of these two new safeguards. This PR leaves that production-path regression separate because #722 restricts changes to `referral.rs`.

Closes #722
