### PR TITLE
test: add coverage for license, metrics, milestone_extension, registry

### DIFF
--- a/contracts/contracts/stellar-grants/src/license.rs
+++ b/contracts/contracts/stellar-grants/src/license.rs
@@ -42,3 +42,187 @@ pub fn attach_license(
 pub fn get_license(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<LicenseRecord> {
     Storage::get_license_record(env, grant_id, milestone_idx)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::Storage;
+    use crate::types::{
+        Grant, GrantStatus, Milestone, MilestoneState, RegistryEntry, RegistryEntryType,
+    };
+    use soroban_sdk::{testutils::Address as _, Env, Map, String, Vec};
+
+    fn setup() -> (Env, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let admin = Address::generate(&env);
+        (env, owner, admin)
+    }
+
+    fn create_grant_with_milestone(env: &Env, owner: &Address, grant_id: u64) {
+        let grant = Grant {
+            id: grant_id,
+            owner: owner.clone(),
+            title: String::from_str(env, "Test Grant"),
+            description: String::from_str(env, "Desc"),
+            token: Address::generate(env),
+            status: GrantStatus::Active,
+            total_amount: 1000,
+            milestone_amount: 500,
+            reviewers: Vec::new(env),
+            total_milestones: 2,
+            milestones_paid_out: 0,
+            escrow_balance: 1000,
+            funders: Vec::new(env),
+            reason: None,
+            timestamp: env.ledger().timestamp(),
+            require_compliance: None,
+        };
+        Storage::set_grant(env, grant_id, &grant);
+
+        let milestone = Milestone {
+            idx: 0,
+            description: String::from_str(env, "MS1"),
+            amount: 500,
+            state: MilestoneState::Approved,
+            votes: Map::new(env),
+            approvals: 1,
+            rejections: 0,
+            reasons: Map::new(env),
+            status_updated_at: 0,
+            proof_url: Some(String::from_str(env, "https://proof")),
+            submission_timestamp: env.ledger().timestamp(),
+            deadline: None,
+            reviewer_count_snapshot: 1,
+        };
+        Storage::set_milestone(env, grant_id, 0, &milestone);
+    }
+
+    #[test]
+    fn test_attach_and_get_license() {
+        let (env, owner, _) = setup();
+        create_grant_with_milestone(&env, &owner, 1);
+
+        let rights = IpRights {
+            commercial_use: true,
+            modification: false,
+            distribution: true,
+            sublicense: false,
+        };
+
+        let record = attach_license(
+            &env,
+            &owner,
+            1,
+            0,
+            String::from_str(&env, "MIT"),
+            LicenseType::OpenSource,
+            rights,
+            String::from_str(&env, "No restrictions"),
+        )
+        .unwrap();
+
+        assert_eq!(record.grant_id, 1);
+        assert_eq!(record.milestone_idx, 0);
+        assert_eq!(record.license_type, LicenseType::OpenSource);
+        assert!(record.rights.commercial_use);
+        assert!(!record.rights.modification);
+
+        let fetched = get_license(&env, 1, 0).unwrap();
+        assert_eq!(fetched, record);
+    }
+
+    #[test]
+    fn test_get_license_returns_none_when_not_set() {
+        let (env, _, _) = setup();
+        assert!(get_license(&env, 999, 0).is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_attach_license_unauthorized() {
+        let (env, owner, _) = setup();
+        create_grant_with_milestone(&env, &owner, 1);
+
+        let other = Address::generate(&env);
+        let rights = IpRights {
+            commercial_use: false,
+            modification: false,
+            distribution: false,
+            sublicense: false,
+        };
+
+        attach_license(
+            &env,
+            &other,
+            1,
+            0,
+            String::from_str(&env, "MIT"),
+            LicenseType::OpenSource,
+            rights,
+            String::from_str(&env, ""),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_attach_license_milestone_out_of_bounds() {
+        let (env, owner, _) = setup();
+        create_grant_with_milestone(&env, &owner, 1);
+
+        let rights = IpRights {
+            commercial_use: false,
+            modification: false,
+            distribution: false,
+            sublicense: false,
+        };
+
+        attach_license(
+            &env,
+            &owner,
+            1,
+            99,
+            String::from_str(&env, "MIT"),
+            LicenseType::OpenSource,
+            rights,
+            String::from_str(&env, ""),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_attach_license_all_types() {
+        let (env, owner, _) = setup();
+        create_grant_with_milestone(&env, &owner, 2);
+
+        let rights = IpRights {
+            commercial_use: true,
+            modification: true,
+            distribution: true,
+            sublicense: true,
+        };
+
+        // Proprietary
+        let r = attach_license(
+            &env, &owner, 2, 0, String::from_str(&env, "PROPRIETARY"),
+            LicenseType::Proprietary, rights.clone(), String::from_str(&env, ""),
+        ).unwrap();
+        assert_eq!(r.license_type, LicenseType::Proprietary);
+
+        // CreativeCommons
+        let r = attach_license(
+            &env, &owner, 2, 0, String::from_str(&env, "CC-BY-4.0"),
+            LicenseType::CreativeCommons, rights.clone(), String::from_str(&env, ""),
+        ).unwrap();
+        assert_eq!(r.license_type, LicenseType::CreativeCommons);
+
+        // Custom
+        let r = attach_license(
+            &env, &owner, 2, 0, String::from_str(&env, "CUSTOM"),
+            LicenseType::Custom, rights, String::from_str(&env, "Special terms"),
+        ).unwrap();
+        assert_eq!(r.license_type, LicenseType::Custom);
+    }
+}

--- a/contracts/contracts/stellar-grants/src/metrics.rs
+++ b/contracts/contracts/stellar-grants/src/metrics.rs
@@ -143,3 +143,228 @@ pub fn reset(env: &Env, admin: &Address) -> Result<(), ContractError> {
     Storage::set_protocol_metrics(env, &default_metrics(env));
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::Storage;
+    use soroban_sdk::{testutils::Address as _, Env};
+
+    fn setup() -> Env {
+        Env::default()
+    }
+
+    #[test]
+    fn test_default_metrics_are_zero() {
+        let env = setup();
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_created, 0);
+        assert_eq!(m.total_grants_active, 0);
+        assert_eq!(m.total_grants_completed, 0);
+        assert_eq!(m.total_grants_cancelled, 0);
+        assert_eq!(m.total_milestones_approved, 0);
+        assert_eq!(m.total_milestones_rejected, 0);
+        assert_eq!(m.total_milestones_paid, 0);
+        assert_eq!(m.total_contributors_registered, 0);
+        assert_eq!(m.total_disputes_raised, 0);
+        assert_eq!(m.total_disputes_resolved, 0);
+        assert_eq!(m.total_bounties_created, 0);
+        assert_eq!(m.total_bounties_awarded, 0);
+    }
+
+    #[test]
+    fn test_increment_grants_created() {
+        let env = setup();
+        increment(&env, MetricField::GrantsCreated, 1);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_created, 1);
+
+        increment(&env, MetricField::GrantsCreated, 3);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_created, 4);
+    }
+
+    #[test]
+    fn test_increment_grants_active() {
+        let env = setup();
+        increment(&env, MetricField::GrantsActive, 2);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_active, 2);
+    }
+
+    #[test]
+    fn test_grants_completed_decrements_active() {
+        let env = setup();
+        increment(&env, MetricField::GrantsActive, 5);
+        increment(&env, MetricField::GrantsCompleted, 2);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_completed, 2);
+        assert_eq!(m.total_grants_active, 3);
+    }
+
+    #[test]
+    fn test_grants_cancelled_decrements_active() {
+        let env = setup();
+        increment(&env, MetricField::GrantsActive, 5);
+        increment(&env, MetricField::GrantsCancelled, 1);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_cancelled, 1);
+        assert_eq!(m.total_grants_active, 4);
+    }
+
+    #[test]
+    fn test_milestone_counters() {
+        let env = setup();
+        increment(&env, MetricField::MilestonesApproved, 3);
+        increment(&env, MetricField::MilestonesRejected, 1);
+        increment(&env, MetricField::MilestonesPaid, 2);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_milestones_approved, 3);
+        assert_eq!(m.total_milestones_rejected, 1);
+        assert_eq!(m.total_milestones_paid, 2);
+    }
+
+    #[test]
+    fn test_dispute_counters() {
+        let env = setup();
+        increment(&env, MetricField::DisputesRaised, 5);
+        increment(&env, MetricField::DisputesResolved, 3);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_disputes_raised, 5);
+        assert_eq!(m.total_disputes_resolved, 3);
+    }
+
+    #[test]
+    fn test_bounty_counters() {
+        let env = setup();
+        increment(&env, MetricField::BountiesCreated, 10);
+        increment(&env, MetricField::BountiesAwarded, 7);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_bounties_created, 10);
+        assert_eq!(m.total_bounties_awarded, 7);
+    }
+
+    #[test]
+    fn test_contributors_counter() {
+        let env = setup();
+        increment(&env, MetricField::ContributorsRegistered, 4);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_contributors_registered, 4);
+    }
+
+    #[test]
+    fn test_saturating_add_never_panics() {
+        let env = setup();
+        // Set to near max
+        let mut m = get_metrics(&env);
+        m.total_grants_created = u32::MAX - 1;
+        Storage::set_protocol_metrics(&env, &m);
+
+        increment(&env, MetricField::GrantsCreated, 5);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_created, u32::MAX);
+    }
+
+    #[test]
+    fn test_saturating_sub_never_panics_on_completed() {
+        let env = setup();
+        // Active is 0, completing 1 should saturate to 0
+        increment(&env, MetricField::GrantsCompleted, 1);
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_completed, 1);
+        assert_eq!(m.total_grants_active, 0);
+    }
+
+    #[test]
+    fn test_multi_action_sequence() {
+        let env = setup();
+        increment(&env, MetricField::GrantsCreated, 3);
+        increment(&env, MetricField::GrantsActive, 3);
+        increment(&env, MetricField::ContributorsRegistered, 5);
+        increment(&env, MetricField::MilestonesApproved, 6);
+        increment(&env, MetricField::MilestonesPaid, 4);
+        increment(&env, MetricField::DisputesRaised, 1);
+        increment(&env, MetricField::DisputesResolved, 1);
+        increment(&env, MetricField::GrantsCompleted, 1);
+        increment(&env, MetricField::GrantsCancelled, 1);
+
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_created, 3);
+        assert_eq!(m.total_grants_active, 1); // 3 - 1 - 1
+        assert_eq!(m.total_grants_completed, 1);
+        assert_eq!(m.total_grants_cancelled, 1);
+        assert_eq!(m.total_milestones_approved, 6);
+        assert_eq!(m.total_milestones_paid, 4);
+        assert_eq!(m.total_disputes_raised, 1);
+        assert_eq!(m.total_disputes_resolved, 1);
+        assert_eq!(m.total_contributors_registered, 5);
+    }
+
+    #[test]
+    fn test_token_metrics_default() {
+        let env = setup();
+        let token = Address::generate(&env);
+        let tm = get_token_metrics(&env, &token);
+        assert_eq!(tm.total_locked, 0);
+        assert_eq!(tm.total_paid_out, 0);
+        assert_eq!(tm.total_refunded, 0);
+    }
+
+    #[test]
+    fn test_update_token_locked_positive() {
+        let env = setup();
+        let token = Address::generate(&env);
+        update_token_locked(&env, &token, 1000);
+        let tm = get_token_metrics(&env, &token);
+        assert_eq!(tm.total_locked, 1000);
+        assert_eq!(tm.total_paid_out, 0);
+    }
+
+    #[test]
+    fn test_update_token_locked_negative() {
+        let env = setup();
+        let token = Address::generate(&env);
+        update_token_locked(&env, &token, 1000);
+        update_token_locked(&env, &token, -400);
+        let tm = get_token_metrics(&env, &token);
+        assert_eq!(tm.total_locked, 600);
+        assert_eq!(tm.total_paid_out, 400);
+    }
+
+    #[test]
+    fn test_record_token_refund() {
+        let env = setup();
+        let token = Address::generate(&env);
+        update_token_locked(&env, &token, 1000);
+        record_token_refund(&env, &token, 300);
+        let tm = get_token_metrics(&env, &token);
+        assert_eq!(tm.total_locked, 700);
+        assert_eq!(tm.total_refunded, 300);
+    }
+
+    #[test]
+    fn test_reset_clears_all() {
+        let env = setup();
+        let admin = Address::generate(&env);
+        Storage::set_global_admin(&env, &admin);
+
+        increment(&env, MetricField::GrantsCreated, 10);
+        increment(&env, MetricField::DisputesRaised, 5);
+
+        reset(&env, &admin).unwrap();
+
+        let m = get_metrics(&env);
+        assert_eq!(m.total_grants_created, 0);
+        assert_eq!(m.total_disputes_raised, 0);
+    }
+
+    #[test]
+    fn test_reset_unauthorized() {
+        let env = setup();
+        let admin = Address::generate(&env);
+        Storage::set_global_admin(&env, &admin);
+
+        let other = Address::generate(&env);
+        assert!(reset(&env, &other).is_err());
+    }
+}

--- a/contracts/contracts/stellar-grants/src/milestone_extension.rs
+++ b/contracts/contracts/stellar-grants/src/milestone_extension.rs
@@ -224,3 +224,281 @@ pub fn is_overdue(env: &Env, grant_id: u64, milestone_idx: u32) -> bool {
 pub fn get_extension_history(env: &Env, grant_id: u64) -> Vec<ExtensionRequest> {
     Storage::get_extension_history(env, grant_id)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::Storage;
+    use crate::types::{Grant, GrantStatus, Milestone, MilestoneState};
+    use soroban_sdk::{testutils::Address as _, Env, Map, String, Vec};
+
+    fn setup() -> (Env, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let owner = Address::generate(&env);
+        let reviewer1 = Address::generate(&env);
+        let reviewer2 = Address::generate(&env);
+        (env, owner, reviewer1, reviewer2)
+    }
+
+    fn create_grant_with_milestone(
+        env: &Env,
+        owner: &Address,
+        reviewers: &Vec<Address>,
+        grant_id: u64,
+        deadline: u64,
+    ) {
+        let grant = Grant {
+            id: grant_id,
+            owner: owner.clone(),
+            title: String::from_str(env, "Test"),
+            description: String::from_str(env, "Desc"),
+            token: Address::generate(env),
+            status: GrantStatus::Active,
+            total_amount: 1000,
+            milestone_amount: 500,
+            reviewers: reviewers.clone(),
+            total_milestones: 1,
+            milestones_paid_out: 0,
+            escrow_balance: 1000,
+            funders: Vec::new(env),
+            reason: None,
+            timestamp: env.ledger().timestamp(),
+            require_compliance: None,
+        };
+        Storage::set_grant(env, grant_id, &grant);
+
+        let milestone = Milestone {
+            idx: 0,
+            description: String::from_str(env, "MS1"),
+            amount: 500,
+            state: MilestoneState::Submitted,
+            votes: Map::new(env),
+            approvals: 0,
+            rejections: 0,
+            reasons: Map::new(env),
+            status_updated_at: 0,
+            proof_url: Some(String::from_str(env, "https://proof")),
+            submission_timestamp: env.ledger().timestamp(),
+            deadline: Some(deadline),
+            reviewer_count_snapshot: reviewers.len() as u32,
+        };
+        Storage::set_milestone(env, grant_id, 0, &milestone);
+    }
+
+    #[test]
+    fn test_request_extension() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+
+        request_extension(&env, &owner, 1, 0, 2000, String::from_str(&env, "Need more time")).unwrap();
+
+        let req = get_request(&env, 1, 0).unwrap();
+        assert_eq!(req.status, ExtensionStatus::Pending);
+        assert_eq!(req.new_deadline, 2000);
+        assert_eq!(req.original_deadline, 1000);
+    }
+
+    #[test]
+    fn test_get_request_returns_none_when_no_request() {
+        let (env, _, _, _) = setup();
+        assert!(get_request(&env, 999, 0).is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_request_extension_unauthorized() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+
+        let other = Address::generate(&env);
+        request_extension(&env, &other, 1, 0, 2000, String::from_str(&env, "reason")).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_request_extension_deadline_not_in_future() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+
+        // new_deadline <= now
+        request_extension(&env, &owner, 1, 0, 400, String::from_str(&env, "reason")).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_request_extension_duplicate_pending() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+
+        request_extension(&env, &owner, 1, 0, 2000, String::from_str(&env, "r1")).unwrap();
+        // Second request on same milestone while first is pending
+        request_extension(&env, &owner, 1, 0, 3000, String::from_str(&env, "r2")).unwrap();
+    }
+
+    #[test]
+    fn test_vote_extension_approve() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+        request_extension(&env, &owner, 1, 0, 2000, String::from_str(&env, "reason")).unwrap();
+
+        // First approve vote (need majority = 2/2 + 1 = 2)
+        let status = vote_extension(&env, &r1, 1, 0, true).unwrap();
+        assert_eq!(status, ExtensionStatus::Pending); // Not yet majority
+
+        // Second approve vote reaches majority
+        let status = vote_extension(&env, &r2, 1, 0, true).unwrap();
+        assert_eq!(status, ExtensionStatus::Approved);
+
+        // Verify deadline was updated
+        let milestone = Storage::get_milestone(&env, 1, 0).unwrap();
+        assert_eq!(milestone.deadline, Some(2000));
+    }
+
+    #[test]
+    fn test_vote_extension_deny() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+        request_extension(&env, &owner, 1, 0, 2000, String::from_str(&env, "reason")).unwrap();
+
+        vote_extension(&env, &r1, 1, 0, false).unwrap();
+        let status = vote_extension(&env, &r2, 1, 0, false).unwrap();
+        assert_eq!(status, ExtensionStatus::Denied);
+
+        // Deadline should NOT change
+        let milestone = Storage::get_milestone(&env, 1, 0).unwrap();
+        assert_eq!(milestone.deadline, Some(1000));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_vote_extension_double_vote() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+        request_extension(&env, &owner, 1, 0, 2000, String::from_str(&env, "reason")).unwrap();
+
+        vote_extension(&env, &r1, 1, 0, true).unwrap();
+        vote_extension(&env, &r1, 1, 0, true).unwrap(); // double vote
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_vote_extension_non_reviewer() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+        request_extension(&env, &owner, 1, 0, 2000, String::from_str(&env, "reason")).unwrap();
+
+        let rando = Address::generate(&env);
+        vote_extension(&env, &rando, 1, 0, true).unwrap();
+    }
+
+    #[test]
+    fn test_withdraw_request() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+        request_extension(&env, &owner, 1, 0, 2000, String::from_str(&env, "reason")).unwrap();
+
+        withdraw_request(&env, &owner, 1, 0).unwrap();
+
+        // Request should be removed
+        assert!(get_request(&env, 1, 0).is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_withdraw_request_unauthorized() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+        request_extension(&env, &owner, 1, 0, 2000, String::from_str(&env, "reason")).unwrap();
+
+        let other = Address::generate(&env);
+        withdraw_request(&env, &other, 1, 0).unwrap();
+    }
+
+    #[test]
+    fn test_is_overdue() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        // Before deadline
+        env.ledger().with_mut(|li| li.timestamp = 500);
+        assert!(!is_overdue(&env, 1, 0));
+
+        // After deadline
+        env.ledger().with_mut(|li| li.timestamp = 1001);
+        assert!(is_overdue(&env, 1, 0));
+    }
+
+    #[test]
+    fn test_extension_history() {
+        let (env, owner, r1, r2) = setup();
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(r1.clone());
+        reviewers.push_back(r2.clone());
+        create_grant_with_milestone(&env, &owner, &reviewers, 1, 1000);
+
+        env.ledger().with_mut(|li| li.timestamp = 500);
+        request_extension(&env, &owner, 1, 0, 2000, String::from_str(&env, "reason")).unwrap();
+
+        // Approve it
+        vote_extension(&env, &r1, 1, 0, true).unwrap();
+        vote_extension(&env, &r2, 1, 0, true).unwrap();
+
+        let history = get_extension_history(&env, 1);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history.get(0).unwrap().status, ExtensionStatus::Approved);
+    }
+}

--- a/contracts/contracts/stellar-grants/src/registry.rs
+++ b/contracts/contracts/stellar-grants/src/registry.rs
@@ -111,3 +111,160 @@ fn require_global_admin(env: &Env, caller: &Address) -> Result<(), ContractError
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::Storage;
+    use soroban_sdk::{testutils::Address as _, Env, String};
+
+    fn setup() -> (Env, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        Storage::set_global_admin(&env, &admin);
+        (env, admin)
+    }
+
+    #[test]
+    fn test_register_contributor() {
+        let (env, _) = setup();
+        let addr = Address::generate(&env);
+        let name = String::from_str(&env, "Alice");
+
+        register_contributor(&env, &addr, &name).unwrap();
+
+        assert_eq!(contributor_count(&env), 1);
+        let page = get_contributors_page(&env, 0, 10);
+        assert_eq!(page.len(), 1);
+        assert_eq!(page.get(0).unwrap().address, addr);
+        assert_eq!(page.get(0).unwrap().entry_type, RegistryEntryType::Contributor);
+        assert!(page.get(0).unwrap().is_active);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_register_contributor_duplicate() {
+        let (env, _) = setup();
+        let addr = Address::generate(&env);
+        let name = String::from_str(&env, "Alice");
+
+        register_contributor(&env, &addr, &name).unwrap();
+        register_contributor(&env, &addr, &name).unwrap(); // duplicate
+    }
+
+    #[test]
+    fn test_register_multiple_contributors() {
+        let (env, _) = setup();
+        let a1 = Address::generate(&env);
+        let a2 = Address::generate(&env);
+        let a3 = Address::generate(&env);
+
+        register_contributor(&env, &a1, &String::from_str(&env, "A")).unwrap();
+        register_contributor(&env, &a2, &String::from_str(&env, "B")).unwrap();
+        register_contributor(&env, &a3, &String::from_str(&env, "C")).unwrap();
+
+        assert_eq!(contributor_count(&env), 3);
+    }
+
+    #[test]
+    fn test_approve_reviewer() {
+        let (env, admin) = setup();
+        let reviewer = Address::generate(&env);
+
+        approve_reviewer(&env, &admin, &reviewer).unwrap();
+
+        assert!(is_approved_reviewer(&env, &reviewer));
+    }
+
+    #[test]
+    fn test_approve_reviewer_idempotent() {
+        let (env, admin) = setup();
+        let reviewer = Address::generate(&env);
+
+        approve_reviewer(&env, &admin, &reviewer).unwrap();
+        approve_reviewer(&env, &admin, &reviewer).unwrap(); // no-op
+
+        assert!(is_approved_reviewer(&env, &reviewer));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_approve_reviewer_unauthorized() {
+        let (env, _) = setup();
+        let reviewer = Address::generate(&env);
+        let other = Address::generate(&env);
+
+        approve_reviewer(&env, &other, &reviewer).unwrap();
+    }
+
+    #[test]
+    fn test_revoke_reviewer() {
+        let (env, admin) = setup();
+        let reviewer = Address::generate(&env);
+
+        approve_reviewer(&env, &admin, &reviewer).unwrap();
+        assert!(is_approved_reviewer(&env, &reviewer));
+
+        revoke_reviewer(&env, &admin, &reviewer).unwrap();
+        assert!(!is_approved_reviewer(&env, &reviewer));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_revoke_reviewer_not_found() {
+        let (env, admin) = setup();
+        let reviewer = Address::generate(&env);
+
+        revoke_reviewer(&env, &admin, &reviewer).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_revoke_reviewer_unauthorized() {
+        let (env, admin) = setup();
+        let reviewer = Address::generate(&env);
+
+        approve_reviewer(&env, &admin, &reviewer).unwrap();
+
+        let other = Address::generate(&env);
+        revoke_reviewer(&env, &other, &reviewer).unwrap();
+    }
+
+    #[test]
+    fn test_is_approved_reviewer_returns_false_for_unknown() {
+        let (env, _) = setup();
+        let addr = Address::generate(&env);
+        assert!(!is_approved_reviewer(&env, &addr));
+    }
+
+    #[test]
+    fn test_pagination() {
+        let (env, _) = setup();
+
+        for i in 0..5 {
+            let addr = Address::generate(&env);
+            register_contributor(&env, &addr, &String::from_str(&env, "C")).unwrap();
+        }
+
+        assert_eq!(contributor_count(&env), 5);
+
+        // Page 0: items 0-2
+        let page0 = get_contributors_page(&env, 0, 3);
+        assert_eq!(page0.len(), 3);
+
+        // Page 1: items 3-4
+        let page1 = get_contributors_page(&env, 3, 3);
+        assert_eq!(page1.len(), 2);
+
+        // Offset beyond count
+        let empty = get_contributors_page(&env, 10, 3);
+        assert_eq!(empty.len(), 0);
+    }
+
+    #[test]
+    fn test_contributor_count_empty() {
+        let (env, _) = setup();
+        assert_eq!(contributor_count(&env), 0);
+    }
+}


### PR DESCRIPTION
Fixes #784, Fixes #785, Fixes #786, Fixes #788

## What changed

**#784 — license.rs test coverage**
- Test attach and get license round-trip
- Test unauthorized caller rejected
- Test milestone index out of bounds
- Test all LicenseType variants (OpenSource, Proprietary, CreativeCommons, Custom)

**#785 — metrics.rs test coverage**
- Test all 12 metric counters increment correctly
- Test GrantsCompleted/Cancelled decrement GrantsActive
- Test saturating arithmetic never panics
- Test token metrics (locked, paid out, refunded)
- Test multi-action sequence correctness
- Test admin-only reset

**#786 — milestone_extension.rs test coverage**
- Test request extension creates Pending request
- Test vote approve reaches majority and updates deadline
- Test vote deny rejects without changing deadline
- Test double vote rejected
- Test non-reviewer vote rejected
- Test withdraw removes request
- Test is_overdue before/after deadline
- Test extension history populated on resolution

**#788 — registry.rs test coverage**
- Test register contributor and lookup
- Test duplicate registration rejected
- Test approve/revoke reviewer
- Test reviewer eligibility checks
- Test pagination correctness
- Test unauthorized operations rejected

## How to test
`cargo test` in `contracts/contracts/stellar-grants/`