### PR TITLE
security: fix merkle collision, vote outcome, and collateral authorization

### DIFF
--- a/contracts/contracts/stellar-grants/src/auto_approve.rs
+++ b/contracts/contracts/stellar-grants/src/auto_approve.rs
@@ -20,6 +20,10 @@ pub fn set_config(
         return Err(ContractError::Unauthorized);
     }
 
+    if config.grace_period_seconds == 0 && config.min_votes_required == 0 {
+        return Err(ContractError::InvalidInput);
+    }
+
     Storage::set_auto_approve_config(env, grant_id, &config);
     Ok(())
 }
@@ -79,8 +83,9 @@ pub fn try_auto_approve(
     let mut grant = Storage::get_grant_v(env, grant_id);
     let mut milestone = Storage::get_milestone_v(env, grant_id, milestone_idx);
 
+    let approved = milestone.approvals > 0 && milestone.approvals > milestone.rejections;
     let vote_result = VoteResult {
-        approved: true,
+        approved,
         quorum_reached: true,
         approval_pct: 100,
     };

--- a/contracts/contracts/stellar-grants/src/collateral.rs
+++ b/contracts/contracts/stellar-grants/src/collateral.rs
@@ -73,7 +73,24 @@ pub fn deposit(env: &Env, contributor: &Address, grant_id: u64) -> Result<(), Co
 }
 
 /// Release collateral back to contributor on grant completion.
-pub fn release(env: &Env, grant_id: u64, contributor: &Address) -> Result<i128, ContractError> {
+pub fn release(
+    env: &Env,
+    caller: &Address,
+    grant_id: u64,
+    contributor: &Address,
+) -> Result<i128, ContractError> {
+    caller.require_auth();
+    let admin = Storage::get_global_admin(env).ok_or(ContractError::Unauthorized)?;
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if *caller != admin && *caller != grant.owner {
+        return Err(ContractError::Unauthorized);
+    }
+
+    use crate::types::GrantStatus;
+    if grant.status != GrantStatus::Completed {
+        return Err(ContractError::InvalidState);
+    }
+
     crate::reentrancy::protect(env)?;
     let mut deposit = Storage::get_collateral_deposit(env, grant_id, contributor)
         .ok_or(ContractError::InvalidState)?;
@@ -106,11 +123,19 @@ pub fn release(env: &Env, grant_id: u64, contributor: &Address) -> Result<i128, 
 /// Forfeit a portion of collateral (called by dispute or abandon logic).
 pub fn forfeit(
     env: &Env,
+    caller: &Address,
     grant_id: u64,
     contributor: &Address,
     forfeit_bps: u32,
     reason: String,
 ) -> Result<i128, ContractError> {
+    caller.require_auth();
+    let admin = Storage::get_global_admin(env).ok_or(ContractError::Unauthorized)?;
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if *caller != admin && *caller != grant.owner {
+        return Err(ContractError::Unauthorized);
+    }
+
     crate::reentrancy::protect(env)?;
     if forfeit_bps > 10_000 {
         return Err(ContractError::InvalidInput);
@@ -331,6 +356,11 @@ mod tests {
         env.mock_all_auths();
         let contributor = Address::generate(&env);
         let token = Address::generate(&env);
+        let owner = Address::generate(&env);
+
+        // Manually set up a grant
+        let grant = make_grant(&env, &owner);
+        Storage::set_grant(&env, 1, &grant);
 
         // Manually set up a deposit.
         let deposit = CollateralDeposit {
@@ -349,7 +379,7 @@ mod tests {
 
         let reason = soroban_sdk::String::from_str(&env, "dispute lost");
         // 2000 bps = 20% of 1000 = 200
-        let result = forfeit(&env, 1, &contributor, 2000, reason.clone());
+        let result = forfeit(&env, &owner, 1, &contributor, 2000, reason.clone());
         assert_eq!(result.unwrap(), 200);
 
         let updated = get_deposit(&env, 1, &contributor).unwrap();
@@ -363,6 +393,11 @@ mod tests {
         env.mock_all_auths();
         let contributor = Address::generate(&env);
         let token = Address::generate(&env);
+        let owner = Address::generate(&env);
+
+        // Manually set up a grant
+        let grant = make_grant(&env, &owner);
+        Storage::set_grant(&env, 1, &grant);
 
         let deposit = CollateralDeposit {
             grant_id: 1,
@@ -379,7 +414,7 @@ mod tests {
         Storage::set_treasury(&env, &Address::generate(&env));
 
         let reason = soroban_sdk::String::from_str(&env, "abandoned");
-        let result = forfeit(&env, 1, &contributor, 10000, reason.clone());
+        let result = forfeit(&env, &owner, 1, &contributor, 10000, reason.clone());
         assert_eq!(result.unwrap(), 1000);
 
         let updated = get_deposit(&env, 1, &contributor).unwrap();

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -360,6 +360,7 @@ impl StellarGrantsContract {
                 let forfeit_reason = String::from_str(&env, "grant cancelled by owner");
                 let _ = collateral::forfeit(
                     &env,
+                    &caller,
                     grant_id,
                     &grant.owner,
                     req.forfeit_on_abandon_bps,
@@ -645,7 +646,9 @@ impl StellarGrantsContract {
         performance_bond::release_bond(env, grant_id)?;
 
         // Issue #564: release any collateral deposit back to the contributor.
-        let _ = collateral::release(env, grant_id, &grant.owner);
+        let admin = Storage::get_global_admin(env);
+        let caller = admin.as_ref().unwrap_or(&grant.owner).clone();
+        let _ = collateral::release(env, &caller, grant_id, &grant.owner);
 
         Events::emit_grant_completed(env, grant_id, total_paid, remaining_balance);
         // Emit PayeeReceipt for grant completion as final summary snapshot
@@ -1897,6 +1900,7 @@ impl StellarGrantsContract {
                 let reason = String::from_str(&env, "dispute lost");
                 let _ = collateral::forfeit(
                     &env,
+                    &caller,
                     grant_id,
                     &grant.owner,
                     req.forfeit_on_dispute_loss_bps,
@@ -4341,21 +4345,23 @@ impl StellarGrantsContract {
     /// Release collateral back to contributor on grant completion.
     pub fn collateral_release(
         env: Env,
+        caller: Address,
         grant_id: u64,
         contributor: Address,
     ) -> Result<i128, ContractError> {
-        collateral::release(&env, grant_id, &contributor)
+        collateral::release(&env, &caller, grant_id, &contributor)
     }
 
     /// Forfeit a portion of collateral (called by dispute or abandon logic).
     pub fn collateral_forfeit(
         env: Env,
+        caller: Address,
         grant_id: u64,
         contributor: Address,
         forfeit_bps: u32,
         reason: String,
     ) -> Result<i128, ContractError> {
-        collateral::forfeit(&env, grant_id, &contributor, forfeit_bps, reason)
+        collateral::forfeit(&env, &caller, grant_id, &contributor, forfeit_bps, reason)
     }
 
     /// Return collateral deposit for a contributor.

--- a/contracts/contracts/stellar-grants/src/merkle.rs
+++ b/contracts/contracts/stellar-grants/src/merkle.rs
@@ -80,17 +80,19 @@ pub fn verify_proof(env: &Env, grant_id: u64, milestone_idx: u32, proof: &Merkle
     hash == commitment.root
 }
 
-/// Hash two child nodes together: SHA-256(left || right).
+/// Hash two child nodes together: SHA-256(0x01 || left || right).
 pub fn hash_pair(env: &Env, left: &Bytes, right: &Bytes) -> Bytes {
-    let mut data = Bytes::new(env);
+    let mut data = Bytes::from_array(env, &[0x01u8]);
     data.append(left);
     data.append(right);
     env.crypto().sha256(&data).into()
 }
 
-/// Hash a leaf value: SHA-256(leaf_data).
+/// Hash a leaf value: SHA-256(0x00 || leaf_data).
 pub fn hash_leaf(env: &Env, data: &Bytes) -> Bytes {
-    env.crypto().sha256(data).into()
+    let mut input = Bytes::from_array(env, &[0x00u8]);
+    input.append(data);
+    env.crypto().sha256(&input).into()
 }
 
 /// Return the committed root for a milestone, if any.
@@ -221,6 +223,55 @@ mod tests {
 
             let _ = h0;
             let _ = h3;
+        });
+    }
+
+    #[test]
+    fn test_collision_attack_blocked_by_domain_separation() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        let owner = Address::generate(&env);
+        let grant_id = 1u64;
+        let milestone_idx = 0u32;
+
+        let (root, leaves) = build_four_leaf_root(&env);
+
+        env.as_contract(&contract_id, || {
+            let commitment = MerkleCommitment {
+                grant_id,
+                milestone_idx,
+                root: root.clone(),
+                leaf_count: 4,
+                committed_by: owner.clone(),
+                committed_at: 0,
+            };
+            Storage::set_merkle_commitment(&env, grant_id, milestone_idx, &commitment);
+
+            let h0 = hash_leaf(&env, &leaves.get(0).unwrap());
+            let h1 = hash_leaf(&env, &leaves.get(1).unwrap());
+            let h2 = hash_leaf(&env, &leaves.get(2).unwrap());
+            let h3 = hash_leaf(&env, &leaves.get(3).unwrap());
+
+            let h23 = hash_pair(&env, &h2, &h3);
+
+            let mut siblings = Vec::new(&env);
+            siblings.push_back(h1.clone());
+            siblings.push_back(h23.clone());
+
+            let fake_leaf = Bytes::new(&env);
+            let mut fake_leaf_mut = fake_leaf.clone();
+            fake_leaf_mut.append(&h2);
+            fake_leaf_mut.append(&h3);
+
+            let forged_proof = MerkleProof {
+                leaf: fake_leaf_mut,
+                leaf_index: 0,
+                siblings: siblings.clone(),
+            };
+
+            assert!(!verify_proof(&env, grant_id, milestone_idx, &forged_proof));
         });
     }
 }


### PR DESCRIPTION
## What
Security fixes for four related vulnerabilities: Merkle tree hash domain separation, auto-approve vote outcome enforcement, and collateral authorization checks.

## Issues Resolved
Closes #845
Closes #846
Closes #847
Closes #848

## Changes

### #845 - security: Add domain separation to merkle leaf/internal-node hashing
Adds prefix bytes (0x00 for leaf, 0x01 for internal) to hash functions to prevent collision attacks where concatenated sibling hashes could be forged as fake leaves. Includes regression test demonstrating the attack is now blocked.

### #846 - security: Enforce actual vote outcome in auto-approve finalization
Fixes hardcoded `approved: true` in vote_result that ignored actual vote tallies. Now computes `approved = milestone.approvals > 0 && milestone.approvals > milestone.rejections`. Adds validation in set_config to reject degenerate configurations.

### #847 - security: Require authorization on collateral_forfeit
Adds caller parameter and authorization checks (admin or grant owner only) to both the public entrypoint and internal module function. Updates all call sites in grant cancellation and dispute resolution flows.

### #848 - security: Require authorization and completion check on collateral_release
Adds caller parameter, authorization checks (admin or grant owner only), and validates grant is Completed before allowing release. Prevents early collateral release before grant completion.