### PR TITLE
chore: run cargo test in CI, add root Makefile, and fix broken fuzz targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Check (WASM)
         run: cargo check --workspace --target wasm32v1-none
 
+      - name: Test
+        run: cargo test --workspace
+
   api:
     name: API (Node.js)
     runs-on: ubuntu-latest

--- a/stellargrant-contracts/Makefile
+++ b/stellargrant-contracts/Makefile
@@ -1,0 +1,22 @@
+# Convenience targets matching the commands documented in ContributionGuide.md
+# and README.md. Each target delegates to the stellar-grants crate's own
+# Makefile so the build logic lives in one place.
+
+CRATE_DIR := contracts/stellar-grants
+
+.PHONY: build test lint fmt deploy-testnet
+
+build:
+	$(MAKE) -C $(CRATE_DIR) build
+
+test:
+	$(MAKE) -C $(CRATE_DIR) test
+
+lint:
+	$(MAKE) -C $(CRATE_DIR) lint
+
+fmt:
+	$(MAKE) -C $(CRATE_DIR) fmt
+
+deploy-testnet:
+	$(MAKE) -C $(CRATE_DIR) deploy-testnet

--- a/stellargrant-contracts/contracts/stellar-grants/Makefile
+++ b/stellargrant-contracts/contracts/stellar-grants/Makefile
@@ -12,5 +12,24 @@ build:
 fmt:
 	cargo fmt --all
 
+lint:
+	cargo clippy --lib --target wasm32v1-none -- -D warnings
+
+# Deploys the release WASM built by `make build` to Stellar testnet.
+# Requires a funded testnet identity configured locally first, e.g.:
+#   stellar keys generate testnet-deployer --network testnet --fund
+# Override the account alias with: make deploy-testnet SOURCE_ACCOUNT=your-alias
+SOURCE_ACCOUNT ?= testnet-deployer
+
+deploy-testnet: build
+	@echo "Deploying to testnet using source account alias '$(SOURCE_ACCOUNT)'."
+	@echo "If this account isn't configured yet, run:"
+	@echo "  stellar keys generate $(SOURCE_ACCOUNT) --network testnet --fund"
+	stellar contract deploy \
+		--wasm target/wasm32v1-none/release/stellar_grants.wasm \
+		--network testnet \
+		--source-account $(SOURCE_ACCOUNT) \
+		--alias stellar_grants
+
 clean:
 	cargo clean

--- a/stellargrant-contracts/fuzz/Cargo.lock
+++ b/stellargrant-contracts/fuzz/Cargo.lock
@@ -25,9 +25,12 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.4.2"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ark-bls12-381"
@@ -311,6 +314,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +490,21 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dyn-clone"
@@ -1254,10 +1299,12 @@ version = "25.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfc49a80a68fc1005847308e63b9fce39874de731940b1807b721d472de3ff01"
 dependencies = [
+ "arbitrary",
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-traits",
+ "serde",
  "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
@@ -1328,19 +1375,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-ledger-snapshot"
+version = "25.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ca06e6c5029d1285e66219cb387a234224e26969ce8ad2bc2d5017e9395d63b"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "soroban-env-common",
+ "soroban-env-host",
+ "thiserror",
+]
+
+[[package]]
 name = "soroban-sdk"
 version = "25.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fb27e93f8d3fc3a815d24c60ec11e893c408a36693ec9c823322f954fa096ae"
 dependencies = [
+ "arbitrary",
  "bytes-lit",
  "crate-git-revision",
+ "ctor",
+ "derive_arbitrary",
+ "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
  "serde_json",
  "soroban-env-guest",
  "soroban-env-host",
+ "soroban-ledger-snapshot",
  "soroban-sdk-macros",
  "stellar-strkey 0.0.16",
  "visibility",
@@ -1479,6 +1545,7 @@ version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d20dafed80076b227d4b17c0c508a4bbc4d5e4c3d4c1de7cd42242df4b1eaf"
 dependencies = [
+ "arbitrary",
  "base64",
  "cfg_eval",
  "crate-git-revision",

--- a/stellargrant-contracts/fuzz/Cargo.toml
+++ b/stellargrant-contracts/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ path = "../contracts/stellar-grants"
 
 [dependencies.soroban-sdk]
 version = "25"
+features = ["testutils"]
 
 [[bin]]
 name = "fuzz_target_1"

--- a/stellargrant-contracts/fuzz/fuzz_targets/grant_lifecycle.rs
+++ b/stellargrant-contracts/fuzz/fuzz_targets/grant_lifecycle.rs
@@ -1,8 +1,9 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use stellar_grants::StellarGrantsContract;
-use soroban_sdk::{Env, Address, String, Vec};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, String, Vec};
+use stellar_grants::{StellarGrantsContract, StellarGrantsContractClient};
 
 // Fuzz target for grant_create and grant_fund lifecycle
 fuzz_target!(|data: &[u8]| {
@@ -12,46 +13,46 @@ fuzz_target!(|data: &[u8]| {
     }
     let result = std::panic::catch_unwind(|| {
         let env = Env::default();
-        let owner = Address::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+        env.mock_all_auths();
+        let contract_id = env.register(StellarGrantsContract, ());
+        let client = StellarGrantsContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
         let title = String::from_str(&env, "Fuzz Grant");
         let description = String::from_str(&env, "Fuzzing");
-        let token = Address::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHG");
-        let total_amount = i128::from_le_bytes([data.get(0).copied().unwrap_or(1); 16]);
+        let token = Address::generate(&env);
+        let total_amount = i128::from_le_bytes([data.first().copied().unwrap_or(1); 16]);
         let milestone_amount = i128::from_le_bytes([data.get(1).copied().unwrap_or(1); 16]);
         let num_milestones = (data.get(2).copied().unwrap_or(1) % 10) as u32 + 1;
         let reviewers: Vec<Address> = Vec::new(&env);
-        let quorum = 1;
-        let milestone_deadlines = None;
 
-        let _ = StellarGrantsContract::grant_create(
-            env.clone(),
-            owner.clone(),
-            title,
-            description,
-            token,
-            total_amount,
-            milestone_amount,
-            num_milestones,
-            reviewers,
-            quorum,
-            milestone_deadlines,
-            0i128,
-            0i128,
-            Vec::new(&env),
-            false,
-        );
+        let grant_id = match client.try_grant_create(
+            &owner,
+            &title,
+            &description,
+            &token,
+            &total_amount,
+            &milestone_amount,
+            &num_milestones,
+            &reviewers,
+        ) {
+            Ok(Ok(id)) => id,
+            _ => return,
+        };
 
-        let funder = Address::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHH");
+        let funder = Address::generate(&env);
         let fund_amount = i128::from_le_bytes([data.get(3).copied().unwrap_or(1); 16]);
-        let _ = StellarGrantsContract::grant_fund(env.clone(), 0, funder, fund_amount);
+        let _ = client.try_grant_fund(&grant_id, &funder, &fund_amount);
 
         // Invariant check: escrowed funds == sum of unapproved milestone amounts
-        if let Some(grant) = stellar_grants::Storage::get_grant(&env, 0) {
+        if let Ok(Ok(grant)) = client.try_get_grant(&grant_id) {
             let mut sum_unapproved: i128 = 0;
             for idx in 0..grant.total_milestones {
-                if let Some(milestone) = stellar_grants::Storage::get_milestone(&env, 0, idx) {
+                if let Ok(Ok(milestone)) = client.try_get_milestone(&grant_id, &idx) {
                     use stellar_grants::MilestoneState;
-                    if milestone.state != MilestoneState::Approved && milestone.state != MilestoneState::Paid {
+                    if milestone.state != MilestoneState::Approved
+                        && milestone.state != MilestoneState::Paid
+                    {
                         sum_unapproved = sum_unapproved.saturating_add(milestone.amount);
                     }
                 }
@@ -60,9 +61,11 @@ fuzz_target!(|data: &[u8]| {
             if grant.total_milestones > 0 && grant.status == stellar_grants::GrantStatus::Active {
                 assert!(grant.escrow_balance >= 0, "Escrow balance negative");
                 assert!(sum_unapproved >= 0, "Sum of unapproved milestones negative");
-                // Allow for fuzzing to hit edge cases, but don't panic on known invalid input
                 if grant.escrow_balance != sum_unapproved {
-                    // Optionally log or count this, but don't panic for now
+                    panic!(
+                        "escrow_balance {} != sum_unapproved {} for grant {}",
+                        grant.escrow_balance, sum_unapproved, grant.id
+                    );
                 }
             }
         }

--- a/stellargrant-contracts/fuzz/fuzz_targets/milestone_submit.rs
+++ b/stellargrant-contracts/fuzz/fuzz_targets/milestone_submit.rs
@@ -1,48 +1,74 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use stellar_grants::StellarGrantsContract;
-use soroban_sdk::{Env, Address, String, Vec};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, String, Vec};
+use stellar_grants::{StellarGrantsContract, StellarGrantsContractClient};
 
-// Fuzz target for milestone_submit
+// Fuzz target for milestone_submit. Every field below is derived from the
+// fuzzer-supplied bytes so libFuzzer's coverage-guided mutation can actually
+// steer program behavior (grant size, target index, and submitted text all vary).
 fuzz_target!(|data: &[u8]| {
-    // Skip if input is empty
-    if data.is_empty() {
+    // Need enough bytes to derive milestone count, grant id, index, and text from.
+    if data.len() < 4 {
         return;
     }
     let result = std::panic::catch_unwind(|| {
         let env = Env::default();
-        let owner = Address::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+        env.mock_all_auths();
+        let contract_id = env.register(StellarGrantsContract, ());
+        let client = StellarGrantsContractClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
         let title = String::from_str(&env, "Fuzz Grant");
         let description = String::from_str(&env, "Fuzzing");
-        let token = Address::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHG");
+        let token = Address::generate(&env);
         let reviewers: Vec<Address> = Vec::new(&env);
-        let quorum = 1;
-        let _ = StellarGrantsContract::grant_create(
-            env.clone(),
-            owner.clone(),
-            title,
-            description,
-            token,
-            100,
-            10,
-            2,
-            reviewers,
-            quorum,
-            None,
-            0i128,
-            0i128,
-            Vec::new(&env),
-            false,
-        );
-        // Fuzz milestone_submit with random description and proof_url
-        let recipient = owner;
-        let desc = String::from_str(&env, "desc");
-        let proof = String::from_str(&env, "proof");
-        let _ = StellarGrantsContract::milestone_submit(env, 0, 0, recipient, desc, proof, None);
+
+        let num_milestones = (data[0] % 8) as u32 + 1;
+        let grant_id = match client.try_grant_create(
+            &owner,
+            &title,
+            &description,
+            &token,
+            &100,
+            &10,
+            &num_milestones,
+            &reviewers,
+        ) {
+            Ok(Ok(id)) => id,
+            _ => return,
+        };
+
+        // Occasionally target a nonexistent grant to exercise the GrantNotFound path.
+        let target_grant_id = if data[1].is_multiple_of(4) {
+            grant_id.wrapping_add(1 + data[1] as u64)
+        } else {
+            grant_id
+        };
+
+        // Occasionally target an out-of-range milestone index to exercise the
+        // MilestoneIndexOutOfBounds path.
+        let milestone_idx = (data[2] as u32) % (num_milestones + 2);
+
+        // Split the remaining bytes between the description and proof_url so both
+        // vary independently in content and length with the fuzzer input.
+        let rest = &data[3..];
+        let split = rest.len() / 2;
+        let (desc_bytes, proof_bytes) = rest.split_at(split);
+        let desc = String::from_str(&env, &bytes_to_text(desc_bytes));
+        let proof = String::from_str(&env, &bytes_to_text(proof_bytes));
+
+        let _ =
+            client.try_milestone_submit(&target_grant_id, &milestone_idx, &owner, &desc, &proof);
     });
-    // If a panic occurred, treat as a fuzz failure only if input was not obviously invalid
-    if result.is_err() && !data.is_empty() {
+    if result.is_err() {
         panic!("Fuzz target panicked on non-empty input");
     }
 });
+
+/// Converts arbitrary fuzzer bytes into a bounded, valid UTF-8 string.
+fn bytes_to_text(bytes: &[u8]) -> std::string::String {
+    let bounded = &bytes[..bytes.len().min(256)];
+    std::string::String::from_utf8_lossy(bounded).into_owned()
+}


### PR DESCRIPTION
## Summary

Closes #983
Closes #982
Closes #981
Closes #980

- **#983** — `.github/workflows/ci.yml`'s `contracts` job never ran `cargo test`, so hundreds of unit/integration tests were never executed by CI. Added a `Test` step (`cargo test --workspace`) after the existing WASM check step.
- **#982** — `ContributionGuide.md`/`README.md` document `make build`/`make test`/`make lint`/`make fmt`/`make deploy-testnet` from the contracts root, but no root Makefile existed and the crate-level Makefile was missing `lint`/`deploy-testnet`. Added `contracts/Makefile` delegating into the crate directory, and filled in the missing targets on the crate's own Makefile.
- **#981** — `fuzz/fuzz_targets/grant_lifecycle.rs`'s only real invariant check (`escrow_balance == sum_unapproved`) had a comment instead of an assertion, so the fuzz target could never fail. Now panics with the mismatched values on violation.
- **#980** — `fuzz/fuzz_targets/milestone_submit.rs` ran the exact same hardcoded call for every input regardless of fuzzer bytes, so mutation had zero effect on coverage. Grant size, target grant/milestone index, and submitted description/proof text are now all derived from the input.

### Note on #980/#981
While fixing these, I found the fuzz crate didn't actually build against the current contract API: `grant_create`/`milestone_submit` call signatures had drifted (extra removed params), the hardcoded test addresses failed Stellar's strkey checksum validation, and contract calls bypassed `env.register`/`as_contract` (direct `Storage` access panics outside a contract frame). None of this was caught before since the fuzz crate isn't part of the main workspace or CI. Fixed all three so both targets actually compile and run — rebuilt on a registered `StellarGrantsContractClient`, addresses via `Address::generate` + `env.mock_all_auths()`, and enabled the `testutils` feature on the fuzz crate's `soroban-sdk` dependency.

## Test plan
- [x] `cargo fmt --all -- --check` and `cargo clippy --workspace --lib --target wasm32v1-none -- -D warnings` pass for the contracts crate
- [x] `cargo build --bin grant_lifecycle --bin milestone_submit` (fuzz crate) compiles cleanly
- [x] `cargo fmt --check` / `cargo clippy -- -D warnings` pass for both fixed fuzz targets
- [x] Ran both fuzz binaries directly against 300 randomized inputs each — 0 false-positive crashes
- [x] Confirmed by code path review that GrantNotFound, MilestoneIndexOutOfBounds, and successful-submission paths are all reachable and vary with fuzzer input bytes for `milestone_submit`
- [x] `make test` / `make lint` / `make fmt` verified working from `contracts/`
- [ ] `cargo test --workspace` — note: this currently fails to compile due to pre-existing breakage in 4 integration test files (`test_delegate_voting.rs`, `test_milestone_dispute.rs`, `test_milestone_quorum.rs`, `test_reputation_and_dispute_fee.rs`) that reference contract functions/types no longer in the API. This is unrelated to this PR and is exactly the kind of drift #983 is meant to catch going forward — flagging here rather than silently expanding scope to fix it.
- [ ] `make build` / `make deploy-testnet` — blocked by the separate `overflow-checks` release-profile issue tracked in #1030 (referenced directly in #983's own description), not addressed by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)