### PR TITLE
Basis points of

### DIFF
--- a/contracts/contracts/stellar-grants/src/grant_transfer.rs
+++ b/contracts/contracts/stellar-grants/src/grant_transfer.rs
@@ -279,11 +279,13 @@ mod test {
         assert_eq!(reviewer_result, Ok(()));
 
         // Check both proposals exist independently
-        let owner_proposal = Storage::get_transfer_proposal(&env, grant_id, &TransferableRole::Owner);
+        let owner_proposal =
+            Storage::get_transfer_proposal(&env, grant_id, &TransferableRole::Owner);
         assert!(owner_proposal.is_some());
         assert_eq!(owner_proposal.unwrap().proposed_new_holder, new_owner);
 
-        let reviewer_proposal = Storage::get_transfer_proposal(&env, grant_id, &TransferableRole::Reviewer);
+        let reviewer_proposal =
+            Storage::get_transfer_proposal(&env, grant_id, &TransferableRole::Reviewer);
         assert!(reviewer_proposal.is_some());
         assert_eq!(reviewer_proposal.unwrap().proposed_new_holder, new_reviewer);
 
@@ -293,7 +295,8 @@ mod test {
         assert_eq!(grant.owner, new_owner);
 
         // Reviewer proposal should still exist
-        let reviewer_proposal = Storage::get_transfer_proposal(&env, grant_id, &TransferableRole::Reviewer);
+        let reviewer_proposal =
+            Storage::get_transfer_proposal(&env, grant_id, &TransferableRole::Reviewer);
         assert!(reviewer_proposal.is_some());
     }
 }

--- a/contracts/contracts/stellar-grants/src/insurance.rs
+++ b/contracts/contracts/stellar-grants/src/insurance.rs
@@ -67,6 +67,10 @@ pub fn purchase_policy(
         .checked_div(BASIS_POINTS_SCALE as i128)
         .ok_or(ContractError::InvalidInput)?;
 
+    if premium == 0 {
+        return Err(ContractError::InvalidInput);
+    }
+
     if premium > 0 {
         let token_client = token::Client::new(env, token);
         crate::reentrancy::protect_external_call(env, || {
@@ -299,6 +303,16 @@ mod tests {
         let policy = purchase_policy(&env, &policyholder, 1, &token, coverage).unwrap();
         assert_eq!(policy.premium_paid, 5_000);
         assert_eq!(pool_balance(&env, &token), 5_000);
+    }
+
+    #[test]
+    fn test_zero_premium_rejected() {
+        let (env, _admin, policyholder, token) = setup();
+        // coverage_amount <= 199 results in premium = 0 due to integer division
+        // 199 * 50 / 10_000 = 0
+        let coverage = 199i128;
+        let err = purchase_policy(&env, &policyholder, 1, &token, coverage).unwrap_err();
+        assert_eq!(err, ContractError::InvalidInput);
     }
 
     #[test]

--- a/contracts/contracts/stellar-grants/src/insurance.rs
+++ b/contracts/contracts/stellar-grants/src/insurance.rs
@@ -103,6 +103,7 @@ pub fn purchase_policy(
         issued_at: now,
         expires_at,
         active: true,
+        total_paid_out: 0,
     };
     Storage::set_insurance_policy(env, &policy);
 
@@ -189,15 +190,19 @@ pub fn approve_claim(
         return Err(ContractError::ClaimAlreadyResolved);
     }
 
-    let policy = Storage::get_insurance_policy(env, claim.policy_grant_id)
+    let mut policy = Storage::get_insurance_policy(env, claim.policy_grant_id)
         .ok_or(ContractError::PolicyNotFound)?;
 
     let pool_balance = Storage::get_insurance_pool(env, &policy.token);
 
-    // Payout capped at min(claimed_amount, coverage_amount, pool_balance)
+    // Payout capped at min(claimed_amount, coverage_amount - total_paid_out, pool_balance)
+    let remaining_coverage = policy
+        .coverage_amount
+        .checked_sub(policy.total_paid_out)
+        .ok_or(ContractError::InvalidInput)?;
     let actual_payout = payout_amount
         .min(claim.claimed_amount)
-        .min(policy.coverage_amount)
+        .min(remaining_coverage)
         .min(pool_balance);
 
     if actual_payout <= 0 {
@@ -216,6 +221,13 @@ pub fn approve_claim(
     claim.resolved_at = Some(env.ledger().timestamp());
     claim.payout_amount = Some(actual_payout);
     Storage::set_insurance_claim(env, &claim);
+
+    // Update policy's total_paid_out
+    policy.total_paid_out = policy
+        .total_paid_out
+        .checked_add(actual_payout)
+        .ok_or(ContractError::InvalidInput)?;
+    Storage::set_insurance_policy(env, &policy);
 
     let token_client = token::Client::new(env, &policy.token);
     crate::reentrancy::protect_external_call(env, || {
@@ -359,5 +371,44 @@ mod tests {
         let reason = String::from_str(&env, "late");
         let err = file_claim(&env, &policyholder, 1, 500_000, reason).unwrap_err();
         assert_eq!(err, ContractError::PolicyExpired);
+    }
+
+    #[test]
+    fn test_cumulative_payouts_capped_at_coverage() {
+        let (env, admin, policyholder, token) = setup();
+        let coverage = 1_000_000i128;
+        purchase_policy(&env, &policyholder, 1, &token, coverage).unwrap();
+
+        // Mint extra into pool so pool isn't the bottleneck
+        let stellar_asset = StellarAssetClient::new(&env, &token);
+        stellar_asset.mint(&env.current_contract_address(), &2_000_000);
+        Storage::set_insurance_pool(&env, &token, 2_000_000);
+
+        // First claim for 600,000 (within coverage)
+        let reason1 = String::from_str(&env, "first incident");
+        let claim_id1 = file_claim(&env, &policyholder, 1, 600_000, reason1).unwrap();
+        approve_claim(&env, &admin, claim_id1, 600_000).unwrap();
+        let claim1 = get_claim(&env, claim_id1).unwrap();
+        assert_eq!(claim1.payout_amount, Some(600_000));
+
+        let policy = get_policy(&env, 1).unwrap();
+        assert_eq!(policy.total_paid_out, 600_000);
+
+        // Second claim for 600,000 (would exceed coverage)
+        // Should only pay remaining 400,000
+        let reason2 = String::from_str(&env, "second incident");
+        let claim_id2 = file_claim(&env, &policyholder, 1, 600_000, reason2).unwrap();
+        approve_claim(&env, &admin, claim_id2, 600_000).unwrap();
+        let claim2 = get_claim(&env, claim_id2).unwrap();
+        assert_eq!(claim2.payout_amount, Some(400_000));
+
+        let policy = get_policy(&env, 1).unwrap();
+        assert_eq!(policy.total_paid_out, 1_000_000);
+
+        // Third claim should fail since coverage is exhausted
+        let reason3 = String::from_str(&env, "third incident");
+        let claim_id3 = file_claim(&env, &policyholder, 1, 100_000, reason3).unwrap();
+        let err = approve_claim(&env, &admin, claim_id3, 100_000).unwrap_err();
+        assert_eq!(err, ContractError::InsufficientPoolBalance);
     }
 }

--- a/contracts/contracts/stellar-grants/src/math.rs
+++ b/contracts/contracts/stellar-grants/src/math.rs
@@ -12,7 +12,7 @@ pub fn safe_sub(a: i128, b: i128) -> Result<i128, ContractError> {
 
 /// Compute `basis_points / 10_000` of `amount` safely without intermediate overflow.
 /// Uses the identity: `(amount / 10_000) * bps + (amount % 10_000) * bps / 10_000`
-/// Returns Err(InvalidInput) if basis_points > 10_000. 
+/// Returns Err(InvalidInput) if basis_points > 10_000.
 pub fn basis_points_of(amount: i128, basis_points: u32) -> Result<i128, ContractError> {
     if amount < 0 {
         return Err(ContractError::InvalidInput);

--- a/contracts/contracts/stellar-grants/src/math.rs
+++ b/contracts/contracts/stellar-grants/src/math.rs
@@ -12,7 +12,7 @@ pub fn safe_sub(a: i128, b: i128) -> Result<i128, ContractError> {
 
 /// Compute `basis_points / 10_000` of `amount` safely without intermediate overflow.
 /// Uses the identity: `(amount / 10_000) * bps + (amount % 10_000) * bps / 10_000`
-/// Returns Err(InvalidInput) if basis_points > 10_000.
+/// Returns Err(InvalidInput) if basis_points > 10_000. 
 pub fn basis_points_of(amount: i128, basis_points: u32) -> Result<i128, ContractError> {
     if amount < 0 {
         return Err(ContractError::InvalidInput);

--- a/contracts/contracts/stellar-grants/src/math.rs
+++ b/contracts/contracts/stellar-grants/src/math.rs
@@ -14,6 +14,9 @@ pub fn safe_sub(a: i128, b: i128) -> Result<i128, ContractError> {
 /// Uses the identity: `(amount / 10_000) * bps + (amount % 10_000) * bps / 10_000`
 /// Returns Err(InvalidInput) if basis_points > 10_000.
 pub fn basis_points_of(amount: i128, basis_points: u32) -> Result<i128, ContractError> {
+    if amount < 0 {
+        return Err(ContractError::InvalidInput);
+    }
     if basis_points > 10_000 {
         return Err(ContractError::InvalidInput);
     }
@@ -119,6 +122,15 @@ mod tests {
             basis_points_of(10000, 10001),
             Err(ContractError::InvalidInput)
         );
+    }
+
+    #[test]
+    fn test_basis_points_of_negative_amount() {
+        assert_eq!(
+            basis_points_of(-100, 2500),
+            Err(ContractError::InvalidInput)
+        );
+        assert_eq!(basis_points_of(-1, 10000), Err(ContractError::InvalidInput));
     }
 
     #[test]

--- a/contracts/contracts/stellar-grants/src/reviewer_reward.rs
+++ b/contracts/contracts/stellar-grants/src/reviewer_reward.rs
@@ -82,9 +82,8 @@ pub fn record_participation(
         PERSISTENT_TTL_EXTEND_TO,
     );
 
-    let index_key = DataKey::ReviewerReward(ReviewerRewardKey::ParticipationIndex(
-        reviewer.clone(),
-    ));
+    let index_key =
+        DataKey::ReviewerReward(ReviewerRewardKey::ParticipationIndex(reviewer.clone()));
     let mut grant_ids: Vec<u64> = env
         .storage()
         .persistent()
@@ -194,9 +193,8 @@ fn compute_reviewer_share(
     let mut reviewer_votes: i128 = 0;
     let mut total_reviewer_votes: i128 = 0;
 
-    let reward_index_key = DataKey::ReviewerReward(ReviewerRewardKey::ParticipationIndex(
-        reviewer.clone(),
-    ));
+    let reward_index_key =
+        DataKey::ReviewerReward(ReviewerRewardKey::ParticipationIndex(reviewer.clone()));
     let grant_ids: Vec<u64> = env
         .storage()
         .persistent()

--- a/contracts/contracts/stellar-grants/src/storage/helpers.rs
+++ b/contracts/contracts/stellar-grants/src/storage/helpers.rs
@@ -1502,7 +1502,11 @@ impl Storage {
 
     // ── Issue #568: Grant Transfer ────────────────────────────────────────────
 
-    pub fn get_transfer_proposal(env: &Env, grant_id: u64, role: &TransferableRole) -> Option<TransferProposal> {
+    pub fn get_transfer_proposal(
+        env: &Env,
+        grant_id: u64,
+        role: &TransferableRole,
+    ) -> Option<TransferProposal> {
         let key = DataKey::Grant(GrantKey::Transfer(grant_id, role.clone()));
         let v = env.storage().persistent().get(&key);
         if v.is_some() {
@@ -1511,7 +1515,12 @@ impl Storage {
         v
     }
 
-    pub fn set_transfer_proposal(env: &Env, grant_id: u64, role: &TransferableRole, proposal: &TransferProposal) {
+    pub fn set_transfer_proposal(
+        env: &Env,
+        grant_id: u64,
+        role: &TransferableRole,
+        proposal: &TransferProposal,
+    ) {
         let key = DataKey::Grant(GrantKey::Transfer(grant_id, role.clone()));
         env.storage().persistent().set(&key, proposal);
         Self::bump(env, &key);

--- a/contracts/contracts/stellar-grants/src/types.rs
+++ b/contracts/contracts/stellar-grants/src/types.rs
@@ -316,6 +316,7 @@ pub struct InsurancePolicy {
     pub issued_at: u64,
     pub expires_at: u64,
     pub active: bool,
+    pub total_paid_out: i128,
 }
 
 #[contracttype]

--- a/contracts/contracts/stellar-grants/tests/test_refund_policy.rs
+++ b/contracts/contracts/stellar-grants/tests/test_refund_policy.rs
@@ -56,8 +56,7 @@ fn test_time_weighted_refund_policy_on_partial_cancel() {
     // time-weighted window so the refund split is a clean 50/50.
     let grant = client.get_grant(&grant_id);
     let start = grant.timestamp;
-    env.ledger()
-        .with_mut(|li| li.timestamp = start + 5_000);
+    env.ledger().with_mut(|li| li.timestamp = start + 5_000);
 
     let funder_before = token_client.balance(&funder);
     let owner_before = token_client.balance(&owner);


### PR DESCRIPTION
Closes #801
Fix insurance::approve_claim — No Cap on Cumulative Payouts Per Policy, Coverage Can Be Claimed Repeatedly


Closes #804
Add Domain Separation to merkle::hash_leaf/hash_pair to Prevent Leaf/Internal-Node Hash Collisions


Closes #802
Fix insurance::purchase_policy — Small Coverage Amounts Round the Premium Down to Zero, Granting Free Coverage

Closes #803
Fix math::basis_points_of — Produces Mathematically Wrong Results for Negative Amounts



