### PR TITLE
fix: scoring truncation, invert order, batch rate limit, and multi_grant tests

### DIFF
--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -803,7 +803,9 @@ impl StellarGrantsContract {
     ) -> Result<(), ContractError> {
         emergency::require_not_paused(&env)?;
         crate::grant_pause::require_not_paused(&env, grant_id)?;
+        circuit_breaker::require_open(&env, ProtocolModule::Grants)?;
         recipient.require_auth();
+        rate_limit::check_and_increment(&env, &recipient, RateLimitAction::MilestoneSubmit)?;
 
         let batch_len = submissions.len();
         if batch_len == 0 {

--- a/contracts/contracts/stellar-grants/src/multi_grant.rs
+++ b/contracts/contracts/stellar-grants/src/multi_grant.rs
@@ -447,4 +447,156 @@ mod tests {
         assert_eq!(portfolio.owner, owner);
         assert_eq!(portfolio.stats.owner, owner);
     }
+
+    use crate::types::{Grant, GrantFund, GrantStatus};
+    use soroban_sdk::String;
+
+    fn create_grant(env: &soroban_sdk::Env, id: u64, owner: &Address, reviewers: Vec<Address>, status: GrantStatus, escrow: i128) {
+        let grant = Grant {
+            id,
+            owner: owner.clone(),
+            title: String::from_str(env, "test"),
+            description: String::from_str(env, "desc"),
+            token: Address::generate(env),
+            status,
+            total_amount: 1000,
+            milestone_amount: 100,
+            reviewers,
+            total_milestones: 3,
+            milestones_paid_out: 0,
+            escrow_balance: escrow,
+            funders: Vec::new(env),
+            reason: None,
+            timestamp: env.ledger().timestamp(),
+            require_compliance: None,
+        };
+        Storage::set_grant(env, id, &grant);
+        // Register in owner index
+        let key = DataKey::Grant(GrantKey::OwnerIndex(owner.clone()));
+        let mut ids: Vec<u64> = env.storage().persistent().get(&key).unwrap_or_else(|| Vec::new(env));
+        ids.push_back(id);
+        env.storage().persistent().set(&key, &ids);
+    }
+
+    #[test]
+    fn test_batch_add_reviewer_across_grants() {
+        let env = soroban_sdk::Env::default();
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+        let mut reviewers = Vec::new(&env);
+
+        create_grant(&env, 1, &owner, reviewers.clone(), GrantStatus::Active, 1000);
+        reviewers.push_back(Address::generate(&env));
+        create_grant(&env, 2, &owner, reviewers.clone(), GrantStatus::Active, 2000);
+
+        let mut grant_ids = Vec::new(&env);
+        grant_ids.push_back(1);
+        grant_ids.push_back(2);
+
+        let result = batch_add_reviewer(&env, &owner, grant_ids, &reviewer).unwrap();
+        assert_eq!(result.successful, 2);
+        assert_eq!(result.failed, 0);
+        assert_eq!(result.total, 2);
+    }
+
+    #[test]
+    fn test_batch_add_reviewer_partial_failure() {
+        let env = soroban_sdk::Env::default();
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+
+        create_grant(&env, 1, &owner, Vec::new(&env), GrantStatus::Active, 1000);
+        // grant 99 doesn't exist
+
+        let mut grant_ids = Vec::new(&env);
+        grant_ids.push_back(1);
+        grant_ids.push_back(99);
+
+        let result = batch_add_reviewer(&env, &owner, grant_ids, &reviewer).unwrap();
+        assert_eq!(result.successful, 1);
+        assert_eq!(result.failed, 1);
+        assert_eq!(result.total, 2);
+    }
+
+    #[test]
+    fn test_batch_remove_reviewer() {
+        let env = soroban_sdk::Env::default();
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+        create_grant(&env, 1, &owner, reviewers.clone(), GrantStatus::Active, 1000);
+        create_grant(&env, 2, &owner, reviewers.clone(), GrantStatus::Active, 2000);
+
+        let mut grant_ids = Vec::new(&env);
+        grant_ids.push_back(1);
+        grant_ids.push_back(2);
+
+        let result = batch_remove_reviewer(&env, &owner, grant_ids, &reviewer).unwrap();
+        assert_eq!(result.successful, 2);
+        assert_eq!(result.failed, 0);
+    }
+
+    #[test]
+    fn test_batch_remove_reviewer_not_found() {
+        let env = soroban_sdk::Env::default();
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+
+        create_grant(&env, 1, &owner, Vec::new(&env), GrantStatus::Active, 1000);
+
+        let mut grant_ids = Vec::new(&env);
+        grant_ids.push_back(1);
+
+        let result = batch_remove_reviewer(&env, &owner, grant_ids, &reviewer).unwrap();
+        assert_eq!(result.successful, 0);
+        assert_eq!(result.failed, 1);
+    }
+
+    #[test]
+    fn test_portfolio_stats_with_grants() {
+        let env = soroban_sdk::Env::default();
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+
+        let mut reviewers = Vec::new(&env);
+        reviewers.push_back(reviewer.clone());
+        create_grant(&env, 1, &owner, reviewers.clone(), GrantStatus::Active, 500);
+        create_grant(&env, 2, &owner, reviewers.clone(), GrantStatus::Completed, 0);
+
+        let stats = get_portfolio_stats(&env, &owner);
+        assert_eq!(stats.total_grants, 2);
+        assert_eq!(stats.active_grants, 1);
+        assert_eq!(stats.completed_grants, 1);
+        assert_eq!(stats.total_funded, 2000);
+        assert_eq!(stats.unique_reviewers, 1);
+    }
+
+    #[test]
+    fn test_total_escrow_balance_with_grants() {
+        let env = soroban_sdk::Env::default();
+        let owner = Address::generate(&env);
+        let token = Address::generate(&env);
+
+        // Create grants with specific tokens to test balance aggregation
+        let grant1 = Grant {
+            id: 1, owner: owner.clone(),
+            title: String::from_str(&env, "t"), description: String::from_str(&env, "d"),
+            token: token.clone(), status: GrantStatus::Active,
+            total_amount: 1000, milestone_amount: 100,
+            reviewers: Vec::new(&env), total_milestones: 3, milestones_paid_out: 0,
+            escrow_balance: 300, funders: Vec::new(&env), reason: None,
+            timestamp: 0, require_compliance: None,
+        };
+        Storage::set_grant(&env, 1, &grant1);
+
+        let owner_key = DataKey::Grant(GrantKey::OwnerIndex(owner.clone()));
+        let mut ids: Vec<u64> = Vec::new(&env);
+        ids.push_back(1);
+        env.storage().persistent().set(&owner_key, &ids);
+
+        let balance = total_escrow_balance(&env, &owner, &token);
+        assert_eq!(balance, 300);
+    }
 }

--- a/contracts/contracts/stellar-grants/src/scoring.rs
+++ b/contracts/contracts/stellar-grants/src/scoring.rs
@@ -123,8 +123,8 @@ fn compute_dimension_score(env: &Env, contributor: &Address, dimension: &Scoring
             let profile = Storage::get_contributor(env, contributor.clone());
             match profile {
                 Some(p) => {
-                    let normalized = (p.total_earned as u64).min(1_000_000_000_000) as u32;
-                    (normalized / 1_000_000_000).min(1000)
+                    let normalized = (p.total_earned.max(0) as u64).min(1_000_000_000_000);
+                    ((normalized / 1_000_000_000) as u32).min(1000)
                 }
                 None => 0,
             }
@@ -182,15 +182,16 @@ pub fn score_contributor(
 
     for w in rubric.weights.iter() {
         let raw = compute_dimension_score(env, contributor, &w.dimension);
-        let weighted = raw
+        let effective_raw = if w.invert {
+            1000u32.saturating_sub(raw.min(1000))
+        } else {
+            raw.min(1000)
+        };
+        let score = effective_raw
             .saturating_mul(w.weight_bps)
             .checked_div(BASIS_POINTS_SCALE)
-            .unwrap_or(0);
-        let score = if w.invert {
-            1000u32.saturating_sub(weighted.min(1000))
-        } else {
-            weighted.min(1000)
-        };
+            .unwrap_or(0)
+            .min(1000);
         total_score = total_score.saturating_add(score);
         dimension_scores.push_back((w.dimension.clone(), score));
     }
@@ -410,5 +411,104 @@ mod tests {
         let ranked = env.as_contract(&contract_id, || rank_contributors(&env, contributors, id));
         assert_eq!(ranked.len(), 2);
         assert!(ranked.get(0).unwrap().total_score >= ranked.get(1).unwrap().total_score);
+    }
+
+    #[test]
+    fn test_total_earned_score_not_truncated() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarGrantsContract, ());
+        let admin = setup_admin(&env, &contract_id);
+        let contributor = make_contributor(&env, &contract_id);
+        // make_contributor has total_earned = 500_000_000_000
+
+        let mut weights: Vec<ScoringWeight> = Vec::new(&env);
+        weights.push_back(ScoringWeight {
+            dimension: ScoringDimension::TotalEarned,
+            weight_bps: 10000,
+            invert: false,
+        });
+
+        let name = String::from_str(&env, "EarnedOnly");
+        let id = env.as_contract(&contract_id, || {
+            define_rubric(&env, &admin, name, weights).unwrap()
+        });
+
+        let result = env.as_contract(&contract_id, || {
+            score_contributor(&env, &contributor, id).unwrap()
+        });
+        assert_eq!(result.total_score, 500);
+    }
+
+    #[test]
+    fn test_total_earned_score_capped_at_1000() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarGrantsContract, ());
+        let admin = setup_admin(&env, &contract_id);
+
+        let c = Address::generate(&env);
+        let profile = crate::types::ContributorProfile {
+            contributor: c.clone(),
+            name: soroban_sdk::String::from_str(&env, "whale"),
+            bio: soroban_sdk::String::from_str(&env, "bio"),
+            skills: soroban_sdk::Vec::new(&env),
+            github_url: soroban_sdk::String::from_str(&env, "url"),
+            registration_timestamp: env.ledger().timestamp(),
+            reputation_score: 750,
+            grants_count: 5,
+            total_earned: 2_000_000_000_000,
+            milestones_completed: 8,
+            milestones_rejected: 2,
+            last_action_at: env.ledger().timestamp(),
+        };
+        env.as_contract(&contract_id, || {
+            Storage::set_contributor(&env, c.clone(), &profile);
+        });
+
+        let mut weights: Vec<ScoringWeight> = Vec::new(&env);
+        weights.push_back(ScoringWeight {
+            dimension: ScoringDimension::TotalEarned,
+            weight_bps: 10000,
+            invert: false,
+        });
+
+        let name = String::from_str(&env, "EarnedCap");
+        let id = env.as_contract(&contract_id, || {
+            define_rubric(&env, &admin, name, weights).unwrap()
+        });
+
+        let result = env.as_contract(&contract_id, || {
+            score_contributor(&env, &c, id).unwrap()
+        });
+        assert_eq!(result.total_score, 1000);
+    }
+
+    #[test]
+    fn test_invert_before_weighting() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(StellarGrantsContract, ());
+        let admin = setup_admin(&env, &contract_id);
+        let contributor = make_contributor(&env, &contract_id);
+        // reputation_score = 750, so raw = 750
+
+        let mut weights: Vec<ScoringWeight> = Vec::new(&env);
+        weights.push_back(ScoringWeight {
+            dimension: ScoringDimension::ReputationScore,
+            weight_bps: 5000,
+            invert: true,
+        });
+
+        let name = String::from_str(&env, "Inverted");
+        let id = env.as_contract(&contract_id, || {
+            define_rubric(&env, &admin, name, weights).unwrap()
+        });
+
+        let result = env.as_contract(&contract_id, || {
+            score_contributor(&env, &contributor, id).unwrap()
+        });
+        // effective_raw = 1000 - 750 = 250, score = 250 * 5000 / 10000 = 125
+        assert_eq!(result.total_score, 125);
     }
 }


### PR DESCRIPTION
fixes #790
fixes #809
fixes #810
fixes #811

- scoring.rs: keep TotalEarned division in u64 so it doesn't silently wrap to 1 for normal contributors
- scoring.rs: invert the raw 0-1000 score before applying weight_bps, not after
- lib.rs: add circuit_breaker and rate_limit checks to milestone_submit_batch to match milestone_submit
- multi_grant.rs: add tests for batch_add_reviewer, batch_remove_reviewer with partial failure, portfolio stats, and escrow balance