### PR TITLE
fix: enforce emergency pause and circuit breakers, cap syndication oversubscription, extend badge TTL

### DIFF
--- a/contracts/contracts/stellar-grants/src/badge.rs
+++ b/contracts/contracts/stellar-grants/src/badge.rs
@@ -3,6 +3,9 @@ use soroban_sdk::{contractevent, contracttype, Address, Env, Vec};
 use crate::types::{BadgeCriteria, BadgeRecord, BadgeType, ContractError};
 use crate::Storage;
 
+const BADGE_TTL_THRESHOLD: u32 = 100_000;
+const BADGE_TTL_EXTEND_TO: u32 = 1_000_000;
+
 #[contracttype]
 pub enum BadgeKey {
     Badge(Address, BadgeType),
@@ -28,9 +31,14 @@ fn get_badges_raw(env: &Env, contributor: &Address) -> Vec<BadgeRecord> {
 }
 
 fn has_badge_raw(env: &Env, contributor: &Address, badge_type: &BadgeType) -> bool {
-    env.storage()
-        .persistent()
-        .has(&BadgeKey::Badge(contributor.clone(), badge_type.clone()))
+    let key = BadgeKey::Badge(contributor.clone(), badge_type.clone());
+    let exists = env.storage().persistent().has(&key);
+    if exists {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, BADGE_TTL_THRESHOLD, BADGE_TTL_EXTEND_TO);
+    }
+    exists
 }
 
 fn meets_criteria(env: &Env, contributor: &Address, criteria: &BadgeCriteria) -> bool {
@@ -76,6 +84,12 @@ fn write_award(
     env.storage().persistent().set(
         &BadgeKey::Badge(contributor.clone(), badge_type.clone()),
         &record,
+    );
+    // Extend TTL for the badge entry
+    env.storage().persistent().extend_ttl(
+        &BadgeKey::Badge(contributor.clone(), badge_type.clone()),
+        BADGE_TTL_THRESHOLD,
+        BADGE_TTL_EXTEND_TO,
     );
 
     let mut badges = get_badges_raw(env, contributor);

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -1535,16 +1535,22 @@ impl StellarGrantsContract {
         sender: Address,
         stream_id: u32,
     ) -> Result<(i128, i128), ContractError> {
+        emergency::require_not_paused(&env)?;
+        circuit_breaker::require_open(&env, ProtocolModule::Streaming)?;
         streaming::cancel_stream(&env, &sender, stream_id)
     }
 
     /// Pause an active stream.
     pub fn pause_stream(env: Env, sender: Address, stream_id: u32) -> Result<(), ContractError> {
+        emergency::require_not_paused(&env)?;
+        circuit_breaker::require_open(&env, ProtocolModule::Streaming)?;
         streaming::pause_stream(&env, &sender, stream_id)
     }
 
     /// Resume a paused stream.
     pub fn resume_stream(env: Env, sender: Address, stream_id: u32) -> Result<(), ContractError> {
+        emergency::require_not_paused(&env)?;
+        circuit_breaker::require_open(&env, ProtocolModule::Streaming)?;
         streaming::resume_stream(&env, &sender, stream_id)
     }
 
@@ -2950,6 +2956,8 @@ impl StellarGrantsContract {
         amount_in: i128,
     ) -> Result<SwapResult, ContractError> {
         caller.require_auth();
+        emergency::require_not_paused(&env)?;
+        circuit_breaker::require_open(&env, ProtocolModule::TokenSwap)?;
         token_swap::swap(&env, &caller, route, amount_in)
     }
 
@@ -2965,6 +2973,7 @@ impl StellarGrantsContract {
         input_amount: i128,
     ) -> Result<SwapResult, ContractError> {
         emergency::require_not_paused(&env)?;
+        circuit_breaker::require_open(&env, ProtocolModule::TokenSwap)?;
         token_swap::swap_and_fund(&env, &funder, grant_id, &input_token, input_amount)
     }
 
@@ -2978,6 +2987,7 @@ impl StellarGrantsContract {
         amount: i128,
     ) -> Result<SwapResult, ContractError> {
         emergency::require_not_paused(&env)?;
+        circuit_breaker::require_open(&env, ProtocolModule::TokenSwap)?;
         token_swap::swap_and_pay(
             &env,
             &payer,

--- a/contracts/contracts/stellar-grants/src/syndication.rs
+++ b/contracts/contracts/stellar-grants/src/syndication.rs
@@ -84,6 +84,13 @@ pub fn join_syndicate(
         return Err(ContractError::InvalidInput);
     }
 
+    // Check total commitments don't exceed target_total
+    let total_committed = total_deposited(env, grant_id);
+    let remaining = syndicate.target_total.saturating_sub(total_committed);
+    if amount > remaining {
+        return Err(ContractError::InvalidInput);
+    }
+
     escrow::deposit(env, grant_id, member, amount)?;
 
     let prior = Storage::get_syndicate_member(env, grant_id, member);


### PR DESCRIPTION
This PR fixes critical security vulnerabilities and data integrity issues by enforcing consistent safety checks across streaming, token swap, syndication, and badge modules.

## Changes Made

### Issue 934 - Stream Management Security
Added emergency pause and circuit breaker checks to stream management functions that previously bypassed these safety mechanisms.

**Functions Updated**
cancel_stream now checks emergency pause and Streaming circuit breaker
- pause_stream now checks emergency pause and Streaming circuit breaker  
- resume_stream now checks emergency pause and Streaming circuit breaker

**Impact**: During an emergency pause, all stream operations are now properly halted, preventing unauthorized fund movements.

### Issue 933 - Token Swap Circuit Breaker
Added TokenSwap circuit breaker checks to all swap entrypoints that previously had no circuit breaker enforcement.

**Functions Updated**
- swap_tokens now checks emergency pause and TokenSwap circuit breaker
- swap_and_fund now checks TokenSwap circuit breaker (emergency pause already present)
- swap_and_pay now checks TokenSwap circuit breaker (emergency pause already present)

**Impact**: Administrators can now properly halt token swap operations during incidents by tripping the TokenSwap breaker.

### Issue 935 - Syndication Oversubscription Prevention
Added validation to prevent syndicate members from committing more than the target total, which previously allowed share_bps corruption.

**Changes**
- Calculate total committed funds before accepting new commitments
- Reject join_syndicate calls that would exceed target_total
- Prevents share_bps from summing to more than 10,000 basis points

**Impact**: Syndicate share allocations now remain mathematically correct and cannot exceed 100 percent total.

### Issue 932 - Badge TTL Extension
Added TTL extension to badge records to prevent legitimate one-time badges from being archived and re-awarded.

**Changes**
- Added TTL constants (BADGE_TTL_THRESHOLD and BADGE_TTL_EXTEND_TO) to badge module
- Modified has_badge_raw to extend TTL when checking badge existence
- Modified write_award to extend TTL immediately after writing new badge records

**Impact**: Badge records are properly preserved and one-time badge constraints are enforced correctly.

## Testing
All changes follow established patterns from other modules in the codebase and maintain backward compatibility with existing functionality.

## Files Modified
- contracts/contracts/stellar-grants/src/lib.rs
- contracts/contracts/stellar-grants/src/syndication.rs
- contracts/contracts/stellar-grants/src/badge.rs

Closes #932
Closes #933
Closes #934
Closes #935