### PR TITLE
fix: gate open_review entrypoints behind emergency pause check (#807)

### DIFF
--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -3232,6 +3232,7 @@ impl StellarGrantsContract {
         signal: PublicReviewSignal,
         comment: String,
     ) -> Result<(), ContractError> {
+        emergency::require_not_paused(&env)?;
         open_review::submit_review(&env, &reviewer, grant_id, milestone_idx, signal, comment)
     }
 
@@ -3242,6 +3243,7 @@ impl StellarGrantsContract {
         milestone_idx: u32,
         reviewer: Address,
     ) -> Result<(), ContractError> {
+        emergency::require_not_paused(&env)?;
         open_review::mark_helpful(&env, &voter, grant_id, milestone_idx, &reviewer)
     }
 

--- a/contracts/contracts/stellar-grants/src/test.rs
+++ b/contracts/contracts/stellar-grants/src/test.rs
@@ -4,7 +4,7 @@ mod tests {
     use crate::storage::Storage;
     use crate::types::{
         AmendmentStatus, AuditAction, ChainId, ContractError, EscrowLifecycleState, Grant,
-        GrantFund, GrantStatus, Milestone, MilestoneState,
+        GrantFund, GrantStatus, Milestone, MilestoneState, PublicReviewSignal,
     };
     use crate::StellarGrantsContract;
     use crate::StellarGrantsContractClient;
@@ -869,5 +869,64 @@ mod tests {
             .provenance_proof_hash(&record.id)
             .expect("hash computed");
         assert_eq!(hash1, hash2);
+    }
+
+    // ── Issue #807: open_review emergency pause gates ───────────────────────
+
+    #[test]
+    fn test_open_review_emergency_pause_gates() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, _contract_id) = setup_test(&env);
+        client.set_global_admin(&admin, &admin);
+
+        let reviewer = Address::generate(&env);
+        let voter = Address::generate(&env);
+        let grant_id = 1u64;
+        let milestone_idx = 0u32;
+
+        // Unpaused: submission succeeds.
+        client.open_review_submit(
+            &reviewer,
+            &grant_id,
+            &milestone_idx,
+            &PublicReviewSignal::Positive,
+            &String::from_str(&env, "Great milestone"),
+        );
+
+        // Unpaused: mark helpful succeeds.
+        client.open_review_mark_helpful(&voter, &grant_id, &milestone_idx, &reviewer);
+
+        // Pause contract.
+        let reason = String::from_str(&env, "Emergency maintenance");
+        client.pause(&admin, &reason);
+
+        // Paused: open_review_submit fails with ContractPaused error.
+        let res_submit = client.try_open_review_submit(
+            &reviewer,
+            &grant_id,
+            &milestone_idx,
+            &PublicReviewSignal::Positive,
+            &String::from_str(&env, "Post-pause review"),
+        );
+        assert_eq!(res_submit, Err(Ok(ContractError::ContractPaused.into())));
+
+        // Paused: open_review_mark_helpful fails with ContractPaused error.
+        let res_helpful =
+            client.try_open_review_mark_helpful(&voter, &grant_id, &milestone_idx, &reviewer);
+        assert_eq!(res_helpful, Err(Ok(ContractError::ContractPaused.into())));
+
+        // Unpause contract.
+        client.unpause(&admin);
+
+        // Unpaused again: operations succeed.
+        client.open_review_submit(
+            &reviewer,
+            &grant_id,
+            &milestone_idx,
+            &PublicReviewSignal::Positive,
+            &String::from_str(&env, "Updated review post-unpause"),
+        );
+        client.open_review_mark_helpful(&voter, &grant_id, &milestone_idx, &reviewer);
     }
 }


### PR DESCRIPTION
## Summary
I added emergency pause checks to `open_review_submit` and `open_review_mark_helpful` entrypoints in `lib.rs` so that all open review write operations are blocked when the contract is emergency-paused.

## Scope
I only worked on issue #807 ("Fix open_review_submit and open_review_mark_helpful Bypassing the Emergency Pause"). I'm not claiming or addressing any other issues in this PR.

## Changes
- I added `emergency::require_not_paused(&env)?;` to `open_review_submit` and `open_review_mark_helpful` in `contracts/contracts/stellar-grants/src/lib.rs`.
- I added a unit test `test_open_review_emergency_pause_gates()` in `contracts/contracts/stellar-grants/src/test.rs` to verify both functions fail with `ContractError::ContractPaused` when emergency-paused and succeed when unpaused.

## Test plan
- [x] I ran `cargo fmt` and verified formatting.
- [x] I ran `cargo clippy -- -D warnings` and verified zero warnings.
- [x] I ran `cargo test` and all 126 unit tests + integration tests passed cleanly.

Closes #807
