### PR TITLE
fix: validate stream grant_id, close reviewer whitelist bypass, enforce GlobalContributor scope, fix data_export staleness

### DIFF
--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -273,6 +273,12 @@ impl StellarGrantsContract {
             return Err(ContractError::InvalidInput);
         }
 
+        // Issue #816: enforce the GlobalContributor whitelist gate. Defaults
+        // to Open mode, so this is a no-op unless an admin restricts it.
+        if !whitelist::is_allowed(&env, &contributor, &WhitelistScope::GlobalContributor) {
+            return Err(ContractError::AddressNotWhitelisted);
+        }
+
         if Storage::get_contributor(&env, contributor.clone()).is_some() {
             return Err(ContractError::AlreadyRegistered);
         }
@@ -365,6 +371,8 @@ impl StellarGrantsContract {
             grant_index::on_status_changed(&env, grant_id, old_status, GrantStatus::Cancelled);
 
             Storage::set_grant(&env, grant_id, &grant);
+            // Issue #817: keep the data_export staleness/filter API fresh.
+            data_export::set_last_updated(&env, grant_id, env.ledger().timestamp());
 
             Events::emit_grant_cancelled(&env, grant_id, caller.clone(), reason, total_refundable);
 
@@ -553,6 +561,8 @@ impl StellarGrantsContract {
         grant.milestones_paid_out = grant.total_milestones;
         grant.timestamp = env.ledger().timestamp();
         Storage::set_grant(env, grant_id, &grant);
+        // Issue #817: keep the data_export staleness/filter API fresh.
+        data_export::set_last_updated(env, grant_id, env.ledger().timestamp());
 
         let mut escrow_state = Storage::get_escrow_state(env, grant_id);
         escrow_state.lifecycle = EscrowLifecycleState::Released;
@@ -604,6 +614,8 @@ impl StellarGrantsContract {
         )?;
 
         Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
+        // Issue #817: keep the data_export staleness/filter API fresh.
+        data_export::set_last_updated(&env, grant_id, env.ledger().timestamp());
 
         provenance::record(
             &env,
@@ -746,6 +758,8 @@ impl StellarGrantsContract {
         }
 
         Storage::set_milestone(&env, grant_id, milestone_idx, &milestone);
+        // Issue #817: keep the data_export staleness/filter API fresh.
+        data_export::set_last_updated(&env, grant_id, env.ledger().timestamp());
         Events::milestone_rejected(&env, grant_id, milestone_idx, reviewer, reason);
 
         Ok(majority_rejected)
@@ -4297,6 +4311,8 @@ fn apply_milestone_submission(
     };
 
     Storage::set_milestone(env, grant_id, milestone_idx, &milestone);
+    // Issue #817: keep the data_export staleness/filter API fresh.
+    data_export::set_last_updated(env, grant_id, env.ledger().timestamp());
     Events::emit_milestone_submitted(env, grant_id, milestone_idx, description);
 
     audit::log(

--- a/contracts/contracts/stellar-grants/src/multi_grant.rs
+++ b/contracts/contracts/stellar-grants/src/multi_grant.rs
@@ -3,7 +3,9 @@ use crate::storage::keys::{DataKey, GrantKey};
 use crate::storage::Storage;
 use crate::types::{
     GrantPortfolio, GrantStatus, MultiGrantBatchResult, PortfolioFilter, PortfolioStats,
+    WhitelistScope,
 };
+use crate::whitelist;
 use soroban_sdk::{Address, Env, Vec};
 
 /// Return portfolio stats for an owner address.
@@ -309,6 +311,13 @@ fn add_reviewer_to_grant(
         return Ok(());
     }
 
+    // Issue #815: enforce the same GlobalReviewer whitelist gate that
+    // internal_grant_create applies at grant-creation time, so a reviewer
+    // excluded from the whitelist can't be added post-creation instead.
+    if !whitelist::is_allowed(env, reviewer, &WhitelistScope::GlobalReviewer) {
+        return Err(ContractError::AddressNotWhitelisted);
+    }
+
     // Add reviewer
     grant.reviewers.push_back(reviewer.clone());
     Storage::set_grant(env, grant_id, &grant);
@@ -598,5 +607,40 @@ mod tests {
 
         let balance = total_escrow_balance(&env, &owner, &token);
         assert_eq!(balance, 300);
+    }
+
+    #[test]
+    fn test_batch_add_reviewer_enforces_global_whitelist() {
+        use crate::types::WhitelistMode;
+
+        let env = soroban_sdk::Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let owner = Address::generate(&env);
+        let reviewer = Address::generate(&env);
+
+        create_grant(&env, 1, &owner, Vec::new(&env), GrantStatus::Active, 1000);
+
+        Storage::set_global_admin(&env, &admin);
+        whitelist::set_mode(&env, &admin, &WhitelistScope::GlobalReviewer, WhitelistMode::Restricted)
+            .unwrap();
+
+        let mut grant_ids = Vec::new(&env);
+        grant_ids.push_back(1);
+
+        // Not whitelisted: batch_add_reviewer should fail for this grant.
+        let result = batch_add_reviewer(&env, &owner, grant_ids.clone(), &reviewer).unwrap();
+        assert_eq!(result.successful, 0);
+        assert_eq!(result.failed, 1);
+        let grant = Storage::get_grant(&env, 1).unwrap();
+        assert!(!grant.reviewers.contains(reviewer.clone()));
+
+        // Whitelist the reviewer; the same call should now succeed.
+        whitelist::add(&env, &admin, &reviewer, &WhitelistScope::GlobalReviewer).unwrap();
+        let result = batch_add_reviewer(&env, &owner, grant_ids, &reviewer).unwrap();
+        assert_eq!(result.successful, 1);
+        assert_eq!(result.failed, 0);
+        let grant = Storage::get_grant(&env, 1).unwrap();
+        assert!(grant.reviewers.contains(reviewer));
     }
 }

--- a/contracts/contracts/stellar-grants/src/streaming.rs
+++ b/contracts/contracts/stellar-grants/src/streaming.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{contractevent, token, Address, Env};
 
 use crate::errors::ContractError;
 use crate::storage::Storage;
-use crate::types::{PaymentStream, StreamStatus};
+use crate::types::{GrantStatus, PaymentStream, StreamStatus};
 
 // ── Events ────────────────────────────────────────────────────────────────────
 
@@ -68,6 +68,12 @@ pub fn create_stream(
     }
     if duration_ledgers == 0 {
         return Err(ContractError::InvalidInput);
+    }
+
+    // Issue #814: streams must be tied to a real, active grant.
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if grant.status != GrantStatus::Active {
+        return Err(ContractError::InvalidState);
     }
 
     let deposited = rate_per_ledger
@@ -309,8 +315,9 @@ pub fn get_stream(env: &Env, stream_id: u32) -> Result<PaymentStream, ContractEr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::Grant;
     use soroban_sdk::testutils::{Address as _, Ledger};
-    use soroban_sdk::{token::StellarAssetClient, Address, Env};
+    use soroban_sdk::{token::StellarAssetClient, Address, Env, String};
 
     fn setup() -> (Env, Address, Address, Address, Address) {
         let env = Env::default();
@@ -325,7 +332,39 @@ mod tests {
         let stellar_asset = StellarAssetClient::new(&env, &token_contract);
         stellar_asset.mint(&sender, &10_000_000);
         let _ = admin;
+
+        // Streams must reference a real, active grant (Issue #814).
+        create_active_grant(&env, 1, &sender, &token_contract, GrantStatus::Active);
+
         (env, sender, recipient, token_contract, token_admin)
+    }
+
+    fn create_active_grant(
+        env: &Env,
+        id: u64,
+        owner: &Address,
+        token: &Address,
+        status: GrantStatus,
+    ) {
+        let grant = Grant {
+            id,
+            owner: owner.clone(),
+            title: String::from_str(env, "test grant"),
+            description: String::from_str(env, "desc"),
+            token: token.clone(),
+            status,
+            total_amount: 1_000_000,
+            milestone_amount: 100_000,
+            reviewers: soroban_sdk::Vec::new(env),
+            total_milestones: 1,
+            milestones_paid_out: 0,
+            escrow_balance: 0,
+            funders: soroban_sdk::Vec::new(env),
+            reason: None,
+            timestamp: env.ledger().timestamp(),
+            require_compliance: None,
+        };
+        Storage::set_grant(env, id, &grant);
     }
 
     #[test]
@@ -374,5 +413,22 @@ mod tests {
 
         let stream_after = Storage::get_stream(&env, stream_id).unwrap();
         assert_eq!(stream_after.end_ledger, original_end + 10);
+    }
+
+    #[test]
+    fn test_create_stream_rejects_nonexistent_grant() {
+        let (env, sender, recipient, token, _) = setup();
+        // Grant 999 was never created.
+        let result = create_stream(&env, &sender, &recipient, 999, &token, 100, 100);
+        assert_eq!(result, Err(ContractError::GrantNotFound));
+    }
+
+    #[test]
+    fn test_create_stream_rejects_inactive_grant() {
+        let (env, sender, recipient, token, _) = setup();
+        create_active_grant(&env, 2, &sender, &token, GrantStatus::Cancelled);
+
+        let result = create_stream(&env, &sender, &recipient, 2, &token, 100, 100);
+        assert_eq!(result, Err(ContractError::InvalidState));
     }
 }

--- a/contracts/contracts/stellar-grants/tests/test_data_export_staleness.rs
+++ b/contracts/contracts/stellar-grants/tests/test_data_export_staleness.rs
@@ -1,0 +1,114 @@
+/// Issue #817: data_export::set_last_updated was only ever called from its
+/// own unit tests, so export_grants's last_updated_after filter, plus
+/// last_global_update and state_fingerprint, never reflected real grant or
+/// milestone activity. These tests drive a real grant through the public
+/// contract entrypoints and confirm the staleness tracking now advances.
+use soroban_sdk::{
+    testutils::{Address as TestAddress, Ledger as _},
+    Address, Env, String, Vec,
+};
+use stellar_grants::{StellarGrantsContract, StellarGrantsContractClient};
+
+fn setup() -> (Env, StellarGrantsContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarGrantsContract);
+    let client = StellarGrantsContractClient::new(&env, &contract_id);
+    let owner = <Address as TestAddress>::generate(&env);
+    let admin = <Address as TestAddress>::generate(&env);
+    (env, client, owner, admin)
+}
+
+fn make_reviewers(env: &Env, count: u32) -> Vec<Address> {
+    let mut reviewers = Vec::new(env);
+    for _ in 0..count {
+        reviewers.push_back(<Address as TestAddress>::generate(env));
+    }
+    reviewers
+}
+
+#[test]
+fn test_milestone_submission_advances_last_updated_and_export_filter() {
+    let (env, client, owner, admin) = setup();
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let reviewers = make_reviewers(&env, 1);
+
+    let grant_id = client.grant_create(
+        &owner,
+        &String::from_str(&env, "Export Grant"),
+        &String::from_str(&env, "Testing staleness tracking"),
+        &token_id,
+        &1000,
+        &1000,
+        &1,
+        &reviewers,
+    );
+
+    let token_admin_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin_client.mint(&owner, &1000);
+    client.grant_fund(&grant_id, &owner, &1000);
+
+    // Record a baseline timestamp before any real mutation past creation.
+    let baseline = client.last_global_update();
+    let fingerprint_before = client.state_fingerprint();
+
+    // Advance ledger time so the milestone submission timestamp is observably later.
+    env.ledger().with_mut(|li| li.timestamp += 100);
+
+    client.milestone_submit(
+        &grant_id,
+        &0,
+        &owner,
+        &String::from_str(&env, "Milestone 0"),
+        &String::from_str(&env, "https://proof.example.com"),
+    );
+
+    // last_global_update must have advanced past the baseline.
+    let after_submit = client.last_global_update();
+    assert!(after_submit > baseline);
+
+    // The fingerprint must change once a real milestone mutation happens.
+    let fingerprint_after = client.state_fingerprint();
+    assert_ne!(fingerprint_before, fingerprint_after);
+
+    // export_grants with last_updated_after set to the baseline must now
+    // include this grant, since it was updated after that timestamp.
+    let page = client.export_grants(&0, &10, &Some(baseline));
+    let found = page.items.iter().any(|g| g.id == grant_id);
+    assert!(found, "grant should appear in incremental export after mutation");
+
+    // Filtering with a cutoff at or after the submission timestamp excludes it again.
+    let page_after = client.export_grants(&0, &10, &Some(after_submit));
+    let found_after = page_after.items.iter().any(|g| g.id == grant_id);
+    assert!(!found_after, "grant should not appear once cutoff is at/after its last update");
+}
+
+#[test]
+fn test_grant_cancellation_advances_last_updated() {
+    let (env, client, owner, admin) = setup();
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let reviewers = make_reviewers(&env, 2);
+
+    let grant_id = client.grant_create(
+        &owner,
+        &String::from_str(&env, "Cancellation Grant"),
+        &String::from_str(&env, "Testing staleness tracking"),
+        &token_id,
+        &1000,
+        &1000,
+        &1,
+        &reviewers,
+    );
+
+    let token_admin_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin_client.mint(&owner, &1000);
+    client.grant_fund(&grant_id, &owner, &1000);
+
+    let before_cancel = client.last_global_update();
+    env.ledger().with_mut(|li| li.timestamp += 100);
+
+    client.grant_cancel(&grant_id, &owner, &String::from_str(&env, "No longer needed"));
+
+    let after_cancel = client.last_global_update();
+    assert!(after_cancel > before_cancel);
+}

--- a/contracts/contracts/stellar-grants/tests/test_reviewer_whitelist_bypass.rs
+++ b/contracts/contracts/stellar-grants/tests/test_reviewer_whitelist_bypass.rs
@@ -1,0 +1,90 @@
+/// Issue #815: batch_add_reviewer (backed by multi_grant::add_reviewer_to_grant)
+/// never checked the GlobalReviewer whitelist, so a reviewer excluded from
+/// the whitelist at grant-creation time could still be added post-creation.
+/// These tests confirm the same gate is now enforced via the real contract
+/// entrypoints.
+use soroban_sdk::{testutils::Address as TestAddress, Address, Env, String, Vec};
+use stellar_grants::{
+    StellarGrantsContract, StellarGrantsContractClient, WhitelistMode, WhitelistScope,
+};
+
+fn setup() -> (Env, StellarGrantsContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarGrantsContract);
+    let client = StellarGrantsContractClient::new(&env, &contract_id);
+    let owner = <Address as TestAddress>::generate(&env);
+    let admin = <Address as TestAddress>::generate(&env);
+    client.set_global_admin(&admin, &admin);
+    (env, client, owner, admin)
+}
+
+#[test]
+fn test_batch_add_reviewer_blocked_when_not_whitelisted() {
+    let (env, client, owner, admin) = setup();
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let reviewer = <Address as TestAddress>::generate(&env);
+
+    let grant_id = client.grant_create(
+        &owner,
+        &String::from_str(&env, "Whitelist Grant"),
+        &String::from_str(&env, "Testing reviewer whitelist bypass"),
+        &token_id,
+        &1000,
+        &1000,
+        &1,
+        &Vec::new(&env),
+    );
+
+    client.whitelist_set_mode(
+        &admin,
+        &WhitelistScope::GlobalReviewer,
+        &WhitelistMode::Restricted,
+    );
+
+    let mut grant_ids = Vec::new(&env);
+    grant_ids.push_back(grant_id);
+
+    // Not whitelisted: the batch call must not sneak this reviewer onto the grant.
+    let result = client.batch_add_reviewer(&owner, &grant_ids, &reviewer);
+    assert_eq!(result.successful, 0);
+    assert_eq!(result.failed, 1);
+
+    let grant = client.get_grant(&grant_id);
+    assert!(!grant.reviewers.contains(reviewer));
+}
+
+#[test]
+fn test_batch_add_reviewer_succeeds_once_whitelisted() {
+    let (env, client, owner, admin) = setup();
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let reviewer = <Address as TestAddress>::generate(&env);
+
+    let grant_id = client.grant_create(
+        &owner,
+        &String::from_str(&env, "Whitelist Grant"),
+        &String::from_str(&env, "Testing reviewer whitelist bypass"),
+        &token_id,
+        &1000,
+        &1000,
+        &1,
+        &Vec::new(&env),
+    );
+
+    client.whitelist_set_mode(
+        &admin,
+        &WhitelistScope::GlobalReviewer,
+        &WhitelistMode::Restricted,
+    );
+    client.whitelist_add(&admin, &reviewer, &WhitelistScope::GlobalReviewer);
+
+    let mut grant_ids = Vec::new(&env);
+    grant_ids.push_back(grant_id);
+
+    let result = client.batch_add_reviewer(&owner, &grant_ids, &reviewer);
+    assert_eq!(result.successful, 1);
+    assert_eq!(result.failed, 0);
+
+    let grant = client.get_grant(&grant_id);
+    assert!(grant.reviewers.contains(reviewer));
+}

--- a/contracts/contracts/stellar-grants/tests/test_streaming_grant_validation.rs
+++ b/contracts/contracts/stellar-grants/tests/test_streaming_grant_validation.rs
@@ -1,0 +1,83 @@
+/// Issue #814: streaming::create_stream never validated the grant_id it was
+/// created against. These tests exercise the real contract entrypoints to
+/// confirm a stream can no longer be created against a nonexistent grant or
+/// one that isn't Active.
+use soroban_sdk::{testutils::Address as TestAddress, Address, Env, String, Vec};
+use stellar_grants::{StellarGrantsContract, StellarGrantsContractClient};
+
+fn setup() -> (Env, StellarGrantsContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarGrantsContract);
+    let client = StellarGrantsContractClient::new(&env, &contract_id);
+    let owner = <Address as TestAddress>::generate(&env);
+    let admin = <Address as TestAddress>::generate(&env);
+    (env, client, owner, admin)
+}
+
+#[test]
+fn test_create_stream_rejects_nonexistent_grant() {
+    let (env, client, owner, admin) = setup();
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let recipient = <Address as TestAddress>::generate(&env);
+
+    let token_admin_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin_client.mint(&owner, &10_000);
+
+    // Grant 999 was never created.
+    let result = client.try_create_stream(&owner, &recipient, &999, &token_id, &100, &10);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_stream_rejects_cancelled_grant() {
+    let (env, client, owner, admin) = setup();
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let recipient = <Address as TestAddress>::generate(&env);
+    let reviewers = Vec::new(&env);
+
+    let grant_id = client.grant_create(
+        &owner,
+        &String::from_str(&env, "Stream Grant"),
+        &String::from_str(&env, "Testing stream validation"),
+        &token_id,
+        &1000,
+        &1000,
+        &1,
+        &reviewers,
+    );
+
+    client.grant_cancel(&grant_id, &owner, &String::from_str(&env, "abandoned"));
+
+    let token_admin_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin_client.mint(&owner, &10_000);
+
+    let result = client.try_create_stream(&owner, &recipient, &grant_id, &token_id, &100, &10);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_stream_succeeds_for_active_grant() {
+    let (env, client, owner, admin) = setup();
+    let token_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let recipient = <Address as TestAddress>::generate(&env);
+    let reviewers = Vec::new(&env);
+
+    let grant_id = client.grant_create(
+        &owner,
+        &String::from_str(&env, "Stream Grant"),
+        &String::from_str(&env, "Testing stream validation"),
+        &token_id,
+        &1000,
+        &1000,
+        &1,
+        &reviewers,
+    );
+
+    let token_admin_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
+    token_admin_client.mint(&owner, &10_000);
+
+    let stream_id = client.create_stream(&owner, &recipient, &grant_id, &token_id, &100, &10);
+    let stream = client.get_stream(&stream_id);
+    assert_eq!(stream.grant_id, grant_id);
+}

--- a/contracts/contracts/stellar-grants/tests/test_whitelist_enforcement.rs
+++ b/contracts/contracts/stellar-grants/tests/test_whitelist_enforcement.rs
@@ -1,0 +1,84 @@
+/// Issue #816: WhitelistScope::GlobalContributor was fully implemented in
+/// whitelist.rs but never consulted by contributor_register, so restricting
+/// the scope had no real effect. These tests exercise the real contract
+/// entrypoints to confirm the gate is now enforced.
+use soroban_sdk::{testutils::Address as TestAddress, Address, Env, String, Vec};
+use stellar_grants::{StellarGrantsContract, StellarGrantsContractClient, WhitelistMode, WhitelistScope};
+
+fn setup() -> (Env, StellarGrantsContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, StellarGrantsContract);
+    let client = StellarGrantsContractClient::new(&env, &contract_id);
+    let admin = <Address as TestAddress>::generate(&env);
+    client.set_global_admin(&admin, &admin);
+    (env, client, admin)
+}
+
+#[test]
+fn test_contributor_register_open_mode_unaffected() {
+    let (env, client, _admin) = setup();
+    let contributor = <Address as TestAddress>::generate(&env);
+
+    // GlobalContributor defaults to Open — registration must remain unrestricted.
+    assert_eq!(
+        client.whitelist_get_mode(&WhitelistScope::GlobalContributor),
+        WhitelistMode::Open
+    );
+
+    let result = client.try_contributor_register(
+        &contributor,
+        &String::from_str(&env, "Alice"),
+        &String::from_str(&env, "Rust developer"),
+        &Vec::new(&env),
+        &String::from_str(&env, "https://github.com/alice"),
+    );
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_contributor_register_blocked_when_restricted_and_not_whitelisted() {
+    let (env, client, admin) = setup();
+    let contributor = <Address as TestAddress>::generate(&env);
+
+    client.whitelist_set_mode(
+        &admin,
+        &WhitelistScope::GlobalContributor,
+        &WhitelistMode::Restricted,
+    );
+
+    let result = client.try_contributor_register(
+        &contributor,
+        &String::from_str(&env, "Alice"),
+        &String::from_str(&env, "Rust developer"),
+        &Vec::new(&env),
+        &String::from_str(&env, "https://github.com/alice"),
+    );
+    assert!(result.is_err());
+
+    // Registration must not have gone through.
+    assert_eq!(client.contributor_count(), 0);
+}
+
+#[test]
+fn test_contributor_register_succeeds_once_whitelisted() {
+    let (env, client, admin) = setup();
+    let contributor = <Address as TestAddress>::generate(&env);
+
+    client.whitelist_set_mode(
+        &admin,
+        &WhitelistScope::GlobalContributor,
+        &WhitelistMode::Restricted,
+    );
+    client.whitelist_add(&admin, &contributor, &WhitelistScope::GlobalContributor);
+
+    let result = client.try_contributor_register(
+        &contributor,
+        &String::from_str(&env, "Alice"),
+        &String::from_str(&env, "Rust developer"),
+        &Vec::new(&env),
+        &String::from_str(&env, "https://github.com/alice"),
+    );
+    assert!(result.is_ok());
+    assert_eq!(client.contributor_count(), 1);
+}


### PR DESCRIPTION
- **#814** — `streaming::create_stream` now looks up `grant_id` via `Storage::get_grant` and rejects `ContractError::GrantNotFound` if it doesn't exist, or `ContractError::InvalidState` if the grant isn't `Active`. Kept the scope minimal (no additional owner/token-match tightening) to match the acceptance criteria exactly; existing streaming unit tests were updated to create a real active grant first.
- **#815** — `multi_grant::add_reviewer_to_grant` (backing `batch_add_reviewer`) now enforces the same `WhitelistScope::GlobalReviewer` gate that `internal_grant_create` applies at grant-creation time, so a reviewer excluded from the whitelist can no longer be added post-creation via the batch path. Placed after the existing "already a reviewer" idempotency check so re-adding an existing reviewer still no-ops regardless of whitelist state.
- **#816** — `contributor_register` now calls `whitelist::is_allowed(..., &WhitelistScope::GlobalContributor)` before registering, returning `ContractError::AddressNotWhitelisted` when restricted and the caller isn't listed. Since the scope defaults to `Open`, this is a no-op until an admin explicitly restricts it.
- **#817** — Wired `data_export::set_last_updated` into the real grant/milestone mutation paths that were missing it: `apply_milestone_submission`, `milestone_vote`, `milestone_reject`, `finalize_grant_release`, and `cancel_grant`. `export_grants`'s `last_updated_after` filter, `last_global_update`, and `state_fingerprint` now actually advance when real contract activity happens instead of always reading the `unwrap_or(0)` fallback.

## Test plan

- [x] `streaming.rs` unit tests updated/added: reject nonexistent grant, reject non-Active grant, existing happy-path tests updated to seed a real grant.
- [x] `multi_grant.rs` unit test added: `batch_add_reviewer` blocked while `GlobalReviewer` is `Restricted` and the reviewer isn't whitelisted, succeeds once whitelisted.
- [x] New integration tests added under `tests/` exercising the real contract entrypoints (since the crate's `--lib` unit-test target currently fails to compile on `main` for reasons unrelated to this PR — see note below):
  - `tests/test_streaming_grant_validation.rs` (#814)
  - `tests/test_reviewer_whitelist_bypass.rs` (#815)
  - `tests/test_whitelist_enforcement.rs` (#816)
  - `tests/test_data_export_staleness.rs` (#817)
  - All 10 new/updated tests pass: `cargo test --test test_streaming_grant_validation --test test_reviewer_whitelist_bypass --test test_whitelist_enforcement --test test_data_export_staleness` → `10 passed; 0 failed`.

**Note on pre-existing failures (unrelated to this PR):** `cargo test --lib` fails to compile on unmodified `main` with 28 errors (e.g. `Ledger::with_mut`/`set` not in scope in `milestone_extension.rs`, `Grant: Default` not satisfied in `split_payment.rs`/`storage/helpers.rs`, a missing `contract_id` field in `referral.rs` test fixtures). Several existing integration suites also fail independently of this change (`integration_lifecycle::test_happy_path_3_milestone_grant`, `test_milestone_quorum::*`, `test_reputation_and_dispute_fee::*`, etc.) — confirmed via `git stash` that the exact same failures occur on unmodified `main` before any of these fixes. None of the failing files/tests touch `streaming.rs`, `multi_grant.rs`, `whitelist.rs`, or `data_export.rs`.

Closes #814
Closes #815
Closes #816
Closes #817