### PR TITLE
fix: insurance deactivation, grant checks, archetype enforcement, matching distribute failures

### DIFF
--- a/contracts/contracts/stellar-grants/src/collateral.rs
+++ b/contracts/contracts/stellar-grants/src/collateral.rs
@@ -211,10 +211,17 @@ pub fn require_deposited(
     grant_id: u64,
     contributor: &Address,
 ) -> Result<(), ContractError> {
-    // If no requirement is set, pass through.
+    // If no requirement is set, pass through — unless the grant's archetype
+    // (issue #912) mandates staking, in which case a requirement must have
+    // been configured before work can proceed.
     let req = match Storage::get_collateral_requirement(env, grant_id) {
         Some(r) => r,
-        None => return Ok(()),
+        None => {
+            if Storage::get_grant_safety_flags(env, grant_id).requires_staking {
+                return Err(ContractError::CollateralNotDeposited);
+            }
+            return Ok(());
+        }
     };
 
     let deposit = Storage::get_collateral_deposit(env, grant_id, contributor)
@@ -304,6 +311,30 @@ mod tests {
         let contributor = Address::generate(&env);
         // No requirement set -> should pass
         assert_eq!(require_deposited(&env, 1, &contributor), Ok(()));
+    }
+
+    #[test]
+    fn test_require_deposited_blocks_archetype_requires_staking() {
+        use crate::types::GrantSafetyFlags;
+
+        let env = Env::default();
+        let contributor = Address::generate(&env);
+
+        // No requirement configured, and the grant's archetype (issue #912)
+        // mandates staking -> must not silently pass through.
+        Storage::set_grant_safety_flags(
+            &env,
+            1,
+            &GrantSafetyFlags {
+                requires_staking: true,
+                multisig_required: false,
+                insurance_opt_in: false,
+            },
+        );
+        assert_eq!(
+            require_deposited(&env, 1, &contributor),
+            Err(ContractError::CollateralNotDeposited)
+        );
     }
 
     #[test]

--- a/contracts/contracts/stellar-grants/src/factory.rs
+++ b/contracts/contracts/stellar-grants/src/factory.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{Address, Env, String, Vec};
 use crate::constants::LEDGERS_PER_DAY;
 use crate::errors::ContractError;
 use crate::storage::Storage;
-use crate::types::{GrantArchetype, GrantTemplate, VotingMechanism};
+use crate::types::{GrantArchetype, GrantSafetyFlags, GrantTemplate, VotingMechanism};
 
 /// Return the default GrantTemplate for a given archetype.
 pub fn template_for(archetype: GrantArchetype) -> GrantTemplate {
@@ -136,6 +136,19 @@ pub fn create_from_custom_template(
     )?;
 
     Storage::set_voting_mechanism(env, grant_id, &template.voting_mechanism);
+
+    // Issue #912: persist the archetype's safety flags so they are actually
+    // enforced (staking, multisig, insurance) rather than discarded.
+    Storage::set_grant_safety_flags(
+        env,
+        grant_id,
+        &GrantSafetyFlags {
+            requires_staking: template.requires_staking,
+            multisig_required: template.multisig_required,
+            insurance_opt_in: template.insurance_opt_in,
+        },
+    );
+
     Ok(grant_id)
 }
 
@@ -262,6 +275,69 @@ mod tests {
 
             let grant = Storage::get_grant(&env, grant_id).unwrap();
             assert_eq!(grant.total_milestones, 4);
+        });
+    }
+
+    #[test]
+    fn test_protocol_integration_persists_safety_flags() {
+        let env = Env::default();
+        env.mock_all_auths();
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let token = Address::generate(&env);
+            let mut reviewers = Vec::new(&env);
+            for _ in 0..4 {
+                reviewers.push_back(Address::generate(&env));
+            }
+
+            let grant_id = create_from_template(
+                &env,
+                &owner,
+                GrantArchetype::ProtocolIntegration,
+                String::from_str(&env, "Integration"),
+                String::from_str(&env, "Desc"),
+                &token,
+                500,
+                reviewers,
+            )
+            .unwrap();
+
+            // The ProtocolIntegration archetype declares multisig_required
+            // and insurance_opt_in — those flags must be persisted on the
+            // grant so downstream enforcement can act on them (issue #912).
+            let flags = Storage::get_grant_safety_flags(&env, grant_id);
+            assert!(flags.multisig_required);
+            assert!(flags.insurance_opt_in);
+            assert!(!flags.requires_staking);
+        });
+    }
+
+    #[test]
+    fn test_community_project_has_no_safety_flags() {
+        let env = Env::default();
+        env.mock_all_auths();
+        with_contract(&env, || {
+            let owner = Address::generate(&env);
+            let token = Address::generate(&env);
+            let mut reviewers = Vec::new(&env);
+            reviewers.push_back(Address::generate(&env));
+
+            let grant_id = create_from_template(
+                &env,
+                &owner,
+                GrantArchetype::CommunityProject,
+                String::from_str(&env, "Community"),
+                String::from_str(&env, "Desc"),
+                &token,
+                300,
+                reviewers,
+            )
+            .unwrap();
+
+            let flags = Storage::get_grant_safety_flags(&env, grant_id);
+            assert!(!flags.multisig_required);
+            assert!(!flags.insurance_opt_in);
+            assert!(!flags.requires_staking);
         });
     }
 }

--- a/contracts/contracts/stellar-grants/src/insurance.rs
+++ b/contracts/contracts/stellar-grants/src/insurance.rs
@@ -40,6 +40,12 @@ pub struct ClaimRejected {
     pub claim_id: u32,
 }
 
+#[contractevent]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PolicyDeactivated {
+    pub grant_id: u64,
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /// Purchase insurance for a grant. Premium = coverage * premium_rate_bps / BASIS_POINTS_SCALE.
@@ -56,6 +62,8 @@ pub fn purchase_policy(
     if coverage_amount <= 0 {
         return Err(ContractError::InvalidInput);
     }
+
+    Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
 
     if Storage::get_insurance_policy(env, grant_id).is_some() {
         return Err(ContractError::AlreadyRegistered);
@@ -131,6 +139,8 @@ pub fn file_claim(
     if claimed_amount <= 0 {
         return Err(ContractError::InvalidInput);
     }
+
+    Storage::get_grant(env, grant_id).ok_or(ContractError::GrantNotFound)?;
 
     let policy =
         Storage::get_insurance_policy(env, grant_id).ok_or(ContractError::PolicyNotFound)?;
@@ -270,6 +280,29 @@ pub fn reject_claim(env: &Env, admin: &Address, claim_id: u32) -> Result<(), Con
     Ok(())
 }
 
+/// Deactivate an active insurance policy. Admin only.
+pub fn deactivate_policy(env: &Env, admin: &Address, grant_id: u64) -> Result<(), ContractError> {
+    admin.require_auth();
+
+    if Storage::get_global_admin(env) != Some(admin.clone()) {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let mut policy =
+        Storage::get_insurance_policy(env, grant_id).ok_or(ContractError::PolicyNotFound)?;
+
+    if !policy.active {
+        return Err(ContractError::PolicyInactive);
+    }
+
+    policy.active = false;
+    Storage::set_insurance_policy(env, &policy);
+
+    PolicyDeactivated { grant_id }.publish(env);
+
+    Ok(())
+}
+
 /// Return total funds in the insurance pool for a given token.
 pub fn pool_balance(env: &Env, token: &Address) -> i128 {
     Storage::get_insurance_pool(env, token)
@@ -290,8 +323,30 @@ pub fn get_claim(env: &Env, claim_id: u32) -> Result<InsuranceClaim, ContractErr
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::{Grant, GrantStatus};
     use soroban_sdk::testutils::{Address as _, Ledger};
-    use soroban_sdk::{token::StellarAssetClient, Address, Env, String};
+    use soroban_sdk::{token::StellarAssetClient, Address, Env, String, Vec};
+
+    fn make_grant(env: &Env, owner: &Address, token: &Address, grant_id: u64) -> Grant {
+        Grant {
+            id: grant_id,
+            owner: owner.clone(),
+            title: String::from_str(env, "Test"),
+            description: String::from_str(env, "Desc"),
+            token: token.clone(),
+            status: GrantStatus::Active,
+            total_amount: 1_000_000,
+            milestone_amount: 500_000,
+            reviewers: Vec::new(env),
+            total_milestones: 2,
+            milestones_paid_out: 0,
+            escrow_balance: 0,
+            funders: Vec::new(env),
+            reason: None,
+            timestamp: env.ledger().timestamp(),
+            require_compliance: None,
+        }
+    }
 
     fn setup() -> (Env, Address, Address, Address) {
         let env = Env::default();
@@ -304,6 +359,9 @@ mod tests {
             .address();
         let stellar_asset = StellarAssetClient::new(&env, &token_contract);
         stellar_asset.mint(&policyholder, &10_000_000);
+        Storage::set_global_admin(&env, &admin);
+        let grant = make_grant(&env, &policyholder, &token_contract, 1);
+        Storage::set_grant(&env, 1, &grant);
         (env, admin, policyholder, token_contract)
     }
 
@@ -410,5 +468,54 @@ mod tests {
         let claim_id3 = file_claim(&env, &policyholder, 1, 100_000, reason3).unwrap();
         let err = approve_claim(&env, &admin, claim_id3, 100_000).unwrap_err();
         assert_eq!(err, ContractError::InsufficientPoolBalance);
+    }
+
+    #[test]
+    fn test_purchase_policy_rejects_nonexistent_grant() {
+        let (env, _admin, policyholder, token) = setup();
+        let err = purchase_policy(&env, &policyholder, 999, &token, 1_000_000).unwrap_err();
+        assert_eq!(err, ContractError::GrantNotFound);
+    }
+
+    #[test]
+    fn test_file_claim_rejects_nonexistent_grant() {
+        let (env, _admin, policyholder, token) = setup();
+        purchase_policy(&env, &policyholder, 1, &token, 1_000_000).unwrap();
+        // grant_id 999 was never created.
+        let reason = String::from_str(&env, "no grant");
+        let err = file_claim(&env, &policyholder, 999, 500_000, reason).unwrap_err();
+        assert_eq!(err, ContractError::GrantNotFound);
+    }
+
+    #[test]
+    fn test_deactivate_policy_by_admin() {
+        let (env, admin, policyholder, token) = setup();
+        purchase_policy(&env, &policyholder, 1, &token, 1_000_000).unwrap();
+
+        deactivate_policy(&env, &admin, 1).unwrap();
+
+        let policy = get_policy(&env, 1).unwrap();
+        assert!(!policy.active);
+
+        let reason = String::from_str(&env, "late");
+        let err = file_claim(&env, &policyholder, 1, 500_000, reason).unwrap_err();
+        assert_eq!(err, ContractError::PolicyInactive);
+    }
+
+    #[test]
+    fn test_deactivate_policy_requires_admin() {
+        let (env, _admin, policyholder, token) = setup();
+        purchase_policy(&env, &policyholder, 1, &token, 1_000_000).unwrap();
+
+        let stranger = Address::generate(&env);
+        let err = deactivate_policy(&env, &stranger, 1).unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized);
+    }
+
+    #[test]
+    fn test_deactivate_policy_not_found() {
+        let (env, admin, _policyholder, _token) = setup();
+        let err = deactivate_policy(&env, &admin, 999).unwrap_err();
+        assert_eq!(err, ContractError::PolicyNotFound);
     }
 }

--- a/contracts/contracts/stellar-grants/src/lib.rs
+++ b/contracts/contracts/stellar-grants/src/lib.rs
@@ -529,6 +529,17 @@ impl StellarGrantsContract {
             compliance::require_compliant_u32(env, &grant.owner, required_level)?;
         }
 
+        // Issue #912: enforce archetype-derived safety flags that were
+        // previously recorded but never checked anywhere.
+        let safety_flags = Storage::get_grant_safety_flags(env, grant_id);
+        if safety_flags.insurance_opt_in {
+            let policy =
+                insurance::get_policy(env, grant_id).ok_or(ContractError::PolicyNotFound)?;
+            if !policy.active {
+                return Err(ContractError::PolicyInactive);
+            }
+        }
+
         let total_paid =
             Self::compute_total_paid_if_quorum_ready(env, grant_id, grant.total_milestones)?;
         if grant.escrow_balance < total_paid {
@@ -572,7 +583,11 @@ impl StellarGrantsContract {
             }
             if owner_amount > 0 {
                 let config: ProtocolConfig = config::get_config(env);
-                if config.multisig_threshold > 0 && owner_amount >= config.multisig_threshold {
+                // Issue #912: an archetype with `multisig_required: true` must
+                // have its releases multisig-gated regardless of amount.
+                let multisig_gated = safety_flags.multisig_required
+                    || (config.multisig_threshold > 0 && owner_amount >= config.multisig_threshold);
+                if multisig_gated {
                     // Issue #821: a multisig request only reserves the payout;
                     // it must not be treated as a completed release until a
                     // signer actually executes it via `execute_escrow_release`.
@@ -1677,6 +1692,15 @@ impl StellarGrantsContract {
     /// Return a claim by id.
     pub fn get_insurance_claim(env: Env, claim_id: u32) -> Result<InsuranceClaim, ContractError> {
         insurance::get_claim(&env, claim_id)
+    }
+
+    /// Deactivate an active insurance policy for a grant. Admin only.
+    pub fn insurance_deactivate_policy(
+        env: Env,
+        admin: Address,
+        grant_id: u64,
+    ) -> Result<(), ContractError> {
+        insurance::deactivate_policy(&env, &admin, grant_id)
     }
 
     // ── External Callback Hooks (#539) ──────────────────────────────────────

--- a/contracts/contracts/stellar-grants/src/matching.rs
+++ b/contracts/contracts/stellar-grants/src/matching.rs
@@ -309,17 +309,19 @@ pub fn distribute(env: &Env, round_id: u32) -> Result<(), ContractError> {
         return Err(ContractError::InvalidState);
     }
 
-    // Distribute match amounts to each grant's escrow
+    // Distribute match amounts to each grant's escrow. A deposit failure aborts
+    // the whole call so the round is never marked distributed with some
+    // allocations left unfunded and unrecoverable.
     for i in 0..round.allocations.len() {
         if let Some(allocation) = round.allocations.get(i) {
             if allocation.match_amount > 0 {
                 // Transfer match amount to grant's escrow
-                let _ = crate::escrow::deposit(
+                crate::escrow::deposit(
                     env,
                     allocation.grant_id,
                     &env.current_contract_address(),
                     allocation.match_amount,
-                );
+                )?;
             }
         }
     }
@@ -531,6 +533,51 @@ mod tests {
         assert_eq!(round.id, 1);
         assert_eq!(round.matching_pool, 10_000);
         assert!(!round.finalized);
+        assert!(!round.distributed);
+    }
+
+    #[test]
+    fn test_distribute_fails_and_leaves_round_undistributed_on_deposit_failure() {
+        use soroban_sdk::testutils::Ledger;
+        use soroban_sdk::token::StellarAssetClient;
+
+        let env = soroban_sdk::Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let token_contract = env
+            .register_stellar_asset_contract_v2(token_admin.clone())
+            .address();
+        let stellar_asset = StellarAssetClient::new(&env, &token_contract);
+        stellar_asset.mint(&admin, &1_000_000);
+
+        let grant_with_escrow: u64 = 1;
+        let grant_without_escrow: u64 = 2;
+
+        // Only grant_with_escrow has an escrow account opened, simulating an
+        // eligible grant whose escrow doesn't exist yet.
+        let owner = Address::generate(&env);
+        crate::escrow::open(&env, grant_with_escrow, &owner, &token_contract).unwrap();
+
+        let eligible = Vec::from_array(&env, [grant_with_escrow, grant_without_escrow]);
+        let round_id = create_round(&env, &admin, &token_contract, 1_000, 1, eligible).unwrap();
+
+        let contributor = Address::generate(&env);
+        stellar_asset.mint(&contributor, &1_000_000);
+        contribute(&env, &contributor, round_id, grant_with_escrow, 400).unwrap();
+        contribute(&env, &contributor, round_id, grant_without_escrow, 100).unwrap();
+
+        env.ledger().with_mut(|li| {
+            li.sequence_number += 2;
+        });
+        compute_allocations(&env, round_id).unwrap();
+
+        let err = distribute(&env, round_id).unwrap_err();
+        assert_eq!(err, ContractError::EscrowNotFound);
+
+        // The round must not be marked distributed when a deposit failed,
+        // so the failure isn't silently discarded and funds aren't stranded.
+        let round = get_round(&env, round_id).unwrap();
         assert!(!round.distributed);
     }
 }

--- a/contracts/contracts/stellar-grants/src/storage/helpers.rs
+++ b/contracts/contracts/stellar-grants/src/storage/helpers.rs
@@ -9,8 +9,8 @@ use crate::types::{
     AutoApproveRecord, BountyGrant, BountySubmission, BreakerState, ChecklistSubmission,
     ClawbackRequest, ComplianceAttestation, ContractError, ContractVersion, ContributorProfile,
     CrowdfundCampaign, CrowdfundPledge, DaoProposal, DexConfig, Dispute, EscrowAccount,
-    EscrowState, EvidenceSchema, FunderLedger, Grant, GrantCategory, GrantTag, GrantVersion,
-    HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy, Invoice, LicenseRecord,
+    EscrowState, EvidenceSchema, FunderLedger, Grant, GrantCategory, GrantSafetyFlags, GrantTag,
+    GrantVersion, HookEvent, HookRegistration, InsuranceClaim, InsurancePolicy, Invoice, LicenseRecord,
     MerkleCommitment, MigrationRecord, Milestone, MilestoneDag, MilestoneNft, MultisigProposal,
     OracleConfig, ParamRecord, PauseRecord, PaymentSplit, PaymentStream, ProtocolConfig,
     ProtocolMetrics, ProtocolModule, PublicReview, QuadraticVoteRecord, RateLimitAction,
@@ -90,6 +90,25 @@ impl Storage {
         env.storage()
             .persistent()
             .has(&DataKey::Grant(GrantKey::Data(grant_id)))
+    }
+
+    /// Archetype-derived safety flags for a grant (issue #912). Defaults to
+    /// all-false for grants not created via an archetype template.
+    pub fn get_grant_safety_flags(env: &Env, grant_id: u64) -> GrantSafetyFlags {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Grant(GrantKey::SafetyFlags(grant_id)))
+            .unwrap_or(GrantSafetyFlags {
+                requires_staking: false,
+                multisig_required: false,
+                insurance_opt_in: false,
+            })
+    }
+
+    pub fn set_grant_safety_flags(env: &Env, grant_id: u64, flags: &GrantSafetyFlags) {
+        let key = DataKey::Grant(GrantKey::SafetyFlags(grant_id));
+        env.storage().persistent().set(&key, flags);
+        Self::bump(env, &key);
     }
 
     /// Append a grant id to the owner's portfolio index (used by multi_grant queries).

--- a/contracts/contracts/stellar-grants/src/storage/keys.rs
+++ b/contracts/contracts/stellar-grants/src/storage/keys.rs
@@ -32,6 +32,7 @@ pub enum GrantKey {
     TokenIndex(Address),
     ContribIndex(Address),
     GlobalOrder,
+    SafetyFlags(u64),
 }
 
 #[contracttype]

--- a/contracts/contracts/stellar-grants/src/types.rs
+++ b/contracts/contracts/stellar-grants/src/types.rs
@@ -1327,6 +1327,15 @@ pub struct GrantTemplate {
     pub insurance_opt_in: bool,
 }
 
+/// Archetype-derived safety flags enforced on a specific grant (issue #912).
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GrantSafetyFlags {
+    pub requires_staking: bool,
+    pub multisig_required: bool,
+    pub insurance_opt_in: bool,
+}
+
 // ── Waitlist Module ─────────────────────────────────────────────────────────────
 
 #[contracttype]


### PR DESCRIPTION
## Summary

Resolves four Stellar Wave issues affecting the insurance, factory, and matching modules: a missing insurance policy deactivation path, missing grant-existence validation in insurance flows, unenforced factory archetype safety flags, and silently discarded deposit failures in matching round distribution.

## Changes

- Added `insurance::deactivate_policy` (admin-only) and wired it as the `insurance_deactivate_policy` public entrypoint, so an active policy can now be revoked early; a deactivated policy correctly causes subsequent `file_claim` calls to fail with `PolicyInactive`.
- `insurance::purchase_policy` and `insurance::file_claim` now verify the referenced grant exists via `Storage::get_grant`, returning `GrantNotFound` otherwise, instead of allowing insurance to be purchased/claimed against a grant that was never created.
- Factory archetype safety flags (`requires_staking`, `multisig_required`, `insurance_opt_in`) are now persisted per grant (`GrantSafetyFlags`) when a grant is created from a template, and actually enforced: `collateral::require_deposited` blocks milestone submission when staking is required but never configured, and `finalize_grant_release` forces multisig-gated release and requires an active insurance policy when those flags are set.
- `matching::distribute` now propagates `escrow::deposit` failures instead of discarding them with `let _ = ...`, so a round is never marked `distributed` when a match-amount deposit fails.

## Issues

Resolves #914
Resolves #913
Resolves #912
Resolves #911

## Verification

- Manual code review of the complete diff was performed; no unrelated files, snapshots, or generated files were touched.
- New and existing unit tests were added/updated in `insurance.rs`, `collateral.rs`, `factory.rs`, and `matching.rs` covering each fix.
- `cargo build` was not run.
- `cargo test` was not run.