### PR TITLE
Fix/milestone dao fork analytics issues

### DIFF
--- a/contracts/contracts/stellar-grants/src/analytics.rs
+++ b/contracts/contracts/stellar-grants/src/analytics.rs
@@ -55,8 +55,8 @@ pub fn category_stats(env: &Env, category_id: u32) -> CategoryStats {
     let mut total_completion_ledgers = 0u64;
     let mut completion_count = 0u32;
 
-    // Iterate through tag index to find grants in this category
-    let grant_ids = Storage::get_tag_index(env, category_id);
+    // Iterate through category index to find grants in this category
+    let grant_ids = Storage::get_category_index(env, category_id);
 
     for grant_id in grant_ids.iter() {
         if let Some(grant) = Storage::get_grant(env, grant_id) {
@@ -187,7 +187,66 @@ pub fn get_window(env: &Env, metric: Symbol) -> Option<RollingWindow> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::testutils::Ledger;
+    use crate::types::{Grant, GrantStatus};
+    use soroban_sdk::testutils::{Address as _, Ledger};
+    use soroban_sdk::{Address, String};
+
+    fn setup_grant(env: &Env, id: u64, owner: &Address, status: GrantStatus, escrow_balance: i128) {
+        let grant = Grant {
+            id,
+            owner: owner.clone(),
+            title: String::from_str(env, "Grant"),
+            description: String::from_str(env, "Desc"),
+            token: Address::generate(env),
+            status,
+            total_amount: 1000,
+            milestone_amount: 500,
+            reviewers: Vec::new(env),
+            total_milestones: 2,
+            milestones_paid_out: 0,
+            escrow_balance,
+            funders: Vec::new(env),
+            reason: None,
+            timestamp: 0,
+            require_compliance: None,
+        };
+        Storage::set_grant(env, id, &grant);
+    }
+
+    /// #876: category_stats must read the per-category index populated by
+    /// grant_tags::tag_grant, not the freeform-tag hash index (whose keys
+    /// are 32-bit hashes that a small sequential category_id will never
+    /// match, silently leaving every category's stats at zero).
+    #[test]
+    fn test_category_stats_reads_tagged_grants() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        Storage::set_global_admin(&env, &admin);
+        let owner = Address::generate(&env);
+
+        let cat_id = crate::grant_tags::create_category(
+            &env,
+            &admin,
+            String::from_str(&env, "Infrastructure"),
+            Vec::new(&env),
+        )
+        .unwrap();
+
+        setup_grant(&env, 1, &owner, GrantStatus::Active, 1000);
+        setup_grant(&env, 2, &owner, GrantStatus::Completed, 2000);
+
+        let no_tags = Vec::new(&env);
+        crate::grant_tags::tag_grant(&env, &owner, 1, Some(cat_id), None, no_tags.clone()).unwrap();
+        crate::grant_tags::tag_grant(&env, &owner, 2, Some(cat_id), None, no_tags).unwrap();
+
+        let stats = category_stats(&env, cat_id);
+        assert_eq!(stats.total_grants, 2);
+        assert_eq!(stats.completed_grants, 1);
+        assert_eq!(stats.total_funded, 3000);
+        assert_eq!(stats.success_rate_bps, constants::BASIS_POINTS_SCALE / 2);
+    }
 
     /// #695: an old cached snapshot must trigger a rebuild once the ledger
     /// advances past the staleness threshold. The previous implementation

--- a/contracts/contracts/stellar-grants/src/dao.rs
+++ b/contracts/contracts/stellar-grants/src/dao.rs
@@ -229,6 +229,7 @@ pub fn require_dao_mode_disabled(env: &Env) -> Result<(), ContractError> {
 }
 
 fn require_global_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
+    caller.require_auth();
     let admin = Storage::get_global_admin(env).ok_or(ContractError::Unauthorized)?;
     if admin != *caller {
         return Err(ContractError::Unauthorized);
@@ -441,6 +442,27 @@ mod tests {
             );
             set_dao_mode(&env, &admin, true).unwrap();
             assert!(is_dao_mode_enabled(&env));
+        });
+    }
+
+    #[test]
+    fn test_set_dao_mode_rejects_admin_address_without_real_auth() {
+        let env = Env::default();
+        // Do NOT mock auths: this verifies require_global_admin enforces a
+        // genuine `require_auth()` on the caller, rather than only comparing
+        // addresses (which anyone could pass since the admin's address is
+        // public). Without any authorization recorded for `admin`, the call
+        // must be rejected even though the address itself matches.
+        with_contract(&env, || {
+            let admin = setup(&env);
+            let result = set_dao_mode(&env, &admin, true);
+            assert!(result.is_err());
+
+            let result = set_voting_period(&env, &admin, 100);
+            assert!(result.is_err());
+
+            let result = set_quorum_votes(&env, &admin, 5);
+            assert!(result.is_err());
         });
     }
 

--- a/contracts/contracts/stellar-grants/src/fork.rs
+++ b/contracts/contracts/stellar-grants/src/fork.rs
@@ -1,10 +1,10 @@
-use soroban_sdk::{Address, Env, String, Vec};
+use soroban_sdk::{Address, Env, Map, String, Vec};
 
 use crate::constants;
 use crate::errors::ContractError;
 use crate::events::Events;
 use crate::storage::Storage;
-use crate::types::{ForkRecord, GrantStatus};
+use crate::types::{ForkRecord, GrantStatus, Milestone, MilestoneState};
 
 pub fn fork_grant(
     env: &Env,
@@ -53,7 +53,31 @@ pub fn fork_grant(
         inherited_fields.push_back(String::from_str(env, "reviewers"));
     }
     if inherit_milestones {
-        inherited_fields.push_back(String::from_str(env, "milestones"));
+        let mut copied_any = false;
+        for idx in 0..original.total_milestones {
+            if let Some(orig_milestone) = Storage::get_milestone(env, original_grant_id, idx) {
+                let new_milestone = Milestone {
+                    idx,
+                    description: orig_milestone.description.clone(),
+                    amount: original.milestone_amount,
+                    state: MilestoneState::Pending,
+                    votes: Map::new(env),
+                    approvals: 0,
+                    rejections: 0,
+                    reasons: Map::new(env),
+                    status_updated_at: 0,
+                    proof_url: None,
+                    submission_timestamp: 0,
+                    deadline: None,
+                    reviewer_count_snapshot: 0,
+                };
+                Storage::set_milestone(env, new_grant_id, idx, &new_milestone);
+                copied_any = true;
+            }
+        }
+        if copied_any {
+            inherited_fields.push_back(String::from_str(env, "milestones"));
+        }
     }
     overridden_fields.push_back(String::from_str(env, "title"));
     overridden_fields.push_back(String::from_str(env, "description"));
@@ -147,6 +171,103 @@ mod test {
             require_compliance: None,
         };
         Storage::set_grant(env, id, &grant);
+    }
+
+    fn setup_milestone(env: &Env, grant_id: u64, idx: u32, description: &str) {
+        let milestone = Milestone {
+            idx,
+            description: String::from_str(env, description),
+            amount: 100,
+            state: MilestoneState::Approved,
+            votes: Map::new(env),
+            approvals: 1,
+            rejections: 0,
+            reasons: Map::new(env),
+            status_updated_at: 0,
+            proof_url: Some(String::from_str(env, "https://proof")),
+            submission_timestamp: env.ledger().timestamp(),
+            deadline: None,
+            reviewer_count_snapshot: 1,
+        };
+        Storage::set_milestone(env, grant_id, idx, &milestone);
+    }
+
+    /// #875: inherit_milestones = true must genuinely copy each submitted
+    /// milestone's description onto the new grant (with approval state
+    /// reset), and only then may ForkRecord.inherited_fields claim
+    /// "milestones" was inherited.
+    #[test]
+    fn test_fork_grant_copies_milestone_data_when_inherited() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let owner = Address::generate(&env);
+        let caller = Address::generate(&env);
+        let token = Address::generate(&env);
+        setup_grant(&env, 1, &owner);
+        setup_milestone(&env, 1, 0, "Design doc");
+        setup_milestone(&env, 1, 1, "MVP implementation");
+
+        let new_grant_id = fork_grant(
+            &env,
+            &caller,
+            1,
+            String::from_str(&env, "Forked Grant"),
+            String::from_str(&env, "Forked Desc"),
+            2000,
+            &token,
+            false,
+            true,
+        )
+        .unwrap();
+
+        let record = get_fork_record(&env, new_grant_id).unwrap();
+        assert!(record
+            .inherited_fields
+            .contains(String::from_str(&env, "milestones")));
+
+        let copied_0 = Storage::get_milestone(&env, new_grant_id, 0).unwrap();
+        assert_eq!(copied_0.description, String::from_str(&env, "Design doc"));
+        assert_eq!(copied_0.state, MilestoneState::Pending);
+        assert_eq!(copied_0.approvals, 0);
+        assert!(copied_0.proof_url.is_none());
+
+        let copied_1 = Storage::get_milestone(&env, new_grant_id, 1).unwrap();
+        assert_eq!(
+            copied_1.description,
+            String::from_str(&env, "MVP implementation")
+        );
+        assert_eq!(copied_1.state, MilestoneState::Pending);
+    }
+
+    #[test]
+    fn test_fork_grant_no_milestones_copied_does_not_claim_inherited() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let owner = Address::generate(&env);
+        let caller = Address::generate(&env);
+        let token = Address::generate(&env);
+        // No milestones ever submitted on the original grant.
+        setup_grant(&env, 1, &owner);
+
+        let new_grant_id = fork_grant(
+            &env,
+            &caller,
+            1,
+            String::from_str(&env, "Forked Grant"),
+            String::from_str(&env, "Forked Desc"),
+            2000,
+            &token,
+            false,
+            true,
+        )
+        .unwrap();
+
+        let record = get_fork_record(&env, new_grant_id).unwrap();
+        assert!(!record
+            .inherited_fields
+            .contains(String::from_str(&env, "milestones")));
     }
 
     #[test]

--- a/contracts/contracts/stellar-grants/src/grant_index.rs
+++ b/contracts/contracts/stellar-grants/src/grant_index.rs
@@ -185,6 +185,8 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::Events as _;
     use soroban_sdk::Env;
+    extern crate std;
+    use std::format;
 
     /// Issue #698: hitting the cap used to be a silent no-op — the id was
     /// dropped with no error and no event. A reduced cap (3, instead of the

--- a/contracts/contracts/stellar-grants/src/license.rs
+++ b/contracts/contracts/stellar-grants/src/license.rs
@@ -1,5 +1,5 @@
 use crate::storage::Storage;
-use crate::types::{ContractError, IpRights, LicenseRecord, LicenseType};
+use crate::types::{ContractError, IpRights, LicenseRecord, LicenseType, MilestoneState};
 use soroban_sdk::{Address, Env, String};
 
 /// Attach a license record to an approved milestone deliverable.
@@ -23,7 +23,11 @@ pub fn attach_license(
     if milestone_idx >= grant.total_milestones {
         return Err(ContractError::MilestoneIndexOutOfBounds);
     }
-    Storage::get_milestone(env, grant_id, milestone_idx).ok_or(ContractError::MilestoneNotFound)?;
+    let milestone = Storage::get_milestone(env, grant_id, milestone_idx)
+        .ok_or(ContractError::MilestoneNotFound)?;
+    if milestone.state != MilestoneState::Approved {
+        return Err(ContractError::InvalidState);
+    }
 
     let record = LicenseRecord {
         grant_id,
@@ -96,6 +100,18 @@ mod tests {
             deadline: None,
             reviewer_count_snapshot: 1,
         };
+        Storage::set_milestone(env, grant_id, 0, &milestone);
+    }
+
+    fn create_grant_with_milestone_in_state(
+        env: &Env,
+        owner: &Address,
+        grant_id: u64,
+        state: MilestoneState,
+    ) {
+        create_grant_with_milestone(env, owner, grant_id);
+        let mut milestone = Storage::get_milestone(env, grant_id, 0).unwrap();
+        milestone.state = state;
         Storage::set_milestone(env, grant_id, 0, &milestone);
     }
 
@@ -190,6 +206,58 @@ mod tests {
             String::from_str(&env, ""),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn test_attach_license_rejects_pending_milestone() {
+        let (env, owner, _) = setup();
+        create_grant_with_milestone_in_state(&env, &owner, 1, MilestoneState::Pending);
+
+        let rights = IpRights {
+            commercial_use: false,
+            modification: false,
+            distribution: false,
+            sublicense: false,
+        };
+
+        let result = attach_license(
+            &env,
+            &owner,
+            1,
+            0,
+            String::from_str(&env, "MIT"),
+            LicenseType::OpenSource,
+            rights,
+            String::from_str(&env, ""),
+        );
+
+        assert_eq!(result, Err(ContractError::InvalidState));
+    }
+
+    #[test]
+    fn test_attach_license_rejects_rejected_milestone() {
+        let (env, owner, _) = setup();
+        create_grant_with_milestone_in_state(&env, &owner, 1, MilestoneState::Rejected);
+
+        let rights = IpRights {
+            commercial_use: false,
+            modification: false,
+            distribution: false,
+            sublicense: false,
+        };
+
+        let result = attach_license(
+            &env,
+            &owner,
+            1,
+            0,
+            String::from_str(&env, "MIT"),
+            LicenseType::OpenSource,
+            rights,
+            String::from_str(&env, ""),
+        );
+
+        assert_eq!(result, Err(ContractError::InvalidState));
     }
 
     #[test]


### PR DESCRIPTION
# Enforce MAX_RUBRIC_WEIGHTS in validate_rubric (#812)

This PR bundles four related fixes to the `stellar-grants` Soroban contract on a single branch: one critical security fix, two fixes to the same broken token-swap call chain, and the full end-to-end integration of the previously-orphaned DAO governance module.

Previously, `constants::MAX_RUBRIC_WEIGHTS` (defined as 6) was never checked in `scoring.rs`. An admin could define a rubric with an arbitrary number of `ScoringWeight` entries as long as their total basis points summed to 10,000 BPS. Every subsequent call to `score_contributor` and `rank_contributors` would iterate over all entries in the rubric's weight vector, turning scoring into an unbounded-cost operation.

## #682 — Fix Unauthorized Escrow Drain via `swap_and_pay` (critical security)

**Files:** `contracts/contracts/stellar-grants/src/token_swap.rs`, `src/lib.rs`

`swap_and_pay` was a public entry point with **no authorization check at all** before releasing a grant's escrow. Since a grant's token is public (`get_grant`), any address could call `swap_and_pay(grant_id, attacker, grant.token, grant.token, amount)` and drain the escrow straight to itself — `escrow::release` trusts its caller to have already authorized the release, and this was the one call site that never did.

- Added a `payer: Address` parameter to `token_swap::swap_and_pay` and the `swap_and_pay` entry point. Requires `payer.require_auth()` and rejects unless `payer == grant.owner`.
- Also rejects if the caller-supplied `grant_token` doesn't match the grant's actual token (previously never checked at all).
- This is a breaking signature change (an entry point with zero caller identity has no way to authenticate without adding one) — confirmed no other package in this monorepo (`backend`, `client`, `web`) references `swap_and_pay`, so nothing else needs updating.
- New tests: a non-owner caller is rejected with `Unauthorized` and the escrow balance is untouched; the real owner succeeds; a grant-token mismatch is rejected.

---

## #683 — Fix `token_swap::swap` Confiscating Input Tokens Without Delivering Output

**Files:** `src/token_swap.rs`, `src/errors.rs`

`quote`/`swap` never integrated a real DEX: `quote` always returned a fake 1:1 rate, and `swap` pulled the caller's input token in but never delivered anything back.

**Decision:** no DEX contract exists to integrate against in this PR. Per the issue's own sanctioned fallback, `quote()` now returns a new `ContractError::SwapNotImplemented` instead of a fake rate, rather than shipping a "successful" swap that delivers nothing. Since `swap()` calls `quote()` before any token transfer, this closes the fund-loss path with no separate change needed in `swap()` itself.

- New error variant `SwapNotImplemented`.
- New tests: `quote()` and `swap()` both refuse cleanly; a `swap()` call is proven to leave the caller's token balance completely untouched.

---

## #684 — Fix `swap_and_fund` Double-Charging the Funder

**Files:** `src/token_swap.rs` (test only — see below)

This was a direct consequence of #683: `swap_and_fund`'s cross-token path called `swap()` (which pulled the input token once) and then `escrow::deposit` (which pulled the same amount again in the grant's real token), since `swap()` faked success without ever delivering anything.

With `swap()` now refusing up front (see #683), the cross-token branch errors out **before any transfer happens at all**, so the double-charge is unreachable. No production code change was needed beyond #683's fix.

- New test: a cross-token `swap_and_fund` call is rejected and the funder's token balance is proven to be exactly unchanged (zero transfers, not two).

**Bonus fix in the same call chain:** found and fixed a latent, previously-untested bug while writing the above test — `swap_and_fund` already authenticates its funder via `require_auth()`, then called into `swap()`, which re-called `require_auth()` for the *same* address. Soroban rejects a repeated `require_auth()` for one address within a single invocation ("frame is already authorized"). Moved that auth check out of `swap()` (which is otherwise only ever invoked with an already-authenticated caller, or the contract's own address from `swap_and_pay`) and into the `swap_tokens` entry point, the one place that actually needs it.

---

## #681 — Integrate On-Chain DAO Governance Module End-to-End

**Files:** `src/types.rs`, `src/storage/keys.rs`, `src/storage/helpers.rs`, `src/config.rs`, `src/dao.rs`, `src/treasury.rs`, `src/lib.rs`

`dao.rs` already contained complete reputation-weighted governance logic (proposal creation, one-vote-per-address weighted by reputation, permissionless finalization/execution, cancellation) with a passing 12-test suite, but had no storage layer or contract entry points — and its `execute()`'s `TreasuryWithdrawal` branch depended on `treasury.rs`, a second fully-written but undeclared module.

**What was added:**
- `DaoProposal`, `DaoProposalStatus`, `DaoProposalType`, and `TreasurySnapshot` types (the last was referenced by `treasury.rs` but didn't exist anywhere).
- A full storage layer: a `Dao` sub-key (proposal CRUD, per-`(proposal_id, voter)` vote tracking, mode/voting-period/quorum config) and a `TreasuryLedger` sub-key for `treasury.rs`'s per-token balances.
- `mod dao;` / `mod treasury;`, plus ten new DAO entry points (`dao_create_proposal`, `dao_vote`, `dao_finalize`, `dao_execute`, `dao_cancel`, `set_dao_mode`, etc.) and six new treasury entry points, all delegating straight into the existing, unmodified logic.

**Design decision — treasury mechanism:** kept the existing simple `Storage::get_treasury`/`set_treasury` (a single payout address, used today by `slash_reviewer`) and the new `treasury.rs` (a per-token spendable ledger of funds the contract itself holds) as **separate concepts**, rather than merging them or replacing one with the other. They serve genuinely different destinations — an external payout address vs. funds held in-contract — and merging would mean changing where slashed stake physically goes, which is a bigger, riskier change than this issue calls for. `slash_reviewer` is untouched.

**Design decision — treasury entry points:** exposed `treasury_deposit` as admin-gated rather than public. Its bookkeeping-only nature (it doesn't itself pull tokens in — see its doc comment) means an unauthenticated caller could otherwise inflate the ledger without a matching real transfer, letting a later `treasury_withdraw` drain unrelated contract funds (e.g. escrow balances). Gating it to the already-fully-trusted global admin keeps it no more dangerous than the admin's existing powers, without changing `treasury.rs`'s internal logic.

**DAO-mode gate:** `dao::require_dao_mode_disabled` existed but was never called anywhere. Wired it into both legacy direct-admin paths it exists to gate — `config::set_config` and `lib.rs::set_global_admin` — so enabling DAO mode now actually restricts them as intended.

**Test infrastructure fix:** `dao.rs`'s and `treasury.rs`'s own test suites could not run at all under the currently-installed `soroban-sdk` version (storage access outside an explicit `env.as_contract()` context now panics, and one test used a constant without importing it). Fixed by wrapping each existing test body in a small contract-registration helper — no assertion or business logic was changed, and all 12 original `dao.rs` tests pass unmodified. Added three new end-to-end tests that drive a full `UpdateConfig` proposal (verifying `ProtocolConfig` actually changes after execution) and a `TreasuryWithdrawal` proposal (verifying tokens actually move) through the real contract entry points, plus a test proving the legacy paths are gated once DAO mode is enabled.

---

## CI / Verification

Only the `contracts` CI job can be affected by this PR (no other package references anything touched here). Ran locally from `contracts/`, matching the CI job exactly:

```
cargo fmt --all -- --check
cargo clippy --workspace --lib --target wasm32v1-none -- -D warnings
cargo check --workspace --target wasm32v1-none
```

All three pass clean on every file this PR touches.

**Note on `cargo test`:** the full workspace `cargo test` currently does not compile on `main` — there are ~28 pre-existing, unrelated compile errors scattered across other modules (`access_control.rs`, `audit.rs`, `compliance.rs`, `lockup.rs`, `milestone_extension.rs`, `referral.rs`, `split_payment.rs`, a fuzz target), all stemming from the same `soroban-sdk` version drift and a couple of unrelated logic bugs. None of that is touched by this PR, and CI itself never runs `cargo test` for the `contracts` job. To verify this PR's own changes, `cargo test --lib -p stellar-grants` for the specific modules touched here (`dao`, `treasury`, `token_swap`) shows:

```
test result: ok. 15 passed; 0 failed   (dao::tests, incl. all 12 original + 3 new)
test result: ok. 6 passed; 0 failed    (treasury::tests)
test result: ok. 9 passed; 0 failed    (token_swap::tests, incl. all 4 original + 5 new)
```

## Notes for Reviewer

- `swap_and_pay`'s signature change (new leading `payer` parameter) is breaking but necessary — happy to adjust the parameter name/position if you'd prefer a different convention.
- The two design decisions above (treasury mechanism, treasury entry-point gating) are exactly the open questions #681 asked to be documented — flagging both explicitly for discussion in case you'd prefer a different call.
- The pre-existing `cargo test` breakage described above is unrelated to this PR and not fixed here, per scope — happy to open a separate tracked issue for it if useful.

---

Closes #874
Closes #871
Closes #875
Closes #876
