### PR TITLE
fix: resolve batch funding, syndication withdrawal, bounty cancellation

### DIFF
--- a/contracts/contracts/stellar-grants/src/batch.rs
+++ b/contracts/contracts/stellar-grants/src/batch.rs
@@ -160,35 +160,39 @@ fn try_fund_grant(
         return Err(ContractError::InvalidState);
     }
 
-    let token_client = token::Client::new(env, &grant.token);
-    let contract_address = env.current_contract_address();
-    token_client.transfer(funder, &contract_address, &amount);
-
-    grant.escrow_balance = grant
+    let new_escrow_balance = grant
         .escrow_balance
         .checked_add(amount)
         .ok_or(ContractError::InvalidInput)?;
 
+    let mut funders = grant.funders.clone();
     let mut funder_found = false;
-    for i in 0..grant.funders.len() {
-        let mut fund_entry = grant.funders.get(i).unwrap();
+    for i in 0..funders.len() {
+        let mut fund_entry = funders.get(i).unwrap();
         if fund_entry.funder == *funder {
             fund_entry.amount = fund_entry
                 .amount
                 .checked_add(amount)
                 .ok_or(ContractError::InvalidInput)?;
-            grant.funders.set(i, fund_entry);
+            funders.set(i, fund_entry);
             funder_found = true;
             break;
         }
     }
 
     if !funder_found {
-        grant.funders.push_back(GrantFund {
+        funders.push_back(GrantFund {
             funder: funder.clone(),
             amount,
         });
     }
+
+    let token_client = token::Client::new(env, &grant.token);
+    let contract_address = env.current_contract_address();
+    token_client.transfer(funder, &contract_address, &amount);
+
+    grant.escrow_balance = new_escrow_balance;
+    grant.funders = funders;
 
     Storage::set_grant(env, grant_id, &grant);
     Events::emit_grant_funded(env, grant_id, funder.clone(), amount, grant.escrow_balance);

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -2263,7 +2263,10 @@ impl StellarGrantsContract {
 
     pub fn cancel_bounty(env: Env, caller: Address, bounty_id: u64) -> Result<(), ContractError> {
         caller.require_auth();
-        bounty::cancel_bounty(&env, &caller, bounty_id)
+        let bounty = bounty::get_bounty(&env, bounty_id).ok_or(ContractError::BountyNotFound)?;
+        bounty::cancel_bounty(&env, &caller, bounty_id)?;
+        metrics::update_token_locked(&env, &bounty.token, -bounty.prize_amount);
+        Ok(())
     }
 
     pub fn get_bounty(env: Env, bounty_id: u64) -> Option<BountyGrant> {
@@ -3947,6 +3950,10 @@ impl StellarGrantsContract {
     ) -> Result<(), ContractError> {
         caller.require_auth();
         syndication::record_payout_allocation(&env, &caller, grant_id, milestone_idx, payout)
+    }
+
+    pub fn syndicate_payout_allocation(env: Env, grant_id: u64, milestone_idx: u32) -> Vec<(Address, i128)> {
+        syndication::get_payout_allocation(&env, grant_id, milestone_idx)
     }
 
     pub fn withdraw_syndicate(

--- a/contracts/contracts/stellar-grants/src/storage/helpers.rs
+++ b/contracts/contracts/stellar-grants/src/storage/helpers.rs
@@ -1445,6 +1445,18 @@ impl Storage {
         Self::bump(env, &key);
     }
 
+    pub fn get_syndicate_payouts(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+    ) -> Vec<(Address, i128)> {
+        let key = DataKey::Grant(GrantKey::SyndicatePayouts(grant_id, milestone_idx));
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(env))
+    }
+
     // ── Issue #591: Grant Specification Versioning ───────────────────────────
 
     pub fn get_grant_version(env: &Env, grant_id: u64, version: u32) -> Option<GrantVersion> {

--- a/contracts/contracts/stellar-grants/src/syndication.rs
+++ b/contracts/contracts/stellar-grants/src/syndication.rs
@@ -189,6 +189,11 @@ pub fn record_payout_allocation(
     Ok(())
 }
 
+/// Get the recorded payout allocation for a milestone.
+pub fn get_payout_allocation(env: &Env, grant_id: u64, milestone_idx: u32) -> Vec<(Address, i128)> {
+    Storage::get_syndicate_payouts(env, grant_id, milestone_idx)
+}
+
 /// Allow members to withdraw after an unclosed formation expires.
 pub fn withdraw_syndicate(
     env: &Env,
@@ -220,6 +225,11 @@ pub fn withdraw_syndicate(
     Storage::set_syndicate_member_index(env, grant_id, &index);
     syndicate.member_count = syndicate.member_count.saturating_sub(1);
     Storage::set_syndicate_grant(env, grant_id, &syndicate);
+
+    env.events().publish(
+        (Symbol::new(env, "member_withdrew"), grant_id),
+        (member.clone(), amount),
+    );
 
     Ok(amount.min(record.deposited_amount))
 }


### PR DESCRIPTION
This pull request fixes four critical issues in the grant protocol.

Issue 939: batch try_fund_grant now performs all fallible bookkeeping computations before executing the token transfer. This prevents scenarios where tokens are transferred but grant state is not updated if checked_add operations fail.

Issue 937: withdraw_syndicate now emits a member_withdrew event with the member address and withdrawn amount. This ensures off-chain indexers can properly track syndicate membership changes.

Issue 938: cancel_bounty now properly releases the token_locked metric by calling metrics::update_token_locked with a negative delta after refunding the prize to the owner.

Issue 936: Added get_payout_allocation function in syndication.rs and syndicate_payout_allocation public entry point in lib.rs to retrieve recorded payout allocations. Also added get_syndicate_payouts helper in storage.

Closes #936
Closes #937
Closes #938
Closes #939