### PR TITLE
fix: timer triggers, milestone event, reviewer transfer, index orphaning

### DIFF
--- a/contracts/contracts/stellar-grants/src/grant_index.rs
+++ b/contracts/contracts/stellar-grants/src/grant_index.rs
@@ -81,17 +81,22 @@ pub fn on_status_changed(
     new_status: GrantStatus,
 ) {
     if old_status != new_status {
-        remove_from_index(
-            env,
-            &DataKey::Grant(GrantKey::StatusIndex(old_status as u32)),
-            grant_id,
-        );
-        push_to_index(
+        // Push to the new-status index first. If the index is full the
+        // grant stays discoverable under its old status rather than being
+        // orphaned in neither index.
+        let pushed = push_to_index(
             env,
             &DataKey::Grant(GrantKey::StatusIndex(new_status as u32)),
             grant_id,
             constants::MAX_INDEX_ENTRIES,
         );
+        if pushed {
+            remove_from_index(
+                env,
+                &DataKey::Grant(GrantKey::StatusIndex(old_status as u32)),
+                grant_id,
+            );
+        }
     }
 }
 

--- a/contracts/contracts/stellar-grants/src/grant_timer.rs
+++ b/contracts/contracts/stellar-grants/src/grant_timer.rs
@@ -88,20 +88,15 @@ pub fn trigger_timers(env: &Env, caller: &Address, grant_id: u64) -> u32 {
             continue;
         }
 
-        execute_timer_action(env, &grant, &timer);
+        let success = execute_timer_action(env, &grant, &timer);
 
-        timer.fired = true;
-        timer.fired_at = Some(now);
-        timer.triggered_by = Some(caller.clone());
-        timers.set(i, timer.clone());
-        fired_count += 1;
-
-        crate::events::Events::milestone_status_changed(
-            env,
-            grant_id,
-            0,
-            crate::types::MilestoneState::Pending,
-        );
+        if success {
+            timer.fired = true;
+            timer.fired_at = Some(now);
+            timer.triggered_by = Some(caller.clone());
+            timers.set(i, timer.clone());
+            fired_count += 1;
+        }
     }
 
     if fired_count > 0 {
@@ -168,24 +163,23 @@ pub fn cancel_timer(
     Ok(())
 }
 
-fn execute_timer_action(env: &Env, grant: &crate::types::Grant, timer: &TimerRecord) {
+/// Returns `true` when the action was actually performed, `false` for
+/// unimplemented trigger types that should not be marked as fired.
+fn execute_timer_action(env: &Env, grant: &crate::types::Grant, timer: &TimerRecord) -> bool {
     match timer.trigger_type {
         TimerTriggerType::AutoExpire => {
             let reason = String::from_str(env, "auto-expired by timer");
             let _ = cancel_grant_internal(env, grant.id, &reason);
+            true
         }
         TimerTriggerType::AutoCancel => {
             let reason = String::from_str(env, "auto-cancelled: not funded by deadline");
             let _ = cancel_grant_internal(env, grant.id, &reason);
+            true
         }
-        TimerTriggerType::AutoActivate => {
-            // Grant is already Active; this is a no-op marker
-        }
-        TimerTriggerType::AutoReleaseLockup => {
-            // Release lockup logic placeholder
-        }
-        TimerTriggerType::CustomCallback => {
-            // Custom callback placeholder
+        TimerTriggerType::AutoActivate | TimerTriggerType::AutoReleaseLockup | TimerTriggerType::CustomCallback => {
+            // Not yet implemented — don't claim success.
+            false
         }
     }
 }

--- a/contracts/contracts/stellar-grants/src/grant_transfer.rs
+++ b/contracts/contracts/stellar-grants/src/grant_transfer.rs
@@ -79,6 +79,12 @@ pub fn accept_transfer(
             let to_replace = proposal
                 .reviewer_to_replace
                 .ok_or(ContractError::InvalidInput)?;
+            // Re-validate that the reviewer being replaced is still present.
+            // If they were removed between proposal and acceptance, fail
+            // rather than silently succeeding with no substitution.
+            if !grant.reviewers.contains(to_replace.clone()) {
+                return Err(ContractError::InvalidState);
+            }
             for i in 0..grant.reviewers.len() {
                 if grant.reviewers.get(i).unwrap() == to_replace {
                     grant.reviewers.set(i, new_holder.clone());


### PR DESCRIPTION
Closes #915, Closes #916, Closes #918, Closes #919

## What changed
- `execute_timer_action` now returns `bool`; unimplemented triggers (`AutoActivate`, `AutoReleaseLockup`, `CustomCallback`) return `false` so they are not marked as fired (#915)
- Removed hardcoded `milestone_status_changed` event from `trigger_timers` — cancel timers already emit correct events via `cancel_grant_internal` (#916)
- `accept_transfer` re-validates that `reviewer_to_replace` is still present in `grant.reviewers` at accept time, returning `InvalidState` if removed (#918)
- `on_status_changed` pushes to the new-status index before removing from the old one, preventing orphaning when the target index is full (#919)

## Why
- Unimplemented timers were silently consumed with zero effect, misleading grant owners
- Incorrect milestone events corrupted off-chain indexer data
- Reviewer transfers could silently no-op after the target was removed
- Full status indexes could permanently orphan grants from all status queries

## How to test
- `cargo test` in `contracts/`
- Verify an `AutoActivate` timer stays unfired after `trigger_timers`
- Verify no `milestone_status_changed` event is emitted for cancel timers
- Verify `accept_transfer` fails with `InvalidState` if reviewer was removed
- Verify a grant stays in old-status index when new-status index is full