### PR TITLE
docs: regenerate stale benchmark numbers

### DIFF
--- a/contracts/BENCHMARK.md
+++ b/contracts/BENCHMARK.md
@@ -2,33 +2,65 @@
 
 ## Contract: stellar-grants
 
-### Before Optimizations
-- **WASM Size**: 18,067 bytes (~17.6 KB)
-- **Profile**: default `opt-level = "z"`, `lto = true`
+Measured on this branch with **Stellar CLI 27.0.0** and **Rust 1.97.1**, using the
+workspace release profile in `contracts/Cargo.toml`.
 
-### After Optimizations
-- **WASM Size**: 16,436 bytes (~16.1 KB)
-- **Drop**: 1,631 bytes (~9.03%)
+> **Note on `stellar contract build`:** Stellar CLI 27 rejects
+> `overflow-checks = false` in `[profile.release]`. The figures below were
+> produced with a temporary `overflow-checks = true` so the documented
+> `stellar contract build` command could run; the checked-in workspace profile
+> still uses `overflow-checks = false` for size. Plain
+> `cargo build --target wasm32v1-none --release` (without the CLI’s spec-shaking
+> env) produces a larger artifact (~700 KB) and is not the size tracked here.
 
-### Optimization Techniques Applied
-1. **Release Profile Enhancements**:
-   - `opt-level = "s"`: Found to be more effective than "z" for this specific instruction mix.
-   - `lto = "fat"`: Enabled full Link Time Optimization.
-   - `strip = true`: Removed all debug symbols and names.
-   - `incremental = false`: Ensured clean release builds.
-   - `overflow-checks = false`: Aggressive instruction pruning for well-typed operations.
+### Build commands
 
-2. **Dependency Profiling**:
-   - `default-features = false` for `soroban-sdk`: Removed standard library components and logging features from the guest environment.
-   - Removed unused crates and internal modules.
+```bash
+cd contracts
+stellar contract build --package stellar-grants --locked --optimize=false
+stellar contract build --package stellar-grants --locked --optimize
+```
 
-3. **Code Level Pruning**:
-   - Removed unused `DataKey` variants and `storage` helpers.
-   - Removed unused `#[contracttype]` structs from `events.rs` that were adding expansion overhead.
-   - Replaced internal `Result` propagation with `env.panic_with_error()` callers in critical paths to reduce error-handling branch overhead.
-   - Ensured zero `std` formatting usage (no `format!`, `println!`).
+`stellar contract build` sets `SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2=1`,
+which is required for the sizes below (plain `cargo build` alone will not match).
 
 ### Results
-- Noticeable reduction in contract size.
-- Reduced resource footprint through instruction pruning.
-- Test coverage (12/12) fully maintained.
+
+| Build | Size |
+|------|------|
+| Release (`--optimize=false`, with spec shaking) | `511,030` bytes (~499.1 KB) |
+| Optimized (`--optimize`) | `447,150` bytes (~436.7 KB) |
+| Optimizer delta | `63,880` bytes smaller (`12.5%`) |
+
+### Release profile
+
+From `contracts/Cargo.toml`:
+
+```toml
+[profile.release]
+opt-level = "s"
+overflow-checks = false
+debug = 0
+strip = true
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = "fat"
+incremental = false
+```
+
+### Optimization techniques applied
+
+1. **Release profile** — `opt-level = "s"`, fat LTO, symbol stripping, single codegen unit, abort-on-panic.
+2. **Spec shaking** — `stellar contract build` enables Soroban SDK spec shaking so unused contract-spec / rustdoc payload is dropped from the WASM.
+3. **WASM optimizer** — `stellar contract build --optimize` (wasm-opt style pass) removes an additional ~12.5% from the release artifact.
+
+### Tests
+
+`cargo test --package stellar-grants` **does not currently compile** (23 errors as of
+this measurement — e.g. tests calling missing client methods such as
+`reviewer_get_sla` / `check_reviewer_sla`). A pass/fail coverage claim is therefore
+not reported.
+
+In-tree `#[test]` attributes under `contracts/stellar-grants`: **415** defined tests
+(awaiting a green suite before a runnable count can be published).

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -168,26 +168,29 @@ stellar contract build --package stellar-grants --locked --optimize
 
 ### WASM Size Benchmark
 
-Measured on this branch with `stellar contract build`:
+Measured on this branch with `stellar contract build` (see [`BENCHMARK.md`](./BENCHMARK.md) for methodology and caveats):
 
 | Build | Size |
 |------|------|
-| Initial release baseline before final size pass | `100,772` bytes |
-| Final release WASM | `87,305` bytes |
-| Final optimized WASM (`--optimize`) | `75,924` bytes |
-| End-to-end delta | `24,848` bytes smaller (`24.7%`) |
+| Release (`--optimize=false`, with spec shaking) | `511,030` bytes |
+| Optimized (`--optimize`) | `447,150` bytes |
+| Optimizer delta | `63,880` bytes smaller (`12.5%`) |
 
-The last size pass combined Soroban spec shaking with trimming embedded rustdoc/spec text from exported contract items. On the current code, the optimizer still removes an additional `11,381` bytes (`13.0%`) from the release WASM.
+`stellar contract build` enables Soroban SDK spec shaking (`SOROBAN_SDK_BUILD_SYSTEM_SUPPORTS_SPEC_SHAKING_V2`). On the current code, `--optimize` still removes an additional `63,880` bytes (`12.5%`) from the release WASM.
 
 The workspace release profile already uses size-focused settings:
 
 ```toml
 [profile.release]
-opt-level = "z"
-lto = true
-codegen-units = 1
+opt-level = "s"
+overflow-checks = false
+debug = 0
+strip = true
+debug-assertions = false
 panic = "abort"
-strip = "symbols"
+codegen-units = 1
+lto = "fat"
+incremental = false
 ```
 
 ### Run Tests


### PR DESCRIPTION
## Summary
- Fully regenerates `contracts/BENCHMARK.md` with fresh WASM sizes from `stellar contract build` (511,030 → 447,150 bytes with `--optimize`).
- Syncs `contracts/README.md` WASM size table and release-profile snippet so both docs stay consistent.
- Replaces the outdated 16KB / “12/12 tests maintained” claims with measured figures and an honest note on current test-suite status.

Closes #742

## Test plan
- [ ] Compare documented sizes against a local `stellar contract build --package stellar-grants --locked --optimize=false` / `--optimize` run
- [ ] Confirm README and BENCHMARK.md tables match each other
- [ ] Confirm no remaining 16KB or “12/12” claims remain in these files