### PR TITLE
fix(contract): harden multisig and notification scopes (#956-#959)

### DIFF
--- a/contracts/contracts/stellar-grants/src/events.rs
+++ b/contracts/contracts/stellar-grants/src/events.rs
@@ -1136,6 +1136,13 @@ pub struct MultisigExecuted {
     pub timestamp: u64,
 }
 
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultisigProposalExpired {
+    pub proposal_id: u32,
+    pub timestamp: u64,
+}
+
 // ── Issue #548: Compliance events ─────────────────────────────────────────────
 
 #[contractevent]
@@ -1225,6 +1232,14 @@ pub struct RoleRenounced {
 }
 
 impl Events {
+    pub fn emit_multisig_proposal_expired(env: &Env, proposal_id: u32) {
+        MultisigProposalExpired {
+            proposal_id,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(env);
+    }
+
     // ... existing methods ...
 
     // ── Invoice event emitters ────────────────────────────────────────────────

--- a/contracts/contracts/stellar-grants/src/multisig.rs
+++ b/contracts/contracts/stellar-grants/src/multisig.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{Address, Bytes, Env, Vec};
 
 use crate::errors::ContractError;
-use crate::events::{MultisigExecuted, MultisigProposalCreated, MultisigSigned};
+use crate::events::{Events, MultisigExecuted, MultisigProposalCreated, MultisigSigned};
 use crate::storage::Storage;
 use crate::types::{MultisigProposal, MultisigSigner, SignatureStatus};
 
@@ -17,7 +17,10 @@ pub fn create_proposal(
     threshold: u32,
     ttl_ledgers: u32,
 ) -> Result<u32, ContractError> {
-    if signer_addresses.is_empty() || threshold == 0 {
+    if signer_addresses.is_empty()
+        || threshold == 0
+        || threshold > signer_addresses.len()
+    {
         return Err(ContractError::InvalidInput);
     }
 
@@ -43,6 +46,7 @@ pub fn create_proposal(
         threshold,
         total_weight_signed: 0,
         executed: false,
+        expired: false,
         expired_at,
         created_by: creator.clone(),
         created_at: now,
@@ -86,8 +90,7 @@ pub fn sign(
         if s.address == *signer {
             found = true;
             if s.status != SignatureStatus::Pending {
-                // Already signed or rejected — idempotent reject of re-sign.
-                return Ok(proposal.total_weight_signed);
+                return Err(ContractError::AlreadyVoted);
             }
             if approve {
                 s.status = SignatureStatus::Signed;
@@ -176,7 +179,10 @@ pub fn expire_proposal(env: &Env, proposal_id: u32) -> Result<(), ContractError>
         return Err(ContractError::InvalidState);
     }
 
-    // Proposal is expired; no state change needed beyond the TTL check in execute/sign.
+    let mut proposal = proposal;
+    proposal.expired = true;
+    Storage::set_multisig_proposal(env, &proposal);
+    Events::emit_multisig_proposal_expired(env, proposal_id);
     Ok(())
 }
 
@@ -231,10 +237,38 @@ mod test {
                 Err(ContractError::ThresholdNotMet)
             );
 
-            assert_eq!(sign(&env, &signer1, id, true), Ok(1));
+            assert_eq!(
+                sign(&env, &signer1, id, true),
+                Err(ContractError::AlreadyVoted)
+            );
             assert_eq!(sign(&env, &signer2, id, true), Ok(2));
             assert!(is_threshold_met(&get_proposal(&env, id).unwrap()));
             assert_eq!(execute(&env, &creator, id), Ok(payload));
+        });
+    }
+
+    #[test]
+    fn rejects_unreachable_threshold() {
+        let env = Env::default();
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        env.as_contract(&contract_id, || {
+            let creator = Address::generate(&env);
+            let signer = Address::generate(&env);
+            let mut signers = Vec::new(&env);
+            signers.push_back(signer);
+
+            assert_eq!(
+                create_proposal(
+                    &env,
+                    &creator,
+                    1,
+                    Bytes::new(&env),
+                    signers,
+                    2,
+                    100,
+                ),
+                Err(ContractError::InvalidInput)
+            );
         });
     }
 
@@ -250,6 +284,9 @@ mod test {
 
             let id = create_proposal(&env, &creator, 1, Bytes::new(&env), signers, 1, 10).unwrap();
             env.ledger().set_timestamp(env.ledger().timestamp() + 11);
+
+            assert_eq!(expire_proposal(&env, id), Ok(()));
+            assert!(get_proposal(&env, id).unwrap().expired);
 
             assert_eq!(
                 sign(&env, &signer, id, true),

--- a/contracts/contracts/stellar-grants/src/notification.rs
+++ b/contracts/contracts/stellar-grants/src/notification.rs
@@ -49,8 +49,8 @@ pub fn subscribe(
         .persistent()
         .set(&DataKey::NotifSub(subscriber.clone(), 0, 0, 0), &subs);
 
-    let scope_type = scope_type_and_data(&scope).0;
-    let list_key = DataKey::NotifSubList(event as u32, scope_type);
+    let (scope_type, _scope_data) = scope_type_and_data(&scope);
+    let list_key = DataKey::NotifSubList(event as u32, scope_type, scope.clone());
     let mut list: Vec<Address> = env
         .storage()
         .persistent()
@@ -90,8 +90,8 @@ pub fn unsubscribe(
         .persistent()
         .set(&DataKey::NotifSub(subscriber.clone(), 0, 0, 0), &subs);
 
-    let scope_type = scope_type_and_data(scope).0;
-    let list_key = DataKey::NotifSubList(event as u32, scope_type);
+    let (scope_type, _scope_data) = scope_type_and_data(scope);
+    let list_key = DataKey::NotifSubList(event as u32, scope_type, scope.clone());
     let mut list: Vec<Address> = env
         .storage()
         .persistent()
@@ -117,8 +117,8 @@ pub fn get_subscribers(
     event: NotificationEvent,
     scope: &SubscriptionScope,
 ) -> Vec<Address> {
-    let scope_type = scope_type_and_data(scope).0;
-    let list_key = DataKey::NotifSubList(event as u32, scope_type);
+    let (scope_type, _scope_data) = scope_type_and_data(scope);
+    let list_key = DataKey::NotifSubList(event as u32, scope_type, scope.clone());
     env.storage()
         .persistent()
         .get(&list_key)
@@ -160,4 +160,68 @@ pub fn is_subscribed(
         }
     }
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    #[test]
+    fn subscription_lists_are_isolated_by_scope() {
+        let env = Env::default();
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        env.as_contract(&contract_id, || {
+            let subscriber_a = Address::generate(&env);
+            let subscriber_b = Address::generate(&env);
+            let contributor_a = Address::generate(&env);
+            let contributor_b = Address::generate(&env);
+
+            subscribe(
+                &env,
+                &subscriber_a,
+                NotificationEvent::MilestoneApproved,
+                SubscriptionScope::PerGrant(1),
+            )
+            .unwrap();
+            subscribe(
+                &env,
+                &subscriber_b,
+                NotificationEvent::MilestoneApproved,
+                SubscriptionScope::PerGrant(2),
+            )
+            .unwrap();
+            subscribe(
+                &env,
+                &subscriber_a,
+                NotificationEvent::NewGrant,
+                SubscriptionScope::PerContributor(contributor_a.clone()),
+            )
+            .unwrap();
+            subscribe(
+                &env,
+                &subscriber_b,
+                NotificationEvent::NewGrant,
+                SubscriptionScope::PerContributor(contributor_b.clone()),
+            )
+            .unwrap();
+
+            assert_eq!(
+                get_subscribers(
+                    &env,
+                    NotificationEvent::MilestoneApproved,
+                    &SubscriptionScope::PerGrant(1),
+                ),
+                Vec::from_array(&env, [subscriber_a.clone()])
+            );
+            assert_eq!(
+                get_subscribers(
+                    &env,
+                    NotificationEvent::NewGrant,
+                    &SubscriptionScope::PerContributor(contributor_a),
+                ),
+                Vec::from_array(&env, [subscriber_a])
+            );
+        });
+    }
 }

--- a/contracts/contracts/stellar-grants/src/storage/keys.rs
+++ b/contracts/contracts/stellar-grants/src/storage/keys.rs
@@ -312,7 +312,7 @@ pub enum DataKey {
 
     // Notifications
     NotifSub(Address, u32, u32, u128),
-    NotifSubList(u32, u32),
+    NotifSubList(u32, u32, crate::types::SubscriptionScope),
 
     // Issue #609: Lockup
     Lockup(u64, u32),
@@ -481,5 +481,5 @@ pub enum LegacyDataKey {
     ForkRecord(u64),
     ForkChildren(u64),
     NotifSub(Address, u32, u32, u128),
-    NotifSubList(u32, u32),
+    NotifSubList(u32, u32, crate::types::SubscriptionScope),
 }

--- a/contracts/contracts/stellar-grants/src/types.rs
+++ b/contracts/contracts/stellar-grants/src/types.rs
@@ -677,6 +677,7 @@ pub struct MultisigProposal {
     pub threshold: u32,
     pub total_weight_signed: u32,
     pub executed: bool,
+    pub expired: bool,
     pub expired_at: u64,
     pub created_by: Address,
     pub created_at: u64,


### PR DESCRIPTION
## Summary
Fixes four core contract bugs affecting multisig proposal safety and notification subscription isolation.

## Related Issues
Closes #956
Closes #957
Closes #958
Closes #959

## Changes Made
- Reject multisig proposals whose approval threshold exceeds the number of fixed-weight signers.
- Persist an `expired` state and emit `MultisigProposalExpired` when an expired proposal is marked.
- Reject attempts to cast a second or changed vote with `ContractError::AlreadyVoted`.
- Include the complete `SubscriptionScope` in notification subscriber list keys so per-grant, per-contributor, and per-tag subscriptions remain isolated.
- Add regression coverage for unreachable thresholds, repeated votes, expiry state, and scope isolation.

## Testing
- `git diff --check` passes.
- Source diagnostics report no errors in the touched modules.
- `cargo test -p stellar-grants` was attempted but the local execution was interrupted/skipped; CI should run the repository's contract format, clippy, WASM check, and workspace test jobs.

## Notes for Reviewer
The notification list key uses the full typed `SubscriptionScope` as its third component rather than a lossy `u128` encoding. This preserves contributor addresses without hash collisions while retaining the existing event payload format.