### PR TITLE
fix: emit events and add validation for grant, template, and extension operations

### DIFF
--- a/contracts/contracts/stellar-grants/src/events.rs
+++ b/contracts/contracts/stellar-grants/src/events.rs
@@ -1726,6 +1726,55 @@ impl Events {
         };
         event.publish(env);
     }
+
+    // ── Issue #955: Reviewer event emitters ────────────────────────────────
+
+    pub fn emit_reviewer_added_to_grant(env: &Env, grant_id: u64, reviewer: Address) {
+        let event = ReviewerAddedToGrant {
+            grant_id,
+            reviewer,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_reviewer_removed_from_grant(env: &Env, grant_id: u64, reviewer: Address) {
+        let event = ReviewerRemovedFromGrant {
+            grant_id,
+            reviewer,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    // ── Issue #954: Template event emitters ────────────────────────────────
+
+    pub fn emit_template_saved(env: &Env, template_id: u64, owner: Address, name: String) {
+        let event = TemplateSaved {
+            template_id,
+            owner,
+            name,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_template_deleted(env: &Env, template_id: u64, owner: Address) {
+        let event = TemplateDeleted {
+            template_id,
+            owner,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_template_used(env: &Env, template_id: u64) {
+        let event = TemplateUsed {
+            template_id,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
 }
 
 // ── Issue #587: Grant Forked event ──────────────────────────────────────────
@@ -1763,5 +1812,49 @@ pub struct WaitlistPromoted {
 pub struct WaitlistLeft {
     pub grant_id: u64,
     pub applicant: Address,
+    pub timestamp: u64,
+}
+
+// ── Issue #955: Grant reviewer events ───────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReviewerAddedToGrant {
+    pub grant_id: u64,
+    pub reviewer: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReviewerRemovedFromGrant {
+    pub grant_id: u64,
+    pub reviewer: Address,
+    pub timestamp: u64,
+}
+
+// ── Issue #954: Milestone template events ───────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemplateSaved {
+    pub template_id: u64,
+    pub owner: Address,
+    pub name: String,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemplateDeleted {
+    pub template_id: u64,
+    pub owner: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemplateUsed {
+    pub template_id: u64,
     pub timestamp: u64,
 }

--- a/contracts/contracts/stellar-grants/src/milestone_extension.rs
+++ b/contracts/contracts/stellar-grants/src/milestone_extension.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{contractevent, Address, Env, Map, String, Vec};
 
 use crate::errors::ContractError;
 use crate::storage::Storage;
-use crate::types::{ExtensionRequest, ExtensionStatus};
+use crate::types::{ExtensionRequest, ExtensionStatus, MilestoneState};
 
 // ── Events ──────────────────────────────────────────────────────────────────
 
@@ -57,6 +57,14 @@ pub fn request_extension(
 
     let milestone = Storage::get_milestone(env, grant_id, milestone_idx)
         .ok_or(ContractError::MilestoneNotFound)?;
+
+    // Issue #953: Reject if milestone is already in a terminal state
+    if matches!(
+        milestone.state,
+        MilestoneState::Approved | MilestoneState::Rejected | MilestoneState::Paid
+    ) {
+        return Err(ContractError::InvalidState);
+    }
 
     // Only one pending request per milestone at a time.
     if let Some(existing) = Storage::get_extension_request(env, grant_id, milestone_idx) {
@@ -130,7 +138,10 @@ pub fn vote_extension(
         request.votes_deny = request.votes_deny.saturating_add(1);
     }
 
-    let total_reviewers = grant.reviewers.len();
+    // Issue #952: Use the same reviewer_count_snapshot that milestone approval uses
+    let milestone = Storage::get_milestone(env, grant_id, milestone_idx)
+        .ok_or(ContractError::MilestoneNotFound)?;
+    let total_reviewers = milestone.reviewer_count_snapshot as usize;
     let majority = total_reviewers / 2 + 1;
 
     if request.votes_approve >= majority {

--- a/contracts/contracts/stellar-grants/src/milestone_template.rs
+++ b/contracts/contracts/stellar-grants/src/milestone_template.rs
@@ -1,3 +1,4 @@
+use crate::events::Events;
 use crate::storage::keys::DataKey;
 use crate::types::{ContractError, MilestoneTemplate, TemplateCategory};
 use soroban_sdk::{Address, Env, String, Vec};
@@ -45,7 +46,9 @@ pub fn save_template(
     owner_templates.push_back(id);
     env.storage()
         .persistent()
-        .set(&DataKey::TemplatesByOwner(owner), &owner_templates);
+        .set(&DataKey::TemplatesByOwner(owner.clone()), &owner_templates);
+
+    Events::emit_template_saved(env, id, owner, name);
 
     Ok(id)
 }
@@ -70,6 +73,8 @@ pub fn create_from_templates(
         env.storage()
             .persistent()
             .set(&DataKey::MilestoneTemplate(id), &template);
+
+        Events::emit_template_used(env, id);
 
         let amount = total_amount
             .checked_mul(template.default_amount_pct as i128)
@@ -138,7 +143,9 @@ pub fn delete_template(env: &Env, caller: Address, id: u64) -> Result<(), Contra
     }
     env.storage()
         .persistent()
-        .set(&DataKey::TemplatesByOwner(caller), &new_templates);
+        .set(&DataKey::TemplatesByOwner(caller.clone()), &new_templates);
+
+    Events::emit_template_deleted(env, id, caller);
 
     Ok(())
 }

--- a/contracts/contracts/stellar-grants/src/multi_grant.rs
+++ b/contracts/contracts/stellar-grants/src/multi_grant.rs
@@ -1,4 +1,5 @@
 use crate::errors::ContractError;
+use crate::events::Events;
 use crate::storage::keys::{DataKey, GrantKey};
 use crate::storage::Storage;
 use crate::types::{
@@ -321,6 +322,7 @@ fn add_reviewer_to_grant(
     // Add reviewer
     grant.reviewers.push_back(reviewer.clone());
     Storage::set_grant(env, grant_id, &grant);
+    Events::emit_reviewer_added_to_grant(env, grant_id, reviewer.clone());
 
     Ok(())
 }
@@ -357,6 +359,7 @@ fn remove_reviewer_from_grant(
 
     grant.reviewers = new_reviewers;
     Storage::set_grant(env, grant_id, &grant);
+    Events::emit_reviewer_removed_from_grant(env, grant_id, reviewer.clone());
 
     Ok(())
 }


### PR DESCRIPTION
Addresses four critical issues affecting event auditing and validation:

**#955 - multi_grant batch reviewer add/remove emits no events**
- Added `ReviewerAddedToGrant` and `ReviewerRemovedFromGrant` events
- `add_reviewer_to_grant` and `remove_reviewer_from_grant` now emit events
- Off-chain systems can now track when grant reviewer lists change

**#954 - milestone_template emits no events anywhere in the module**
- Added `TemplateSaved`, `TemplateDeleted`, and `TemplateUsed` events
- `save_template` emits `TemplateSaved`
- `delete_template` emits `TemplateDeleted`
- `create_from_templates` emits `TemplateUsed` for each template used
- Provides complete audit trail for template lifecycle

**#953 - milestone_extension request_extension doesn't validate milestone state**
- Added state validation before accepting extension requests
- Rejects requests on milestones in `Approved`, `Rejected`, or `Paid` states
- Prevents reviewers from wasting votes on closed milestones

**#952 - milestone_extension vote_extension uses different reviewer-quorum snapshot**
- Changed `vote_extension` to use `milestone.reviewer_count_snapshot` instead of live `grant.reviewers.len()`
- Ensures consistent quorum calculations even if reviewers are added after milestone submission
- Synchronizes extension voting with milestone approval voting logic

All changes follow existing code patterns and maintain backward compatibility.

closes #954
closes #952
closes #953 
closes #955