### PR TITLE
fix: add TTL bumps to storage helpers and remove unbounded BadgeRegistry

### DIFF
--- a/contracts/contracts/stellar-grants/src/badge.rs
+++ b/contracts/contracts/stellar-grants/src/badge.rs
@@ -10,7 +10,6 @@ const BADGE_TTL_EXTEND_TO: u32 = 1_000_000;
 pub enum BadgeKey {
     Badge(Address, BadgeType),
     BadgeList(Address),
-    BadgeRegistry,
     BadgeAwardCount(BadgeType),
 }
 
@@ -107,16 +106,6 @@ fn write_award(
         &BadgeKey::BadgeAwardCount(badge_type.clone()),
         &count.saturating_add(1),
     );
-
-    let mut registry: Vec<BadgeRecord> = env
-        .storage()
-        .persistent()
-        .get(&BadgeKey::BadgeRegistry)
-        .unwrap_or_else(|| Vec::new(env));
-    registry.push_back(record.clone());
-    env.storage()
-        .persistent()
-        .set(&BadgeKey::BadgeRegistry, &registry);
 
     BadgeAwarded {
         contributor: contributor.clone(),

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -424,7 +424,8 @@ impl StellarGrantsContract {
                 return Err(ContractError::InvalidState);
             }
 
-            let mut escrow_state = Storage::get_escrow_state(&env, grant_id);
+            let mut escrow_state = Storage::get_escrow_state(&env, grant_id)
+                .ok_or(ContractError::InvalidState)?;
             if escrow_state.lifecycle == EscrowLifecycleState::Released {
                 return Err(ContractError::GrantAlreadyReleased);
             }
@@ -452,7 +453,8 @@ impl StellarGrantsContract {
                 return Err(ContractError::InvalidState);
             }
 
-            let mut escrow_state = Storage::get_escrow_state(&env, grant_id);
+            let mut escrow_state = Storage::get_escrow_state(&env, grant_id)
+                .ok_or(ContractError::InvalidState)?;
             if escrow_state.mode != EscrowMode::HighSecurity {
                 return Err(ContractError::InvalidState);
             }
@@ -599,7 +601,8 @@ impl StellarGrantsContract {
         if multisig_pending {
             // Grant stays Active with escrow untouched (beyond what was
             // already paid out above) until execute_escrow_release runs.
-            let mut escrow_state = Storage::get_escrow_state(env, grant_id);
+            let mut escrow_state = Storage::get_escrow_state(env, grant_id)
+                .ok_or(ContractError::InvalidState)?;
             escrow_state.lifecycle = EscrowLifecycleState::AwaitingMultisig;
             escrow_state.quorum_ready = true;
             Storage::set_escrow_state(env, grant_id, &escrow_state);
@@ -634,7 +637,8 @@ impl StellarGrantsContract {
         // Issue #817: keep the data_export staleness/filter API fresh.
         data_export::set_last_updated(env, grant_id, env.ledger().timestamp());
 
-        let mut escrow_state = Storage::get_escrow_state(env, grant_id);
+        let mut escrow_state = Storage::get_escrow_state(env, grant_id)
+            .ok_or(ContractError::InvalidState)?;
         escrow_state.lifecycle = EscrowLifecycleState::Released;
         escrow_state.quorum_ready = true;
         Storage::set_escrow_state(env, grant_id, &escrow_state);

--- a/contracts/contracts/stellar-grants/src/storage/helpers.rs
+++ b/contracts/contracts/stellar-grants/src/storage/helpers.rs
@@ -136,12 +136,12 @@ impl Storage {
     }
 
     pub fn get_milestone(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<Milestone> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Milestone(MilestoneKey::Data(
-                grant_id,
-                milestone_idx,
-            )))
+        let key = DataKey::Milestone(MilestoneKey::Data(grant_id, milestone_idx));
+        let result = env.storage().persistent().get(&key);
+        if result.is_some() {
+            Self::bump(env, &key);
+        }
+        result
     }
 
     pub fn get_milestone_v(env: &Env, grant_id: u64, milestone_idx: u32) -> Milestone {
@@ -151,37 +151,39 @@ impl Storage {
     }
 
     pub fn set_milestone(env: &Env, grant_id: u64, milestone_idx: u32, milestone: &Milestone) {
-        env.storage().persistent().set(
-            &DataKey::Milestone(MilestoneKey::Data(grant_id, milestone_idx)),
-            milestone,
-        );
+        let key = DataKey::Milestone(MilestoneKey::Data(grant_id, milestone_idx));
+        env.storage().persistent().set(&key, milestone);
+        Self::bump(env, &key);
     }
 
     pub fn get_contributor(env: &Env, contributor: Address) -> Option<ContributorProfile> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::User(UserKey::Profile(contributor)))
+        let key = DataKey::User(UserKey::Profile(contributor));
+        let result = env.storage().persistent().get(&key);
+        if result.is_some() {
+            Self::bump(env, &key);
+        }
+        result
     }
 
     pub fn set_contributor(env: &Env, contributor: Address, profile: &ContributorProfile) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::User(UserKey::Profile(contributor)), profile);
+        let key = DataKey::User(UserKey::Profile(contributor));
+        env.storage().persistent().set(&key, profile);
+        Self::bump(env, &key);
     }
 
-    pub fn get_escrow_state(env: &Env, grant_id: u64) -> EscrowState {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Escrow(EscrowKey::State(grant_id)))
-            .unwrap_or_else(|| {
-                env.panic_with_error(ContractError::InvalidState);
-            })
+    pub fn get_escrow_state(env: &Env, grant_id: u64) -> Option<EscrowState> {
+        let key = DataKey::Escrow(EscrowKey::State(grant_id));
+        let result = env.storage().persistent().get(&key);
+        if result.is_some() {
+            Self::bump(env, &key);
+        }
+        result
     }
 
     pub fn set_escrow_state(env: &Env, grant_id: u64, state: &EscrowState) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::Escrow(EscrowKey::State(grant_id)), state);
+        let key = DataKey::Escrow(EscrowKey::State(grant_id));
+        env.storage().persistent().set(&key, state);
+        Self::bump(env, &key);
     }
 
     pub fn get_multisig_signers(env: &Env, grant_id: u64) -> Vec<Address> {

--- a/contracts/contracts/stellar-grants/src/test.rs
+++ b/contracts/contracts/stellar-grants/src/test.rs
@@ -696,7 +696,7 @@ mod tests {
         assert_eq!(grant.escrow_balance, 1000);
 
         env.as_contract(&contract_id, || {
-            let escrow_state = Storage::get_escrow_state(&env, grant_id);
+            let escrow_state = Storage::get_escrow_state(&env, grant_id).unwrap();
             assert_eq!(
                 escrow_state.lifecycle,
                 EscrowLifecycleState::AwaitingMultisig
@@ -848,7 +848,7 @@ mod tests {
         let total_before = client.provenance_total_records();
         assert!(total_before >= 1);
 
-        let by_grant = client.provenance_get_by_grant(&grant_id);
+        let by_grant = client.provenance_get_by_grant(&grant_id, &0, &10);
         assert!(!by_grant.is_empty());
         let record = by_grant.get(0).unwrap();
         assert_eq!(record.grant_id, grant_id);


### PR DESCRIPTION
Closes #928, Closes #929, Closes #930, Closes #931

## What changed
- Added persistent storage TTL extension (`Self::bump`) on read/write for milestone, contributor, and escrow_state helpers
- Changed `get_escrow_state` return type from `EscrowState` to `Option<EscrowState>` with TTL bump
- Removed unbounded global `BadgeRegistry` Vec from badge.rs
- Fixed pre-existing test compilation error in `provenance_get_by_grant`

## Why
- Storage entries expire without TTL bumps, causing data loss for milestones, contributors, and escrow states
- `get_escrow_state` panicked when no state existed, causing confusing errors instead of proper error handling
- `BadgeRegistry` was a global Vec that only grew and was never queried, wasting storage

## How to test
- `cargo build` compiles successfully
- Existing tests pass (pre-existing failures unrelated to this change)