### PR TITLE
fix: address issues 948, 949, 950, 951

### DIFF
--- a/contracts/contracts/stellar-grants/src/milestone_deps.rs
+++ b/contracts/contracts/stellar-grants/src/milestone_deps.rs
@@ -5,6 +5,23 @@ use soroban_sdk::{Address, Env, Vec as SorobanVec};
 /// Check if a milestone can be submitted by verifying all dependencies are satisfied.
 /// A milestone can be submitted if all previous milestones have been approved.
 pub fn can_submit(env: &Env, grant_id: u64, milestone_idx: u32) -> Result<(), ContractError> {
+    if let Some(dag) = Storage::get_milestone_dag(env, grant_id) {
+        for dep in dag.dependencies.iter() {
+            if dep.milestone_idx == milestone_idx {
+                for parent in dep.depends_on.iter() {
+                    if let Some(m) = Storage::get_milestone(env, grant_id, parent) {
+                        if m.state != MilestoneState::Approved {
+                            return Err(ContractError::DependencyNotSatisfied);
+                        }
+                    } else {
+                        return Err(ContractError::DependencyNotSatisfied);
+                    }
+                }
+                return Ok(());
+            }
+        }
+    }
+    // Fallback: sequential ordering when no DAG entry covers this milestone.
     if milestone_idx == 0 {
         return Ok(());
     }

--- a/contracts/contracts/stellar-grants/src/quadratic.rs
+++ b/contracts/contracts/stellar-grants/src/quadratic.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{Address, Env, Vec};
 
 use crate::errors::ContractError;
-use crate::storage::Storage;
+use crate::storage::{DataKey, Storage, VotingKey};
 use crate::types::{QuadraticVoteRecord, VoiceCredits};
 
 /// Allocate voice credits to a voter for a grant (called when reviewer is added).
@@ -9,16 +9,27 @@ pub fn allocate_credits(
     env: &Env,
     voter: &Address,
     grant_id: u64,
-    credits: u32,
+    additional_credits: u32,
 ) -> Result<(), ContractError> {
+    let existing = Storage::get_voice_credits(env, voter, grant_id);
     let record = VoiceCredits {
         voter: voter.clone(),
         grant_id,
-        total_credits: credits,
-        spent_credits: 0,
+        total_credits: existing.as_ref().map(|r| r.total_credits).unwrap_or(0).saturating_add(additional_credits),
+        spent_credits: existing.map(|r| r.spent_credits).unwrap_or(0),
     };
     Storage::set_voice_credits(env, &record);
     Ok(())
+}
+
+fn get_voter_cumulative_votes(env: &Env, grant_id: u64, milestone_idx: u32, voter: &Address) -> u32 {
+    let key = DataKey::Voting(VotingKey::CumulativeVotes(grant_id, milestone_idx, voter.clone()));
+    env.storage().persistent().get(&key).unwrap_or(0)
+}
+
+fn set_voter_cumulative_votes(env: &Env, grant_id: u64, milestone_idx: u32, voter: &Address, votes: u32) {
+    let key = DataKey::Voting(VotingKey::CumulativeVotes(grant_id, milestone_idx, voter.clone()));
+    env.storage().persistent().set(&key, &votes);
 }
 
 /// Compute the credit cost for casting `votes` unit votes: cost = votes^2.
@@ -32,35 +43,39 @@ pub fn cast_qv_vote(
     voter: &Address,
     grant_id: u64,
     milestone_idx: u32,
-    votes: u32,
+    additional_votes: u32,
     in_favor: bool,
 ) -> Result<QuadraticVoteRecord, ContractError> {
     voter.require_auth();
 
-    if votes == 0 {
+    if additional_votes == 0 {
         return Err(ContractError::InvalidInput);
     }
 
     let mut credits =
         Storage::get_voice_credits(env, voter, grant_id).ok_or(ContractError::VoterNotAllocated)?;
 
-    let cost = credit_cost(votes);
+    let prior_votes = get_voter_cumulative_votes(env, grant_id, milestone_idx, voter);
+    let new_total_votes = prior_votes.saturating_add(additional_votes);
+    let marginal_cost = credit_cost(new_total_votes).saturating_sub(credit_cost(prior_votes));
     let available = credits.total_credits.saturating_sub(credits.spent_credits);
-    if cost > available {
+    
+    if marginal_cost > available {
         return Err(ContractError::InsufficientVoiceCredits);
     }
 
     credits.spent_credits = credits
         .spent_credits
-        .checked_add(cost)
+        .checked_add(marginal_cost)
         .ok_or(ContractError::InvalidInput)?;
     Storage::set_voice_credits(env, &credits);
+    set_voter_cumulative_votes(env, grant_id, milestone_idx, voter, new_total_votes);
 
     let record = QuadraticVoteRecord {
         voter: voter.clone(),
         milestone_idx,
-        votes_cast: votes,
-        credits_spent: cost,
+        votes_cast: additional_votes,
+        credits_spent: marginal_cost,
         in_favor,
     };
 

--- a/contracts/contracts/stellar-grants/src/reviewer_reward.rs
+++ b/contracts/contracts/stellar-grants/src/reviewer_reward.rs
@@ -23,6 +23,7 @@ pub fn fund_pool(env: &Env, token: &Address, amount: i128) {
                 balance: 0,
                 total_deposited: 0,
                 total_paid_out: 0,
+                total_votes_recorded: 0,
             });
 
     pool.balance = pool.balance.saturating_add(amount);
@@ -99,6 +100,28 @@ pub fn record_participation(
             PERSISTENT_TTL_EXTEND_TO,
         );
     }
+    
+    if let Some(grant) = crate::storage::Storage::get_grant(env, grant_id) {
+        let pool_key = DataKey::ReviewerReward(ReviewerRewardKey::Pool(grant.token.clone()));
+        let mut pool: ReviewerRewardPool = env
+            .storage()
+            .persistent()
+            .get(&pool_key)
+            .unwrap_or_else(|| ReviewerRewardPool {
+                token: grant.token.clone(),
+                balance: 0,
+                total_deposited: 0,
+                total_paid_out: 0,
+                total_votes_recorded: 0,
+            });
+        pool.total_votes_recorded = pool.total_votes_recorded.saturating_add(1);
+        env.storage().persistent().set(&pool_key, &pool);
+        env.storage().persistent().extend_ttl(
+            &pool_key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
+    }
 }
 
 /// Compute reward entitlement for a reviewer based on participation.
@@ -136,6 +159,7 @@ pub fn accrue_reward(
             balance: 0,
             total_deposited: 0,
             total_paid_out: 0,
+            total_votes_recorded: 0,
         });
 
     if pool.balance <= 0 {
@@ -207,7 +231,7 @@ fn compute_reviewer_share(
         }
     }
 
-    total_reviewer_votes = reviewer_votes;
+    total_reviewer_votes = pool.total_votes_recorded;
 
     if total_reviewer_votes <= 0 {
         return Ok(0);

--- a/contracts/contracts/stellar-grants/src/storage/keys.rs
+++ b/contracts/contracts/stellar-grants/src/storage/keys.rs
@@ -97,6 +97,7 @@ pub enum VotingKey {
     ReleaseApproval(u64, Address),
     Proposal(u32),
     ProposalCounter,
+    CumulativeVotes(u64, u32, Address),
 }
 
 #[contracttype]

--- a/contracts/contracts/stellar-grants/src/types.rs
+++ b/contracts/contracts/stellar-grants/src/types.rs
@@ -555,6 +555,7 @@ pub struct ReviewerRewardPool {
     pub balance: i128,
     pub total_deposited: i128,
     pub total_paid_out: i128,
+    pub total_votes_recorded: i128,
 }
 
 // ── Issue #533: Bounty-Mode Grants ────────────────────────────────────────────


### PR DESCRIPTION
This PR addresses and resolves the following issues:

### 1. #951: Fix `milestone_deps` `can_submit` ignores the attached dependency DAG entirely
- **Problem**: The `can_submit` function was purely enforcing sequential ordering and ignored the actual dependency DAG that could have skipped milestones.
- **Solution**: Updated `can_submit` to first consult the `MilestoneDag` if it exists. It now correctly checks only the declared dependencies within the DAG, allowing non-linear milestones to be submitted. If no DAG is attached, it correctly falls back to sequential ordering.

### 2. #950: Fix quadratic `allocate_credits` resets `spent_credits` on every re-allocation
- **Problem**: When `allocate_credits` was called to top up a voter's credits, it completely overwrote the previous record and reset their `spent_credits` to `0`, allowing a voter to cast votes beyond their cumulative allowance.
- **Solution**: The `allocate_credits` function now fetches the existing `VoiceCredits` record (if any) and preserves the `spent_credits`, properly adding the new allocation to the existing `total_credits`.

### 3. #949: Security: quadratic voting cost-splitting lets a voter buy 10x power for the same credits
- **Problem**: `cast_qv_vote` was charging credits based on the square of the votes passed in a single transaction, without tracking the cumulative total. This allowed a Sybil exploit where voters split votes into smaller chunks (e.g. 1 vote x 10 times) to bypass the quadratic scaling curve and get 10x voting power.
- **Solution**: Introduced `get_voter_cumulative_votes` and `set_voter_cumulative_votes`. The credit deduction now correctly calculates the marginal quadratic cost based on the total cumulative votes cast across multiple function calls by the same voter.

### 4. #948: Fix `reviewer_reward` `compute_reviewer_share` always returns the entire pool to the first claimant
- **Problem**: In `compute_reviewer_share`, `total_reviewer_votes` was misconfigured to simply take the value of the individual `reviewer_votes`, instead of the true total across all reviewers. This gave 100% of the pool to the first reviewer to claim rewards.
- **Solution**: Added `total_votes_recorded` directly to the `ReviewerRewardPool` struct to efficiently track total participation globally. Updated `record_participation` to increment this counter and correctly used it as the denominator in `compute_reviewer_share` to distribute proportional rewards correctly.

Closes #948
Closes #949
Closes #950
Closes #951
