### PR TITLE
Fix grant_pause guard, evidence_schema bounds check, escrow_multisig events, waitlist auth/cap

### DIFF
--- a/contracts/contracts/stellar-grants/src/escrow_multisig.rs
+++ b/contracts/contracts/stellar-grants/src/escrow_multisig.rs
@@ -1,3 +1,4 @@
+use crate::events::Events;
 use crate::storage::keys::DataKey;
 use crate::types::{ContractError, EscrowReleaseApproval, EscrowReleaseRequest, ProtocolConfig};
 use soroban_sdk::{Address, Env, Vec};
@@ -23,6 +24,7 @@ pub fn create_request(
         executed: false,
     };
     env.storage().persistent().set(&key, &request);
+    Events::emit_escrow_multisig_request_created(env, grant_id, milestone_idx, amount);
     Ok(())
 }
 
@@ -55,11 +57,13 @@ pub fn approve(
         approver: approver.clone(),
         timestamp: env.ledger().timestamp(),
     });
+    let total_approvals = request.approvals.len();
 
     env.storage().persistent().set(
         &DataKey::EscrowReleaseRequest(grant_id, milestone_idx),
         &request,
     );
+    Events::emit_escrow_multisig_approved(env, grant_id, milestone_idx, approver, total_approvals);
     Ok(())
 }
 
@@ -98,7 +102,9 @@ pub fn execute_release(env: &Env, grant_id: u64, milestone_idx: u32) -> Result<(
         &request,
     );
 
-    crate::escrow::release(env, grant_id, &request.recipient, request.amount)
+    crate::escrow::release(env, grant_id, &request.recipient, request.amount)?;
+    Events::emit_escrow_multisig_executed(env, grant_id, milestone_idx, request.amount);
+    Ok(())
 }
 
 pub fn get_request(env: &Env, grant_id: u64, milestone_idx: u32) -> Option<EscrowReleaseRequest> {

--- a/contracts/contracts/stellar-grants/src/events.rs
+++ b/contracts/contracts/stellar-grants/src/events.rs
@@ -1875,3 +1875,82 @@ pub struct TemplateUsed {
     pub template_id: u64,
     pub timestamp: u64,
 }
+
+// ── Issue #926: Escrow multisig events ──────────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EscrowMultisigRequestCreated {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EscrowMultisigApproved {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub approver: Address,
+    pub total_approvals: u32,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EscrowMultisigExecuted {
+    pub grant_id: u64,
+    pub milestone_idx: u32,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+impl Events {
+    pub fn emit_escrow_multisig_request_created(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        amount: i128,
+    ) {
+        let event = EscrowMultisigRequestCreated {
+            grant_id,
+            milestone_idx,
+            amount,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_escrow_multisig_approved(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        approver: Address,
+        total_approvals: u32,
+    ) {
+        let event = EscrowMultisigApproved {
+            grant_id,
+            milestone_idx,
+            approver,
+            total_approvals,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+
+    pub fn emit_escrow_multisig_executed(
+        env: &Env,
+        grant_id: u64,
+        milestone_idx: u32,
+        amount: i128,
+    ) {
+        let event = EscrowMultisigExecuted {
+            grant_id,
+            milestone_idx,
+            amount,
+            timestamp: env.ledger().timestamp(),
+        };
+        event.publish(env);
+    }
+}

--- a/contracts/contracts/stellar-grants/src/evidence_schema.rs
+++ b/contracts/contracts/stellar-grants/src/evidence_schema.rs
@@ -49,6 +49,9 @@ pub fn submit_evidence(
     if grant.owner != *caller {
         return Err(ContractError::Unauthorized);
     }
+    if milestone_idx >= grant.total_milestones {
+        return Err(ContractError::MilestoneIndexOutOfBounds);
+    }
 
     if let Some(schema) = Storage::get_evidence_schema(env, grant_id, milestone_idx) {
         for field in schema.fields.iter() {
@@ -223,5 +226,23 @@ mod test {
 
         let submit_result = submit_evidence(&env, &owner, 1, 0, values);
         assert_eq!(submit_result, Ok(()));
+    }
+
+    #[test]
+    fn test_submit_evidence_rejects_out_of_range_milestone() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let owner = Address::generate(&env);
+        setup_grant(&env, 1, &owner);
+
+        let mut values = Map::new(&env);
+        values.set(
+            String::from_str(&env, "anything"),
+            String::from_str(&env, "value"),
+        );
+
+        let result = submit_evidence(&env, &owner, 1, 999_999, values);
+        assert_eq!(result, Err(ContractError::MilestoneIndexOutOfBounds));
     }
 }

--- a/contracts/contracts/stellar-grants/src/grant_pause.rs
+++ b/contracts/contracts/stellar-grants/src/grant_pause.rs
@@ -51,12 +51,11 @@ pub fn unpause(env: &Env, caller: &Address, grant_id: u64) -> Result<(), Contrac
     }
 
     let key = DataKey::GrantPaused(grant_id);
-    if let Some(mut record) = get_record(env, grant_id) {
-        let now = env.ledger().timestamp();
-        record.unpause_history.push_back((caller.clone(), now));
-        record.auto_unpause_at = Some(now);
-        env.storage().persistent().set(&key, &record);
-    }
+    let mut record = get_record(env, grant_id).ok_or(ContractError::InvalidState)?;
+    let now = env.ledger().timestamp();
+    record.unpause_history.push_back((caller.clone(), now));
+    record.auto_unpause_at = Some(now);
+    env.storage().persistent().set(&key, &record);
     env.events().publish(
         (Symbol::new(env, "grant_unpaused"), grant_id),
         caller.clone(),
@@ -308,6 +307,24 @@ mod tests {
 
             let record = get_record(&env, grant_id).unwrap();
             assert_eq!(record.unpause_history.len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_unpause_never_paused_grant_returns_invalid_state() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(crate::StellarGrantsContract, ());
+        let grant_id = 1;
+        let owner = Address::generate(&env);
+
+        with_contract_id(&env, &contract_id, || {
+            setup_grant(&env, &owner, grant_id);
+            assert!(!is_paused(&env, grant_id));
+
+            let result = unpause(&env, &owner, grant_id);
+            assert_eq!(result, Err(ContractError::InvalidState));
         });
     }
 }

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -4606,8 +4606,8 @@ impl StellarGrantsContract {
 
     /// Promote the top-ranked entry. Called when a slot opens.
     /// Returns the promoted address if successful, None if waitlist is empty.
-    pub fn promote_from_waitlist(env: Env, grant_id: u64) -> Option<Address> {
-        waitlist::promote_next(&env, grant_id)
+    pub fn promote_from_waitlist(env: Env, caller: Address, grant_id: u64) -> Result<Option<Address>, ContractError> {
+        waitlist::promote_next(&env, &caller, grant_id)
     }
 
     /// Return all entries, sorted by reputation (or FIFO).

--- a/contracts/contracts/stellar-grants/src/storage/helpers.rs
+++ b/contracts/contracts/stellar-grants/src/storage/helpers.rs
@@ -2255,6 +2255,21 @@ impl Storage {
         Self::bump(env, &key);
     }
 
+    // Issue #927: tracks how many waitlist promotions have happened for this
+    // grant so promote_next can enforce config.max_slots.
+    pub fn get_waitlist_promoted_count(env: &Env, grant_id: u64) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Waitlist(WaitlistKey::PromotedCount(grant_id)))
+            .unwrap_or(0)
+    }
+
+    pub fn set_waitlist_promoted_count(env: &Env, grant_id: u64, count: u32) {
+        let key = DataKey::Waitlist(WaitlistKey::PromotedCount(grant_id));
+        env.storage().persistent().set(&key, &count);
+        Self::bump(env, &key);
+    }
+
     // ── Issue #533: Bounty-Mode Grants ───────────────────────────────────────
 
     pub fn next_bounty_id(env: &Env) -> u64 {

--- a/contracts/contracts/stellar-grants/src/storage/keys.rs
+++ b/contracts/contracts/stellar-grants/src/storage/keys.rs
@@ -151,6 +151,7 @@ pub enum CollateralKey {
 pub enum WaitlistKey {
     Config(u64),
     Entries(u64),
+    PromotedCount(u64),
 }
 
 #[contracttype]

--- a/contracts/contracts/stellar-grants/src/waitlist.rs
+++ b/contracts/contracts/stellar-grants/src/waitlist.rs
@@ -139,20 +139,34 @@ pub fn leave(env: &Env, applicant: &Address, grant_id: u64) -> Result<(), Contra
 
 /// Promote the top-ranked entry. Called when a slot opens.
 /// Returns the promoted address if successful, None if waitlist is empty.
-pub fn promote_next(env: &Env, grant_id: u64) -> Option<Address> {
-    let config = Storage::get_waitlist_config(env, grant_id)?;
+pub fn promote_next(env: &Env, caller: &Address, grant_id: u64) -> Result<Option<Address>, ContractError> {
+    caller.require_auth();
+    let grant = Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
+    if grant.owner != *caller {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let config = match Storage::get_waitlist_config(env, grant_id) {
+        Some(c) => c,
+        None => return Ok(None),
+    };
     if !config.auto_promote {
-        return None;
+        return Ok(None);
+    }
+
+    let promoted_count = Storage::get_waitlist_promoted_count(env, grant_id);
+    if promoted_count >= config.max_slots {
+        return Err(ContractError::WaitlistFull);
     }
 
     let mut entries = Storage::get_waitlist_entries(env, grant_id);
 
     if entries.is_empty() {
-        return None;
+        return Ok(None);
     }
 
     // Get the first (highest-ranked) entry
-    let promoted_entry = entries.get(0)?.clone();
+    let promoted_entry = entries.get(0).ok_or(ContractError::InvalidState)?.clone();
 
     // Mark as promoted
     let mut first = entries.get(0).unwrap();
@@ -171,9 +185,10 @@ pub fn promote_next(env: &Env, grant_id: u64) -> Option<Address> {
     }
 
     Storage::set_waitlist_entries(env, grant_id, &entries);
+    Storage::set_waitlist_promoted_count(env, grant_id, promoted_count + 1);
     Events::emit_waitlist_promoted(env, grant_id, promoted_entry.applicant.clone(), 1);
 
-    Some(promoted_entry.applicant)
+    Ok(Some(promoted_entry.applicant))
 }
 
 /// Return all entries, sorted by reputation (or FIFO).
@@ -461,13 +476,81 @@ mod tests {
             join(&env, &applicant2, grant_id).unwrap();
 
             // Promote first
-            let promoted = promote_next(&env, grant_id);
+            let promoted = promote_next(&env, &owner, grant_id).unwrap();
             assert_eq!(promoted, Some(applicant1.clone()));
 
             let waitlist = get_waitlist(&env, grant_id);
             assert_eq!(waitlist.len(), 1);
             assert_eq!(waitlist.get(0).unwrap().applicant, applicant2);
             assert_eq!(waitlist.get(0).unwrap().position, 1);
+        });
+    }
+
+    #[test]
+    fn test_promote_next_requires_owner() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = register(&env);
+
+        let owner = Address::generate(&env);
+        let stranger = Address::generate(&env);
+        let applicant1 = Address::generate(&env);
+
+        let grant_id = 1;
+        let config = WaitlistConfig {
+            grant_id,
+            max_slots: 2,
+            max_waitlist_size: 10,
+            rank_by_reputation: false,
+            auto_promote: true,
+        };
+
+        env.as_contract(&contract_id, || {
+            setup_grant(&env, grant_id, &owner);
+            configure(&env, &owner, grant_id, config.clone()).unwrap();
+            setup_contributor(&env, &applicant1, 500);
+            join(&env, &applicant1, grant_id).unwrap();
+
+            let result = promote_next(&env, &stranger, grant_id);
+            assert_eq!(result, Err(ContractError::Unauthorized));
+        });
+    }
+
+    #[test]
+    fn test_promote_next_stops_at_max_slots() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = register(&env);
+
+        let owner = Address::generate(&env);
+        let applicant1 = Address::generate(&env);
+        let applicant2 = Address::generate(&env);
+        let applicant3 = Address::generate(&env);
+
+        let grant_id = 1;
+        let config = WaitlistConfig {
+            grant_id,
+            max_slots: 2,
+            max_waitlist_size: 10,
+            rank_by_reputation: false,
+            auto_promote: true,
+        };
+
+        env.as_contract(&contract_id, || {
+            setup_grant(&env, grant_id, &owner);
+            configure(&env, &owner, grant_id, config.clone()).unwrap();
+            setup_contributor(&env, &applicant1, 500);
+            setup_contributor(&env, &applicant2, 500);
+            setup_contributor(&env, &applicant3, 500);
+            join(&env, &applicant1, grant_id).unwrap();
+            join(&env, &applicant2, grant_id).unwrap();
+            join(&env, &applicant3, grant_id).unwrap();
+
+            promote_next(&env, &owner, grant_id).unwrap();
+            promote_next(&env, &owner, grant_id).unwrap();
+
+            let result = promote_next(&env, &owner, grant_id);
+            assert_eq!(result, Err(ContractError::WaitlistFull));
         });
     }
 


### PR DESCRIPTION
## Summary
- `grant_pause::unpause` returns `Err(ContractError::InvalidState)` when the grant was never paused, instead of silently succeeding and emitting a misleading `grant_unpaused` event.
- `evidence_schema::submit_evidence` now enforces the same `milestone_idx` bounds check `set_schema` already enforces.
- `escrow_multisig`'s `create_request`/`approve`/`execute_release` now emit events, matching the pattern already used by `clawback.rs`.
- `waitlist::promote_next` now requires the grant owner's authorization and enforces `config.max_slots` via a new `promoted_count` counter.

## Issues
Closes #924
Closes #925
Closes #926
Closes #927

## Test plan
- [x] `cargo check -p stellar-grants` (lib) compiles clean
- [x] Added tests for #924, #925, and #927's two new guard paths (unauthorized caller, max_slots cap)
- [x] #926 (event emission) has no accompanying new test — this file had no existing test module and building one from scratch was out of scope for this pass; the event-wiring itself follows the exact pattern already verified in `clawback.rs`
- Note: `cargo test -p stellar-grants` currently fails on `main` before this change too, on an unrelated pre-existing `provenance_get_by_grant` argument-count mismatch in `test.rs` — confirmed via `git stash` that this error is present without this diff as well